### PR TITLE
feat(ui): redesign actor sheet and chat cards with sci-fi theme

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -175,9 +175,21 @@ tasks:
 
   # ── Foundry VTT Test Instance ───────────────────────────────────
 
+  foundry:init-config:
+    internal: true
+    cmds:
+      - mkdir -p "{{.FOUNDRY_DATA}}/Config"
+      - |
+        node -e "
+          const fs = require('fs');
+          const p = '{{.FOUNDRY_DATA}}/Config/options.json';
+          const existing = fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : {};
+          fs.writeFileSync(p, JSON.stringify({ ...existing, telemetry: false }, null, 2) + '\n');
+        "
+
   foundry:start:
     desc: Start a Foundry VTT v14 container for testing
-    deps: [build]
+    deps: [build, foundry:init-config]
     preconditions:
       - sh: test -f .env
         msg: ".env not found. Run 'task setup:secrets' or copy .env.example to .env"
@@ -198,6 +210,7 @@ tasks:
         --env FOUNDRY_PASSWORD="${FOUNDRY_PASSWORD}"
         --env FOUNDRY_LICENSE_KEY="${FOUNDRY_LICENSE_KEY}"
         --env FOUNDRY_ADMIN_KEY="${FOUNDRY_ADMIN_KEY}"
+        --env FOUNDRY_TELEMETRY=false
         --publish {{.FOUNDRY_PORT}}:30000/tcp
         --volume "{{.FOUNDRY_DATA}}:/data"
         --volume "{{.ROOT_DIR}}/src:/data/Data/systems/od6s"
@@ -309,9 +322,9 @@ tasks:
         msg: "Working directory must be clean"
       - sh: git diff --quiet HEAD origin/main
         msg: "Local main must be up to date with origin"
-      - sh: grep -q '"version": "{{.NEXT_VERSION}}"' src/system.json
+      - sh: "grep -q '\"version\": \"{{.NEXT_VERSION}}\"' src/system.json"
         msg: 'src/system.json version must be "{{.NEXT_VERSION}}" before tagging'
-      - sh: grep -q '"version": "{{.NEXT_VERSION}}"' package.json
+      - sh: "grep -q '\"version\": \"{{.NEXT_VERSION}}\"' package.json"
         msg: 'package.json version must be "{{.NEXT_VERSION}}" before tagging'
     cmds:
       - echo "{{.LATEST_TAG}} → {{.NEXT_TAG}}"

--- a/scss/components/_attributes.scss
+++ b/scss/components/_attributes.scss
@@ -1,46 +1,155 @@
+@use '../utils' as *;
+
 .od6s {
+  // ── List containers ──────────────────────────────────────────────────────
   .attribute-list,
   .skill-list,
   .specialization-list,
   .combat-list {
     list-style: none;
     margin: 1px 0;
-    padding: 2px;
+    padding: 0;
     overflow-y: auto;
   }
 
+  // Attribute list — top-level structural container; gap between attribute groups
+  .attribute-list > li.attributes {
+    margin-bottom: 6px;
+    padding: 0;
+    background: $c-panel;
+    border: 1px solid $c-border;
+    border-radius: 3px;
+    box-shadow: $c-shadow-inset;
+    overflow: hidden;
+  }
+
+  // Nested skill list inside an attribute group: tighter padding
+  .attribute-list .skill-list {
+    margin: 0;
+    padding: 2px 4px 4px;
+  }
+
+  // ── Skill / specialization rows ──────────────────────────────────────────
+  .skill-list > li.skills,
+  .specialization-list > li.specializations {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-radius: 2px;
+    border-left: 2px solid transparent;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+      background-color: $c-row-hover;
+      border-left-color: $c-accent;
+    }
+  }
+
+  // Alternating row tint inside skill/spec lists
+  .skill-list > li:nth-child(even),
+  .specialization-list > li:nth-child(even) {
+    background-color: $c-row-alt;
+  }
+  .skill-list > li:nth-child(even):hover,
+  .specialization-list > li:nth-child(even):hover {
+    background-color: $c-row-hover;
+  }
+
+  // The skilldialog cell holds the skill name (left side)
+  .skilldialog,
+  .specdialog {
+    color: $c-text-primary;
+    font-weight: 400;
+    padding: 2px 6px;
+    transition: color 0.15s ease;
+
+    &.rolldialog:hover {
+      color: $c-accent-bright;
+      background: transparent;
+      text-shadow: 0 0 8px rgba(201, 162, 39, 0.45);
+    }
+  }
+
+  // Specialization name — italic, indented, slightly muted
+  .specdialog {
+    color: $c-text-muted;
+    font-style: italic;
+    padding-left: 18px;
+    position: relative;
+
+    &::before {
+      content: "↳";
+      position: absolute;
+      left: 4px;
+      color: $c-accent-border;
+      font-style: normal;
+    }
+  }
+
+  // Specialization list spacing inside a skill row
+  .specialization-list {
+    padding: 0 0 2px;
+  }
+
+  // ── Modifier indicators ──────────────────────────────────────────────────
   .moddedup {
-    text-shadow: 0 0 2px darkgreen;
+    text-shadow: 0 0 6px $c-mod-up;
+    position: relative;
+
     &:hover,
     &:focus {
-      color: #000;
-      text-shadow: 0 0 10px red;
+      color: $c-accent-bright;
+      background-color: $c-hover-bg;
+      text-shadow: 0 0 8px rgba(201, 162, 39, 0.5);
       cursor: pointer;
     }
   }
 
   .moddeddown {
-    text-shadow: 0 0 2px darkred;
+    text-shadow: 0 0 6px $c-mod-down;
+
     &:hover,
     &:focus {
-      color: #000;
-      text-shadow: 0 0 10px red;
+      color: $c-accent-bright;
+      background-color: $c-hover-bg;
+      text-shadow: 0 0 8px rgba(201, 162, 39, 0.5);
       cursor: pointer;
     }
   }
 
   .manifestation-active {
-    text-shadow: 0 0 10px lightblue;
+    text-shadow: 0 0 8px rgba(100, 180, 255, 0.9);
   }
 
   .disabled {
-    color: grey;
+    color: $c-text-dim;
   }
 
   .attributes-sort {
     list-style: none;
-    margin: 2px 0;
-    padding: 2px;
-    outline: 1px solid #000;
+    margin: 4px 0;
+    padding: 4px;
+    background: $c-panel;
+    border: 1px solid $c-border;
+    border-radius: 2px;
+  }
+
+  // ── Skill grid alignment ─────────────────────────────────────────────────
+  // The skills-grid contains [checkbox, skill-name] in the left column
+  .skills-grid {
+    padding: 1px 0;
+  }
+
+  // Item controls (advance/edit/delete buttons) on skill/spec rows
+  .item-list .item-controls {
+    a {
+      color: $c-text-muted;
+      transition: color 0.15s ease, text-shadow 0.15s ease;
+
+      &:hover {
+        color: $c-accent-bright;
+        text-shadow: 0 0 6px rgba(201, 162, 39, 0.45);
+      }
+    }
   }
 }

--- a/scss/components/_attributes.scss
+++ b/scss/components/_attributes.scss
@@ -140,16 +140,87 @@
     padding: 1px 0;
   }
 
-  // Item controls (advance/edit/delete buttons) on skill/spec rows
-  .item-list .item-controls {
-    a {
+  // ── Action icon group on skill / spec rows ──────────────────────────────
+  // Templates emit `<div class="item item-controls flexrow flex-group-center">`
+  // containing 1–3 anchors (advance / specialize / edit / delete). Style as a
+  // tidy icon row with consistent hit areas, no jumping between modes.
+  .item-list .item-controls,
+  .skill-list .item-controls,
+  .specialization-list .item-controls {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: nowrap;
+    gap: 4px;
+    padding: 0 4px;
+
+    > a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      flex: 0 0 20px;
       color: $c-text-muted;
-      transition: color 0.15s ease, text-shadow 0.15s ease;
+      border-radius: 2px;
+      transition: color 0.15s ease, background-color 0.15s ease;
+      cursor: pointer;
+
+      i {
+        font-size: 0.85em;
+      }
 
       &:hover {
         color: $c-accent-bright;
-        text-shadow: 0 0 6px rgba(201, 162, 39, 0.45);
+        background-color: rgba(201, 162, 39, 0.12);
+      }
+
+      &.item-delete:hover {
+        color: $c-bad;
+        background-color: rgba(226, 95, 99, 0.12);
       }
     }
+  }
+
+  // ── Attribute-header action buttons (add skill / edit attribute) ─────────
+  // Sit in the third column of the attribute banner row in advance/freeedit.
+  // Make them match the gold banner styling instead of looking like loose
+  // misaligned glyphs.
+  .attribute-list > li.attributes > div > .flex-group-center > .item-add,
+  .attribute-list > li.attributes > div > .flex-group-center > .attribute-edit,
+  .attribute-list > li.attributes > div > .advancedialog,
+  .attribute-list > li.attributes > div > .attribute-edit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    flex: 0 0 22px;
+    border-radius: 2px;
+    color: $c-accent;
+    transition: color 0.15s ease, background-color 0.15s ease;
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      color: inherit;
+
+      i { font-size: 0.92em; }
+    }
+
+    &:hover {
+      background-color: rgba(201, 162, 39, 0.18);
+      color: $c-accent-bright;
+    }
+  }
+
+  // The flex-group-center wrapping the freeedit attribute action buttons
+  // should center its contents and reserve a stable width.
+  .attribute-list > li.attributes > div > .flex-group-center.flexrow {
+    gap: 4px;
+    justify-content: center;
   }
 }

--- a/scss/components/_chat.scss
+++ b/scss/components/_chat.scss
@@ -1,0 +1,509 @@
+@use '../utils' as *;
+
+// ── Chat cards ──────────────────────────────────────────────────────────────
+// Foundry renders chat-message <li> items into the chat sidebar. The system
+// templates produce a specific structure (.message-header.flexrow + .flavor-text
+// + .message-content) that we target here. We also override Foundry's defaults
+// for .dice-roll / .dice-formula / .dice-total inside our message-content so the
+// stark white roll boxes match the sheet theme.
+
+#chat-log .chat-message,
+#chat #chat-log .chat-message,
+.chat-sidebar .chat-message,
+.chat-message.message.flexcol {
+  background:
+    linear-gradient(180deg, rgba(20, 24, 32, 0.92) 0%, rgba(8, 12, 18, 0.92) 100%);
+  color: $c-text-primary;
+  border: 1px solid $c-border;
+  border-left: 2px solid $c-accent-border;
+  border-radius: 3px;
+  margin: 6px 4px;
+  padding: 6px 8px;
+  box-shadow: $c-shadow-deep;
+  font-family: $font-primary;
+  position: relative;
+
+  // Soft corner highlight
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border-radius: inherit;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  // ── Header ────────────────────────────────────────────────────────────
+  .message-header {
+    border: none;
+    padding: 0 0 4px;
+    margin: 0 0 6px;
+    border-bottom: 1px solid $c-border;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    position: relative;
+
+    .message-sender {
+      font-family: $font-display;
+      color: $c-accent;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      font-size: 0.95em;
+      margin: 0;
+      flex: 1 1 auto;
+      text-shadow: 0 0 10px rgba(201, 162, 39, 0.25);
+    }
+
+    .message-metadata {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      flex: 0 0 auto;
+
+      .message-timestamp {
+        color: $c-text-muted;
+        font-size: 0.75em;
+        text-transform: lowercase;
+        letter-spacing: 0.04em;
+      }
+
+      .button,
+      .message-delete,
+      .message-reveal {
+        color: $c-text-muted;
+        background: transparent;
+        border: 1px solid transparent;
+        border-radius: 2px;
+        padding: 2px 5px;
+        line-height: 1;
+        transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+
+        &:hover {
+          color: $c-accent-bright;
+          border-color: $c-accent-border;
+          background-color: $c-hover-bg;
+          cursor: pointer;
+          text-shadow: 0 0 6px rgba(201, 162, 39, 0.45);
+        }
+
+        i {
+          font-size: 0.85em;
+        }
+      }
+
+      .message-delete:hover {
+        color: $c-bad;
+        border-color: rgba(226, 95, 99, 0.4);
+        background-color: rgba(226, 95, 99, 0.08);
+      }
+    }
+
+    // Flavor strip beneath the name row
+    .flavor-text {
+      flex: 1 1 100%;
+      color: $c-text-muted;
+      font-style: italic;
+      font-size: 0.88em;
+      line-height: 1.35;
+
+      // Promote item/skill names mentioned in flavor
+      strong, b {
+        color: $c-text-primary;
+        font-style: normal;
+      }
+    }
+
+    .choose-target {
+      color: $c-accent;
+      transition: color 0.15s ease, text-shadow 0.15s ease;
+
+      &:hover {
+        color: $c-accent-bright;
+        text-shadow: 0 0 6px rgba(201, 162, 39, 0.45);
+        cursor: pointer;
+      }
+    }
+  }
+
+  // ── Wild die notice ───────────────────────────────────────────────────
+  .wilddie,
+  .wilddiegm {
+    text-align: center;
+    color: $c-bad;
+    font-family: $font-display;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.85em;
+    padding: 3px 6px;
+    margin: 4px 0;
+    background: linear-gradient(180deg, rgba(226, 95, 99, 0.15), rgba(226, 95, 99, 0.05));
+    border-left: 2px solid $c-bad;
+    border-radius: 2px;
+    text-shadow: 0 0 8px rgba(226, 95, 99, 0.5);
+  }
+
+  // ── Roll output (Foundry's .dice-roll inside .message-content) ────────
+  .message-content {
+    padding: 0;
+
+    // Top-level roll wrapper
+    .dice-roll {
+      margin: 6px 0;
+    }
+
+    .dice-result {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    // Formula bar — "6d6[Base] + 1dwx6[Wild]"
+    .dice-formula {
+      background: $grad-pill;
+      border: 1px solid rgba(201, 162, 39, 0.18);
+      border-radius: 3px;
+      color: $c-text-primary;
+      font-family: $font-numeric;
+      font-weight: 500;
+      font-size: 0.95em;
+      letter-spacing: 0.02em;
+      padding: 4px 8px;
+      text-align: center;
+      box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+
+      // Foundry wraps die labels in spans; gild them subtly
+      .flavor,
+      em,
+      i {
+        color: $c-accent;
+        font-style: normal;
+      }
+    }
+
+    // The big "32" total
+    .dice-total {
+      background: linear-gradient(180deg, rgba(40, 30, 8, 0.85) 0%, rgba(20, 14, 4, 0.85) 100%);
+      border: 1px solid $c-accent-border;
+      border-radius: 3px;
+      color: $c-accent-bright;
+      font-family: $font-display;
+      font-weight: 700;
+      font-size: 1.5em;
+      letter-spacing: 0.08em;
+      padding: 6px 8px;
+      margin: 0;
+      text-align: center;
+      text-shadow: 0 0 14px rgba(201, 162, 39, 0.55), 0 1px 0 rgba(0, 0, 0, 0.6);
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 -2px 6px rgba(0, 0, 0, 0.4),
+        0 0 14px rgba(201, 162, 39, 0.18);
+    }
+
+    // Tooltip (per-die breakdown) — keep Foundry's collapsed behavior;
+    // when expanded, soften the panel
+    .dice-tooltip {
+      background: rgba(0, 0, 0, 0.35);
+      border: 1px solid $c-border;
+      border-radius: 2px;
+      padding: 4px 6px;
+      margin-top: 2px;
+
+      .dice-rolls,
+      .tooltip-part {
+        color: $c-text-primary;
+      }
+
+      .roll {
+        color: $c-text-primary;
+        background: rgba(0, 0, 0, 0.3);
+        border: 1px solid $c-border;
+        border-radius: 2px;
+
+        &.max,
+        &.success {
+          color: $c-good;
+          border-color: rgba(78, 201, 122, 0.4);
+        }
+
+        &.min,
+        &.failure {
+          color: $c-bad;
+          border-color: rgba(226, 95, 99, 0.4);
+        }
+      }
+    }
+  }
+
+  // ── Result lines ──────────────────────────────────────────────────────
+  .skillsuccess,
+  .attacksuccess {
+    margin: 6px 0 4px;
+    padding: 4px 8px;
+    background: $c-panel;
+    border-left: 2px solid $c-accent;
+    border-radius: 2px;
+    font-family: $font-display;
+    color: $c-accent-bright;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.92em;
+    text-shadow: 0 0 10px rgba(201, 162, 39, 0.3);
+
+    > div {
+      line-height: 1.4;
+    }
+  }
+
+  // Difficulty / modifiers row beneath result
+  > .flexrow {
+    margin: 4px 0;
+    align-items: center;
+    gap: 6px;
+
+    > div:first-child {
+      color: $c-text-muted;
+      font-size: 0.88em;
+      letter-spacing: 0.02em;
+
+      &.edit-difficulty,
+      &.edit-damage {
+        color: $c-text-primary;
+        cursor: pointer;
+        transition: color 0.15s ease;
+
+        &:hover {
+          color: $c-accent-bright;
+          text-shadow: 0 0 6px rgba(201, 162, 39, 0.4);
+        }
+      }
+    }
+
+    .modifiers-button,
+    .damage-modifiers-button {
+      color: $c-text-muted;
+      cursor: pointer;
+      transition: color 0.15s ease, transform 0.1s ease;
+      flex: 0 0 auto;
+
+      &:hover {
+        color: $c-accent-bright;
+        transform: scale(1.1);
+      }
+    }
+  }
+
+  .modifiers-display,
+  .damage-modifiers-display {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    padding: 4px 8px;
+    margin: 2px 0 4px;
+
+    .modifiers-list,
+    .damage-modifiers-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      > li {
+        color: $c-text-primary;
+        font-size: 0.85em;
+        padding: 1px 0;
+        border-bottom: 1px dotted rgba(255, 255, 255, 0.06);
+
+        &:last-child {
+          border-bottom: none;
+        }
+      }
+    }
+  }
+
+  // Difficulty selector (GM)
+  select.choose-difficulty {
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    color: $c-text-primary;
+    padding: 2px 6px;
+    margin-left: 6px;
+
+    &:focus {
+      outline: none;
+      border-color: $c-accent-border;
+    }
+  }
+
+  // ── Damage button ─────────────────────────────────────────────────────
+  .damage-button {
+    margin: 6px 0 2px;
+
+    button {
+      width: 100%;
+      background: $grad-button-stop;
+      border: 1px solid rgba(226, 95, 99, 0.5);
+      color: $c-white;
+      padding: 6px 12px;
+      font-family: $font-display;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-weight: 700;
+      font-size: 0.85em;
+      border-radius: 2px;
+      cursor: pointer;
+      box-shadow: $c-shadow-inset, 0 2px 6px rgba(0, 0, 0, 0.45);
+      text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
+      transition: filter 0.15s ease, transform 0.05s ease, box-shadow 0.15s ease;
+
+      &:hover {
+        filter: brightness(1.18);
+        box-shadow:
+          $c-shadow-inset,
+          0 2px 8px rgba(0, 0, 0, 0.5),
+          0 0 12px rgba(226, 95, 99, 0.35);
+      }
+
+      &:active {
+        transform: translateY(1px);
+      }
+    }
+  }
+
+  // Damage info row ("7D+0 Energy")
+  .damage-display {
+    margin: 4px 0;
+    padding: 3px 6px;
+    background: $c-panel;
+    border-radius: 2px;
+    font-family: $font-numeric;
+    color: $c-text-primary;
+    font-size: 0.92em;
+    align-items: center;
+    gap: 6px;
+
+    .edit-damage {
+      cursor: pointer;
+      transition: color 0.15s ease, text-shadow 0.15s ease;
+
+      &:hover {
+        color: $c-accent-bright;
+        text-shadow: 0 0 6px rgba(201, 162, 39, 0.4);
+      }
+    }
+  }
+
+  // ── Oppose button (bottom of card) ────────────────────────────────────
+  .message-oppose {
+    margin: 6px 0 0;
+    padding-top: 4px;
+    border-top: 1px solid $c-border;
+
+    .message-oppose-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 24px;
+      background: $c-panel;
+      border: 1px solid $c-border;
+      border-radius: 2px;
+      color: $c-text-muted;
+      transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+
+      &:hover {
+        color: $c-accent-bright;
+        border-color: $c-accent-border;
+        background-color: $c-hover-bg;
+        cursor: pointer;
+      }
+
+      i {
+        font-size: 0.92em;
+      }
+    }
+  }
+
+  // ── Apply-damage button (used on damage messages) ─────────────────────
+  .apply-damage-button {
+    width: 100%;
+    background: $grad-button-stop;
+    border: 1px solid rgba(226, 95, 99, 0.5);
+    color: $c-white;
+    padding: 5px 10px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-weight: 700;
+    font-size: 0.8em;
+    border-radius: 2px;
+    cursor: pointer;
+    box-shadow: $c-shadow-inset, 0 2px 6px rgba(0, 0, 0, 0.45);
+
+    &:hover {
+      filter: brightness(1.18);
+    }
+  }
+
+  // ── Explosive damage block ────────────────────────────────────────────
+  .explosive-targets,
+  .explosive-target-zone {
+    background: $c-panel;
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    padding: 4px 6px;
+    margin: 4px 0;
+  }
+
+  .explosive-targets-label {
+    font-family: $font-display;
+    color: $c-accent;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.88em;
+    font-weight: 600;
+  }
+
+  .explosive-damage-button button {
+    background: $grad-button-stop;
+    border: 1px solid rgba(226, 95, 99, 0.5);
+    color: $c-white;
+    border-radius: 2px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 4px 10px;
+
+    &:hover {
+      filter: brightness(1.18);
+      cursor: pointer;
+    }
+  }
+
+  // ── Range table ───────────────────────────────────────────────────────
+  .ranges {
+    background: $c-panel;
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    padding: 4px 6px;
+    margin: 4px 0;
+    font-family: $font-numeric;
+    color: $c-text-primary;
+  }
+}
+
+// ── Whisper / blind / private message tints ────────────────────────────────
+.chat-message.whisper {
+  background:
+    linear-gradient(180deg, rgba(28, 24, 40, 0.92) 0%, rgba(14, 12, 22, 0.92) 100%) !important;
+}
+
+.chat-message.blind {
+  border-left-color: $c-warning !important;
+}

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -259,34 +259,9 @@
         min-width: 110px;
       }
 
-      // Metaphysics-extranormal toggle moved here from the header in
-      // non-normal modes. Render as a tidy checkbox + label pair.
-      .metaphysics-toggle {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 0 4px;
-        border-left: 1px solid $c-border;
-        color: $c-text-muted;
-        font-size: 0.78em;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        white-space: nowrap;
-        cursor: pointer;
-
-        input[type="checkbox"] {
-          margin: 0;
-        }
-
-        &:has(input:disabled) {
-          opacity: 0.6;
-          cursor: default;
-        }
-      }
-
       // Reset-Session sits alongside the mode controls in non-normal modes.
       .session-reset-button {
-        margin-left: auto;
+        margin-left: 4px;
       }
     }
   }

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -1,8 +1,14 @@
 @use '../utils' as *;
 
+// ── Sheet ──────────────────────────────────────────────────────────────────
 .od6s {
   .item-form {
     font-family: $font-primary;
+  }
+
+  // ── Header ───────────────────────────────────────────────────────────────
+  header.sheet-header {
+    border: none;
   }
 
   .sheet-header {
@@ -10,52 +16,153 @@
     overflow: hidden;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-start;
+    flex-wrap: nowrap;
+    align-items: stretch;
     justify-content: flex-start;
-    margin-bottom: 10px;
+    margin-bottom: 0;
+    padding: 4px 4px 14px;
+    border-bottom: 1px solid $c-border;
+    gap: 14px;
+    position: relative;
 
-    .profile-img {
-      flex: 0 0 200px;
-      height: 200px;
-      margin-right: 10px;
+    // Gold scribe line under the header
+    &::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 1px;
+      background: $grad-rule;
+      pointer-events: none;
     }
 
-    .header-fields {
+    .profile-img {
+      flex: 0 0 180px;
+      width: 180px;
+      height: 180px;
+      object-fit: cover;
+      border-radius: 4px;
+      border: 1px solid $c-accent-border;
+      box-shadow:
+        0 0 0 1px rgba(0, 0, 0, 0.6),
+        0 6px 22px rgba(0, 0, 0, 0.55),
+        inset 0 0 24px rgba(0, 0, 0, 0.45);
+      filter: saturate(1.05) contrast(1.02);
+      transition: filter 0.2s ease, box-shadow 0.2s ease;
+
+      &:hover {
+        filter: saturate(1.15) contrast(1.05);
+        box-shadow:
+          0 0 0 1px $c-accent-border,
+          0 6px 28px rgba(0, 0, 0, 0.6),
+          0 0 16px rgba(201, 162, 39, 0.25);
+      }
+    }
+
+    .header-right {
       flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      min-width: 0;
+      gap: 6px;
+    }
+
+    // Header data strips — replace boxed cells with subtle bar layout
+    .flex-group-center,
+    .flex-group-left {
+      border: none;
+      background:
+        linear-gradient(90deg, rgba(201, 162, 39, 0.08) 0%, transparent 22%),
+        $c-raised;
+      padding: 4px 8px 4px 10px;
+      border-radius: 2px;
+      box-shadow: $c-shadow-inset;
+      position: relative;
+
+      // Left accent rail
+      &::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 4px;
+        bottom: 4px;
+        width: 2px;
+        background: $c-accent-strong;
+        border-radius: 2px;
+        opacity: 0.7;
+      }
     }
 
     .header-fields label {
-      display: inline-block;
-      text-align: right;
-      float: left;
-      margin-right: 4px;
+      color: $c-text-muted;
+      font-size: 0.72em;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 500;
+      margin-right: 6px;
+      white-space: nowrap;
     }
 
     .header-fields input {
-      display: inline-block;
-      text-align: left;
-      float: right;
+      font-family: $font-numeric;
+      color: $c-text-primary;
+      font-weight: 500;
     }
 
     h2.charname {
-      height: 30px;
-      padding: 0px;
-      margin: 5px 0;
-      border-bottom: 0;
+      height: 44px;
+      padding: 0;
+      margin: 0 0 6px;
+      border: none;
+      position: relative;
+
+      &::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 1px;
+        background: linear-gradient(90deg, $c-accent-strong 0%, $c-accent-border 40%, transparent 100%);
+      }
 
       input {
         width: 100%;
         height: 100%;
         margin: 0;
+        font-family: $font-display;
+        font-size: 2.1em;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        color: $c-accent;
+        background: transparent;
+        border: none;
+        padding: 0 2px;
+        text-shadow: 0 1px 0 rgba(0, 0, 0, 0.7), 0 0 18px rgba(201, 162, 39, 0.25);
+
+        &::placeholder {
+          color: rgba(201, 162, 39, 0.35);
+        }
+
+        &:focus {
+          outline: none;
+          color: $c-accent-bright;
+        }
       }
     }
   }
 
+  // ── Tabs container ───────────────────────────────────────────────────────
   .sheet-tabs {
     flex: 0;
-    border-width: thick;
-    border-style: double;
+    border-style: none;
+    border-top: 1px solid $c-border;
+    border-bottom: 1px solid $c-border;
+    margin-bottom: 8px;
+    background: $c-panel-deep;
+    box-shadow: inset 0 -1px 0 rgba(201, 162, 39, 0.08);
   }
 
   .sheet-body,
@@ -67,11 +174,27 @@
   .sheet-body .editor {
     height: 8em;
     min-height: 300px;
-    overflow: hidden
+    overflow: hidden;
   }
 
   .sheet-mode {
-    width: 200px
+    width: 220px;
+    margin-top: 6px;
+
+    .sheetmode {
+      gap: 6px;
+      padding: 4px 8px;
+      background: $c-panel;
+      border: 1px solid $c-border;
+      border-radius: 3px;
+
+      label {
+        color: $c-text-muted;
+        font-size: 0.78em;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+    }
   }
 
   .tox {
@@ -86,21 +209,25 @@
 
   .boxed {
     box-sizing: border-box;
-    padding: 2px;
+    padding: 4px 6px;
     margin: 5px;
-    border: 1px solid #999;
+    border: 1px solid $c-border;
+    background: $c-panel;
+    border-radius: 2px;
   }
 
   .bordered {
-    border: 3px solid black;
+    border: 1px solid $c-border-strong;
+    border-radius: 2px;
   }
 
   .advancebox {
-    border: 1px solid;
-    border: 5px;
+    border: 1px solid $c-accent-border;
+    background: $c-panel;
     width: 55px;
     height: 55px;
     font-size: 300%;
+    border-radius: 3px;
   }
 
   .actorsetup {
@@ -109,49 +236,115 @@
     align-items: center;
   }
 
+  // ── Section banners (attribute headers + body-points / solid headers) ────
   .attribute,
   .header-solid,
   .body-points-max {
     justify-content: center;
     align-items: center;
-    background-color: black;
-    color: lightgrey;
+    background: $grad-banner;
+    color: $c-accent-bright;
+    padding: 5px 8px;
+    font-family: $font-display;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.95em;
+    border-radius: 2px;
+    border-top: 1px solid $c-accent-border;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.4);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      inset 0 -2px 6px rgba(0, 0, 0, 0.35);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.6);
   }
 
   .attribute-action {
     justify-content: center;
     align-items: center;
-    background-color: black;
-    color: white;
+    background: transparent;
+    color: $c-accent;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-bottom: 1px solid $c-accent-border;
+    margin-top: 4px;
+  }
+
+  // ── Dice value pill ──────────────────────────────────────────────────────
+  // Right-side dice readouts in attribute/skill/spec/combat lists
+  .attribute-list .flex-group-center,
+  .skill-list .flex-group-center,
+  .specialization-list .flex-group-center,
+  .combat-list .flex-group-center,
+  .grid-2col-combat > .flex-group-center,
+  .grid-4col-resistance > .flex-group-center {
+    background: $grad-pill;
+    border: 1px solid rgba(201, 162, 39, 0.18);
+    border-radius: 3px;
+    padding: 2px 6px;
+    font-family: $font-numeric;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: $c-text-primary;
+    box-shadow:
+      inset 0 0 0 1px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+
+    &.rolldialog:hover {
+      color: $c-accent-bright;
+      border-color: $c-accent-strong;
+      box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.3),
+        0 0 12px rgba(201, 162, 39, 0.35);
+      background: linear-gradient(180deg, rgba(20, 16, 4, 0.7), rgba(40, 30, 6, 0.55));
+    }
+  }
+
+  .attribute-list b,
+  .skill-list b,
+  .specialization-list b,
+  .combat-list b,
+  .availableaction b {
+    color: $c-accent;
+    font-weight: 700;
   }
 
   .indent {
-    text-indent: 1em;
+    padding-left: 14px;
+    position: relative;
+
+    &::before {
+      content: "›";
+      position: absolute;
+      left: 4px;
+      color: $c-accent-border;
+      font-weight: 700;
+    }
   }
 
   .tab-header {
-    margin-top: 10px;
+    margin-top: 12px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid $c-border;
+    color: $c-accent;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
   }
 
   .small-font {
     font-size: 75%;
   }
 
-  .align-right {
-    text-align: right;
-  }
-
-  .float-right {
-    float: right;
-  }
-
-  .align-left {
-    text-align: left;
-  }
-
-  .align-center {
-    text-align: center;
-  }
+  .align-right    { text-align: right; }
+  .float-right    { float: right; }
+  .align-left     { text-align: left; }
+  .align-center   { text-align: center; }
 
   .align-center-bottom {
     width: auto;
@@ -174,38 +367,167 @@
     width: 4ch;
   }
 
+  // ── Inputs / Selects ─────────────────────────────────────────────────────
+  input[type="text"],
+  input[type="number"],
+  input[type="password"],
+  select {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    color: $c-text-primary;
+    padding: 2px 6px;
+    font-family: $font-primary;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus {
+      outline: none;
+      border-color: $c-accent-border;
+      box-shadow: 0 0 0 2px rgba(201, 162, 39, 0.18);
+    }
+
+    &::placeholder {
+      color: $c-text-dim;
+    }
+  }
+
+  // Header inputs sit on the data-strip background — go transparent
+  .sheet-header .header-fields input,
+  .sheet-header .header-fields select {
+    background: transparent;
+    border: none;
+    border-bottom: 1px dotted $c-border;
+    border-radius: 0;
+    padding: 1px 2px;
+
+    &:focus {
+      box-shadow: none;
+      border-bottom-color: $c-accent;
+    }
+  }
+
+  input[type="checkbox"] {
+    accent-color: $c-accent;
+    cursor: pointer;
+  }
+
+  // ── Buttons ──────────────────────────────────────────────────────────────
   .reset-template,
   .reset-species-template {
-    background-color: red;
-    border: none;
-    color: black;
+    background: $grad-button-stop;
+    border: 1px solid #c0392b;
+    color: $c-white;
     text-align: center;
     text-decoration: none;
     display: inline-block;
+    border-radius: 2px;
+    padding: 3px 10px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.78em;
+    font-weight: 600;
+    box-shadow: $c-shadow-inset, 0 2px 4px rgba(0, 0, 0, 0.4);
+    transition: filter 0.15s ease, transform 0.05s ease;
+
+    &:hover {
+      filter: brightness(1.15);
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
   }
 
   .create-character {
-    background-color: green
+    background: $grad-button-go;
+    border: 1px solid rgba(78, 201, 122, 0.45);
+    color: $c-white;
+    border-radius: 2px;
+    padding: 6px 16px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 700;
+    font-size: 0.95em;
+    box-shadow: $c-shadow-inset, 0 2px 8px rgba(0, 0, 0, 0.5);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.6);
+    cursor: pointer;
+    position: relative;
+    transition: filter 0.15s ease, transform 0.05s ease, box-shadow 0.15s ease;
+
+    &:hover {
+      filter: brightness(1.18);
+      box-shadow:
+        $c-shadow-inset,
+        0 2px 10px rgba(0, 0, 0, 0.55),
+        0 0 14px rgba(78, 201, 122, 0.35);
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
+  }
+
+  .session-reset-button {
+    background: $c-panel-deep;
+    border: 1px solid $c-border;
+    color: $c-text-muted;
+    padding: 4px 10px;
+    border-radius: 2px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.78em;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+      color: $c-accent;
+      border-color: $c-accent-border;
+    }
   }
 
   .damage-button {
-    background-color: crimson;
-    border: none;
-    color: white;
-    padding: 15px 32px;
+    background: $grad-button-stop;
+    border: 1px solid rgba(226, 95, 99, 0.5);
+    color: $c-white;
+    padding: 12px 28px;
     text-align: center;
     text-decoration: none;
     display: inline-block;
     font-size: 16px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    border-radius: 2px;
+    box-shadow: $c-shadow-inset, 0 2px 8px rgba(0, 0, 0, 0.5);
   }
 
   .item-info-ok-button {
-    padding: 15px 32px;
+    padding: 12px 28px;
     text-align: center;
     text-decoration: none;
     display: inline-block;
     width: 200px;
-    font-size: 24px;
+    font-size: 20px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+  }
+
+  // Plus / add affordance
+  .item-add,
+  .addaction {
+    color: $c-text-muted;
+    transition: color 0.15s ease, transform 0.15s ease, text-shadow 0.15s ease;
+
+    &:hover {
+      color: $c-accent-bright;
+      transform: scale(1.1);
+      text-shadow: 0 0 8px rgba(201, 162, 39, 0.5);
+      cursor: pointer;
+    }
   }
 
   .editor,
@@ -215,25 +537,22 @@
   }
 
   .equip-checkbox {
-    transform: scale(0.66);
+    transform: scale(0.85);
     vertical-align: middle;
-    horiz-align: left;
     text-align: left;
   }
 
   .skill-used-checkbox {
-    transform: scale(0.66);
+    transform: scale(0.85);
     vertical-align: middle;
-    horiz-align: left;
     text-align: left;
     margin: 1px;
     justify-self: start;
   }
 
   .spec-used-checkbox {
-    transform: scale(0.66);
+    transform: scale(0.85);
     vertical-align: middle;
-    horiz-align: left;
     text-align: left;
     margin: 2px;
     justify-self: start;
@@ -242,5 +561,26 @@
   .checkbox {
     vertical-align: middle;
     margin: 2px;
+  }
+
+  // Generic prose-mirror editor — give it a panel background
+  prose-mirror {
+    display: block;
+    background: rgba(0, 0, 0, 0.32);
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    margin-top: 4px;
+    margin-bottom: 8px;
+    min-height: 80px;
+    padding: 4px;
+  }
+
+  .resource-label {
+    font-family: $font-display;
+    color: $c-accent;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    font-size: 0.85em;
   }
 }

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -156,7 +156,7 @@
 
   // ── Tabs container ───────────────────────────────────────────────────────
   .sheet-tabs {
-    flex: 0;
+    flex: 0 0 auto;
     border-style: none;
     border-top: 1px solid $c-border;
     border-bottom: 1px solid $c-border;
@@ -165,10 +165,47 @@
     box-shadow: inset 0 -1px 0 rgba(201, 162, 39, 0.08);
   }
 
-  .sheet-body,
-  .sheet-body .tab,
-  .sheet-body .tab {
+  // ── Sheet body scroll plumbing ───────────────────────────────────────────
+  // The form is flexcol; we let the header + tabs + sheet-mode size to content
+  // and grant the sheet-body the remaining vertical space with internal scroll.
+  > form {
+    display: flex;
+    flex-direction: column;
     height: 100%;
+    min-height: 0;
+  }
+
+  .sheet-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-right: 4px;
+
+    > .tab {
+      min-height: 100%;
+    }
+
+    // Themed scrollbar (WebKit / Chromium)
+    &::-webkit-scrollbar {
+      width: 8px;
+    }
+    &::-webkit-scrollbar-track {
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: 4px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: rgba(201, 162, 39, 0.3);
+      border-radius: 4px;
+      transition: background 0.15s ease;
+
+      &:hover {
+        background: rgba(201, 162, 39, 0.55);
+      }
+    }
+    // Firefox
+    scrollbar-width: thin;
+    scrollbar-color: rgba(201, 162, 39, 0.35) rgba(0, 0, 0, 0.2);
   }
 
   .sheet-body .editor {

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -239,14 +239,15 @@
     margin-top: 6px;
 
     .sheetmode {
-      gap: 8px;
+      gap: 12px;
       padding: 4px 10px;
       background: $c-panel;
       border: 1px solid $c-border;
       border-radius: 3px;
       width: max-content;
+      align-items: center;
 
-      label {
+      > label {
         color: $c-text-muted;
         font-size: 0.78em;
         text-transform: uppercase;
@@ -254,12 +255,38 @@
         white-space: nowrap;
       }
 
-      // The template hard-codes width: 70px on the select inline, which
-      // truncates "advance" / "freeedit" — override so all options read
-      // correctly when the dropdown is closed.
       select {
-        width: auto !important;
         min-width: 110px;
+      }
+
+      // Metaphysics-extranormal toggle moved here from the header in
+      // non-normal modes. Render as a tidy checkbox + label pair.
+      .metaphysics-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 0 4px;
+        border-left: 1px solid $c-border;
+        color: $c-text-muted;
+        font-size: 0.78em;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        white-space: nowrap;
+        cursor: pointer;
+
+        input[type="checkbox"] {
+          margin: 0;
+        }
+
+        &:has(input:disabled) {
+          opacity: 0.6;
+          cursor: default;
+        }
+      }
+
+      // Reset-Session sits alongside the mode controls in non-normal modes.
+      .session-reset-button {
+        margin-left: auto;
       }
     }
   }

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -166,13 +166,23 @@
   }
 
   // ── Sheet body scroll plumbing ───────────────────────────────────────────
-  // The form is flexcol; we let the header + tabs + sheet-mode size to content
-  // and grant the sheet-body the remaining vertical space with internal scroll.
-  > form {
+  // .od6s lives on the application root; the form is a grandchild via
+  // .window-content. Make window-content a flex column that constrains the
+  // form's height, then let the form's flex column give sheet-body the
+  // remaining vertical space with internal scroll.
+  .window-content {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    overflow: hidden;
     min-height: 0;
+  }
+
+  form.flexcol {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
   }
 
   .sheet-body {

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -60,7 +60,13 @@
       }
     }
 
-    .header-right {
+    // Right-side column: charname stacked above stat grid.
+    // Actor sheets wrap it in `.header-right`; item sheets use
+    // `.header-fields` directly. Match both as direct children only —
+    // the actor's nested `.header-fields` grid is a deeper descendant
+    // and is styled separately below.
+    > .header-right,
+    > .header-fields {
       flex: 1;
       display: flex;
       flex-direction: column;

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -231,21 +231,35 @@
   }
 
   .sheet-mode {
-    width: 220px;
+    // Sit at the bottom of the form's flex column without being squeezed by
+    // the scrollable .sheet-body above. Auto-sized to its contents so the
+    // mode dropdown's options remain readable.
+    flex: 0 0 auto;
+    align-self: flex-start;
     margin-top: 6px;
 
     .sheetmode {
-      gap: 6px;
-      padding: 4px 8px;
+      gap: 8px;
+      padding: 4px 10px;
       background: $c-panel;
       border: 1px solid $c-border;
       border-radius: 3px;
+      width: max-content;
 
       label {
         color: $c-text-muted;
         font-size: 0.78em;
         text-transform: uppercase;
         letter-spacing: 0.06em;
+        white-space: nowrap;
+      }
+
+      // The template hard-codes width: 70px on the select inline, which
+      // truncates "advance" / "freeedit" — override so all options read
+      // correctly when the dropdown is closed.
+      select {
+        width: auto !important;
+        min-width: 110px;
       }
     }
   }

--- a/scss/components/_items.scss
+++ b/scss/components/_items.scss
@@ -1,4 +1,7 @@
+@use '../utils' as *;
+
 .od6s {
+  // ── Inventory / item lists ───────────────────────────────────────────────
   .gear-list,
   .weapons-list,
   .armor-list,
@@ -19,8 +22,30 @@
     padding: 0;
     overflow-y: auto;
 
+    > li {
+      list-style: none;
+      margin: 1px 0;
+      padding: 4px 6px;
+      border-radius: 2px;
+      border-left: 2px solid transparent;
+      transition: background-color 0.15s ease, border-color 0.15s ease;
+
+      &:nth-child(even) {
+        background: $c-row-alt;
+      }
+
+      &:hover {
+        background-color: $c-row-hover;
+        border-left-color: $c-accent;
+      }
+    }
+
     .item-header {
       font-weight: bold;
+      font-family: $font-display;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: $c-accent;
     }
 
     .item .item-mod {
@@ -28,7 +53,7 @@
       display: inline-block;
       line-height: 24px;
       padding: 3px 0;
-      border-bottom: 1px solid #BBB;
+      border-bottom: 1px solid $c-border;
 
       .item-image {
         flex: 0 0 24px;
@@ -49,6 +74,23 @@
       flex: 0 0 86px;
       text-align: center;
       vertical-align: middle;
+
+      a {
+        color: $c-text-muted;
+        margin: 0 2px;
+        transition: color 0.15s ease, text-shadow 0.15s ease, transform 0.1s ease;
+
+        &:hover {
+          color: $c-accent-bright;
+          text-shadow: 0 0 6px rgba(201, 162, 39, 0.5);
+          transform: scale(1.1);
+        }
+
+        &.item-delete:hover {
+          color: $c-bad;
+          text-shadow: 0 0 6px rgba(226, 95, 99, 0.5);
+        }
+      }
     }
   }
 
@@ -72,5 +114,182 @@
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;
     break-inside: avoid-column;
+  }
+
+  // ── Section banner (Armor / Weapons / Gear titles) ───────────────────────
+  // The template uses `.title-add-grid` with a centered title cell + add button
+  .title-add-grid {
+    margin: 10px 0 4px;
+    align-items: center;
+
+    > .flex-group-center {
+      position: relative;
+      font-family: $font-display;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: $c-accent;
+      font-weight: 600;
+      font-size: 0.95em;
+      padding: 4px 0;
+
+      // Bracket flanks: ┄ TITLE ┄
+      &::before,
+      &::after {
+        content: "";
+        flex: 1;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, $c-accent-border, transparent);
+        margin: 0 8px;
+        opacity: 0.6;
+      }
+
+      b {
+        text-shadow: 0 0 12px rgba(201, 162, 39, 0.3);
+      }
+    }
+  }
+
+  // ── Combat: Available Actions / Actions section title ────────────────────
+  // These use .grid-3col-combat / `<b>Actions</b>` patterns; style the
+  // bold-wrapped centered cells as section markers.
+  .tab.combat > .row > .column > .flexrow.flex-group-center,
+  .tab.combat .grid-3col-combat > .flex-group-center:first-child {
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: $c-accent;
+    font-weight: 600;
+    padding: 4px 0;
+    margin: 6px 0 2px;
+    border-bottom: 1px solid $c-accent-border;
+
+    b {
+      text-shadow: 0 0 10px rgba(201, 162, 39, 0.3);
+    }
+  }
+
+  // Combat — small-grid stat rows (Action Penalties, Wound Penalties, etc.)
+  .tab.combat .grid-2col-combat,
+  .tab.combat .grid-4col-resistance {
+    background: $c-panel;
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    padding: 4px 6px;
+    margin: 4px 0;
+    box-shadow: $c-shadow-inset;
+
+    > .flex-group-left {
+      color: $c-text-primary;
+      font-size: 0.92em;
+    }
+  }
+
+  // Defense grid (Dodge / Parry / Block) — line of three readouts
+  .defense-grid {
+    background: $c-panel;
+    border: 1px solid $c-border;
+    border-radius: 2px;
+    padding: 4px 6px;
+    margin: 4px 0;
+    box-shadow: $c-shadow-inset;
+
+    > .flex-group-left {
+      gap: 6px;
+
+      label {
+        color: $c-text-muted;
+        font-size: 0.78em;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      input {
+        background: rgba(0, 0, 0, 0.4);
+        border: 1px solid $c-border;
+        border-radius: 2px;
+        color: $c-accent;
+        font-family: $font-numeric;
+        font-weight: 600;
+        text-align: center;
+        width: 3em;
+      }
+    }
+  }
+
+  // ── Available actions list ───────────────────────────────────────────────
+  // Each li.availableaction wraps an action; turn them into clean rows
+  ul.availableaction {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    > li.availableaction {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      border-radius: 2px;
+      border-left: 2px solid transparent;
+      transition: background-color 0.15s ease, border-color 0.15s ease;
+
+      &:hover {
+        background-color: $c-row-hover;
+        border-left-color: $c-accent;
+      }
+
+      .combat-action,
+      .vehicle-action {
+        padding: 3px 8px;
+        color: $c-text-primary;
+      }
+    }
+
+    > li.availableaction.attribute-action {
+      // Inherits banner-ish styling from .attribute-action above
+      border-left: none;
+    }
+  }
+
+  // ── Assigned actions list ────────────────────────────────────────────────
+  .assigned-action-list {
+    > li.assignedaction {
+      background: $c-panel;
+      border: 1px solid $c-border;
+      border-left: 2px solid $c-accent-border;
+      border-radius: 2px;
+      margin: 3px 0;
+      padding: 0;
+
+      &:hover {
+        border-left-color: $c-accent;
+      }
+
+      .grid-2col-combat {
+        background: transparent;
+        border: none;
+        margin: 0;
+        padding: 4px 6px;
+        box-shadow: none;
+      }
+    }
+  }
+
+  // ── Edit-quantity input on gear ──────────────────────────────────────────
+  .edit-quantity input {
+    width: 100%;
+    text-align: center;
+    background: rgba(0, 0, 0, 0.4);
+    color: $c-accent;
+    font-family: $font-numeric;
+    font-weight: 600;
+  }
+
+  // ── Edit-funds (used by no-credits worlds) ───────────────────────────────
+  .edit-funds input {
+    text-align: center;
+    background: rgba(0, 0, 0, 0.4);
+    color: $c-accent;
+    font-family: $font-numeric;
+    font-weight: 600;
+    width: 4ch;
   }
 }

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -1,17 +1,91 @@
+@use '../utils' as *;
+
 .od6s {
   .tabs {
-    height: 40px;
-    border-top: 1px solid #AAA;
-    border-bottom: 1px solid #AAA;
+    height: 42px;
+    border-top: 1px solid $c-border;
+    border-bottom: 1px solid $c-border;
+    background: $c-panel-deep;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: stretch;
+    gap: 0;
 
     .item {
-      line-height: 40px;
-      font-weight: bold;
-    }
+      flex: 1;
+      line-height: 42px;
+      font-family: $font-display;
+      font-weight: 600;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      font-size: 0.88em;
+      color: $c-text-muted;
+      text-align: center;
+      transition: color 0.18s ease, background-color 0.18s ease, text-shadow 0.18s ease;
+      position: relative;
+      border-right: 1px solid rgba(255, 255, 255, 0.04);
+      cursor: pointer;
 
-    .item.active {
-      text-decoration: underline;
-      text-shadow: none;
+      &:last-child {
+        border-right: none;
+      }
+
+      // Subtle "scribe" indicator above tab text
+      &::before {
+        content: "";
+        position: absolute;
+        top: 4px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: $c-accent;
+        opacity: 0;
+        transition: opacity 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      // Active underline (replaces default 2px)
+      &::after {
+        content: "";
+        position: absolute;
+        left: 12%;
+        right: 12%;
+        bottom: -1px;
+        height: 2px;
+        background: linear-gradient(90deg, transparent 0%, $c-accent 50%, transparent 100%);
+        opacity: 0;
+        transition: opacity 0.2s ease;
+      }
+
+      &:hover:not(.active) {
+        color: $c-accent;
+        background: rgba(201, 162, 39, 0.05);
+        text-shadow: 0 0 8px rgba(201, 162, 39, 0.3);
+        cursor: pointer;
+      }
+
+      &.active {
+        text-decoration: none;
+        color: $c-accent-bright;
+        background: linear-gradient(180deg, rgba(201, 162, 39, 0.18) 0%, rgba(201, 162, 39, 0.06) 100%);
+        text-shadow: 0 0 10px rgba(201, 162, 39, 0.5);
+        border: none;
+
+        &::before {
+          opacity: 1;
+          box-shadow: 0 0 8px $c-accent, 0 0 14px rgba(201, 162, 39, 0.7);
+        }
+
+        &::after {
+          opacity: 1;
+          height: 3px;
+          background: linear-gradient(90deg, transparent 0%, $c-accent-bright 50%, transparent 100%);
+          box-shadow: 0 0 12px rgba(201, 162, 39, 0.6);
+        }
+      }
     }
   }
 }

--- a/scss/global/_grid.scss
+++ b/scss/global/_grid.scss
@@ -293,6 +293,25 @@
   text-align: right;
 }
 
+// Strip Foundry's default 1px #999 cell outlines inside our sheets — we
+// reintroduce intentional surfaces in the component layer instead.
+.od6s {
+  .flex-group-center,
+  .flex-group-left,
+  .flex-group-right {
+    border: none;
+    padding: 2px 4px;
+  }
+
+  .row {
+    gap: 12px;
+  }
+
+  .column {
+    padding: 0;
+  }
+}
+
 .inv-grid {
   display: grid;
   border: 1px;

--- a/scss/global/_grid.scss
+++ b/scss/global/_grid.scss
@@ -85,13 +85,18 @@
   align-items: center;
 }
 
+// `grid-2col-attributes` / `grid-2col-combat` are emitted by the templates in
+// Normal mode; their 3-col counterparts below are used in Advance / Free-Edit.
+// Both variants intentionally share the same column template so that switching
+// modes does not shift the dice column horizontally — the third column is just
+// empty in Normal mode.
 .grid-2col-attributes,
 .grid-2col-combat {
   display: grid;
-  grid-column: span 2 / span 2;
-  grid-template-columns: 75% 20%;
+  grid-column: span 3 / span 3;
+  grid-template-columns: 65% 20% 14%;
   border: 1px;
-  gap: 5px;
+  gap: 1px;
   margin: 1px 0;
   padding: 0;
 }

--- a/scss/global/_window.scss
+++ b/scss/global/_window.scss
@@ -2,20 +2,39 @@
 
 .window-app {
   font-family: $font-primary;
+  color: $c-text-primary;
 }
 
+// ── Sheet body wash ───────────────────────────────────────────────────────
+// Subtle radial glow + hairline interior frame so the sheet feels intentional
+// rather than a transparent overlay on the Foundry background.
+.od6s.sheet {
+  // Interior atmosphere — soft vignette toward the bottom
+  .window-content,
+  & {
+    background:
+      radial-gradient(ellipse at top, rgba(201, 162, 39, 0.05) 0%, transparent 60%),
+      linear-gradient(180deg, rgba(8, 12, 18, 0.35) 0%, rgba(8, 12, 18, 0.55) 100%);
+  }
+}
+
+// ── Interactive elements ─────────────────────────────────────────────────
 .rollable,
 .highlight {
+  transition: color 0.15s ease, text-shadow 0.15s ease, background-color 0.15s ease;
+  border-radius: 3px;
+
   &:hover,
   &:focus {
-    color: #000;
-    text-shadow: 0 0 10px red;
+    color: $c-accent-bright;
+    background-color: $c-hover-bg;
+    text-shadow: 0 0 6px rgba(201, 162, 39, 0.5);
     cursor: pointer;
   }
 }
 
 .damaged {
-   color: #8B0000; 
+  color: $c-bad;
 }
 
 .modifier-button {
@@ -39,23 +58,27 @@
 .show-item-details,
 .choose-target,
 .crew-member {
+  transition: color 0.15s ease, text-shadow 0.15s ease, background-color 0.15s ease, transform 0.1s ease;
+  border-radius: 3px;
+
   &:hover,
   &:focus {
-    color: #000;
-    text-shadow: 0 0 10px red;
+    color: $c-accent-bright;
+    background-color: $c-hover-bg;
+    text-shadow: 0 0 6px rgba(201, 162, 39, 0.5);
     cursor: pointer;
   }
 }
 
 .wilddie {
-  color: #f00;
+  color: $c-bad;
 }
 
 .wilddiegm {
-  color: #f00;
+  color: $c-bad;
   &:hover,
   &:focus {
-    color: #f00;
+    color: $c-bad;
     text-shadow: 0 0 10px black;
     cursor: pointer;
   }

--- a/scss/od6s.scss
+++ b/scss/od6s.scss
@@ -16,3 +16,4 @@
 @use 'components/tabs';
 @use 'components/items';
 @use 'components/attributes';
+@use 'components/chat';

--- a/scss/utils/_colors.scss
+++ b/scss/utils/_colors.scss
@@ -1,2 +1,50 @@
 $c-white: #fff;
 $c-black: #000;
+
+// ── Core palette ────────────────────────────────────────────────────────────
+$c-accent:        #c9a227;      // signature gold
+$c-accent-bright: #e8c349;      // hover/active gold
+$c-accent-deep:   #8a6d12;      // pressed/border gold
+$c-accent-dim:    rgba(201, 162, 39, 0.13);
+$c-accent-border: rgba(201, 162, 39, 0.4);
+$c-accent-strong: rgba(201, 162, 39, 0.7);
+
+// Surface tones — built on near-black with cool undertone
+$c-bg-deep:    #080b11;
+$c-panel:      rgba(8, 12, 18, 0.55);
+$c-panel-deep: rgba(4, 7, 12, 0.78);
+$c-raised:     rgba(255, 255, 255, 0.045);
+$c-row-alt:    rgba(255, 255, 255, 0.028);
+$c-row-hover:  rgba(201, 162, 39, 0.07);
+
+// Borders & rules
+$c-border:        rgba(255, 255, 255, 0.12);
+$c-border-strong: rgba(255, 255, 255, 0.22);
+$c-rule:          rgba(201, 162, 39, 0.22);
+
+// Text
+$c-text-primary: #d6dae4;
+$c-text-muted:   #7a8499;
+$c-text-dim:     #4f586c;
+
+// Status
+$c-good:    #4ec97a;
+$c-warning: #e8a740;
+$c-bad:     #e25f63;
+$c-mod-up:   rgba(78, 201, 122, 0.55);
+$c-mod-down: rgba(226, 95, 99, 0.55);
+
+// Effects
+$c-hover-bg:     rgba(201, 162, 39, 0.13);
+$c-glow-accent:  0 0 12px rgba(201, 162, 39, 0.45);
+$c-glow-soft:    0 0 6px rgba(201, 162, 39, 0.3);
+$c-shadow-deep:  0 4px 18px rgba(0, 0, 0, 0.55);
+$c-shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06), inset 0 -1px 0 rgba(0, 0, 0, 0.4);
+
+// Gradients
+$grad-banner:      linear-gradient(180deg, rgba(201, 162, 39, 0.32) 0%, rgba(201, 162, 39, 0.12) 100%);
+$grad-banner-deep: linear-gradient(180deg, rgba(8, 12, 18, 0.85) 0%, rgba(20, 24, 32, 0.85) 100%);
+$grad-pill:        linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(20, 18, 8, 0.55) 100%);
+$grad-button-go:   linear-gradient(180deg, #2e7a44 0%, #154d27 100%);
+$grad-button-stop: linear-gradient(180deg, #b14040 0%, #6b1f1f 100%);
+$grad-rule:        linear-gradient(90deg, transparent 0%, rgba(201, 162, 39, 0.55) 50%, transparent 100%);

--- a/scss/utils/_typography.scss
+++ b/scss/utils/_typography.scss
@@ -1,4 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Martel:wght@400;800&family=Roboto:wght@300;400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&family=Roboto:wght@300;400;500;700&display=swap');
 
-$font-primary: 'Roboto', sans-serif;
-$font-secondary: 'Roboto', sans-serif;
+$font-primary: 'Roboto', 'Helvetica Neue', sans-serif;
+$font-display: 'Rajdhani', 'Roboto', sans-serif;
+$font-numeric: 'Rajdhani', 'Roboto', sans-serif;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -985,6 +985,7 @@
   "OD6S.SET_EXPLOSIVE": "Set Explosive",
   "OD6S.SET": "Set",
   "OD6S.SHEET_MODE": "Mode",
+  "OD6S.RESET_SESSION": "Reset Session",
   "OD6S.SHEETMODE": "Mode",
   "OD6S.SHEETMODE_ADVANCE": "Advance",
   "OD6S.SHEETMODE_FREEDIT": "Free Edit",

--- a/src/module/actor/actor-helpers/skill-score.ts
+++ b/src/module/actor/actor-helpers/skill-score.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helper for the score that the actor sheet displays (and rolls from)
+ * for a skill or specialization owned by an actor.
+ *
+ * The display score derives from three immutable-per-call inputs:
+ *   - the item's own progression (`base + mod`)
+ *   - whether the skill is "advanced" (rolls flat without the linked attribute)
+ *   - the linked attribute's score
+ *
+ * This must be idempotent. Earlier code at the call site mutated
+ * `item.system.score` by reading it, adding the attribute, and writing back —
+ * which compounded over re-renders because `prepareDerivedData()` only resets
+ * `score = base + mod` when the actor is re-prepared, not on every sheet
+ * render. Computing from `base + mod` directly removes that aliasing.
+ */
+
+export interface SkillScoreInputs {
+    /** The item's own base progression in pips. */
+    base: number;
+    /** Mod from advancement / active effects targeting `mod`, in pips. */
+    mod: number;
+    /**
+     * True if this is an "advanced" skill — its score is rolled flat without
+     * the linked attribute being added (Star Wars D6 / OpenD6 advanced skills).
+     */
+    isAdvancedSkill?: boolean;
+    /** Linked attribute's score in pips. Ignored when `isAdvancedSkill`. */
+    attributeScore?: number;
+    /**
+     * If true, the world is in flat-skill mode and the display score is the
+     * raw item progression (`base + mod`) without the attribute.
+     */
+    flatSkills?: boolean;
+}
+
+/**
+ * Compute the score that the sheet should render and rolls should use for a
+ * skill or specialization.
+ *
+ * Pure: never reads or mutates anything outside its inputs.
+ */
+export function computeSkillDisplayScore(input: SkillScoreInputs): number {
+    const own = (+input.base) + (+input.mod);
+    if (input.flatSkills) return own;
+    if (input.isAdvancedSkill) return own;
+    return own + (+(input.attributeScore ?? 0));
+}

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -328,6 +328,18 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
                 if (ok) await this._onClearSpeciesTemplate();
             }));
 
+        // Sheet-mode dropdown: explicit change handler. The template wraps
+        // the body in its own <form> nested inside the application's root
+        // form (which is itself a <form> via DocumentSheetV2's tag:"form"),
+        // and HTML's nested-form parsing prematurely closes the outer form
+        // — so the auto submitOnChange listener doesn't see the select.
+        // Update the actor directly here.
+        root.querySelectorAll<HTMLSelectElement>('select[name="system.sheetmode.value"]')
+            .forEach((el) => el.addEventListener("change", async (ev) => {
+                const value = (ev.target as HTMLSelectElement).value;
+                await this.document.update({"system.sheetmode.value": value});
+            }));
+
         // Existing listener modules accept html[0]; pass [root] for compatibility.
         registerInventoryListeners(html, this);
         registerCombatActionListeners(html, this);

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -12,6 +12,7 @@ import {registerEffectListeners} from "./sheet-listeners/effects";
 import {registerDragListeners} from "./sheet-listeners/drag";
 
 // Helper modules
+import {computeSkillDisplayScore} from "./actor-helpers/skill-score";
 import {deleteItem, addItem, onItemCreate} from "./sheet-helpers/item-crud";
 import {
     onDropCharacterTemplate, onDropSpeciesTemplate, onDropItemGroup,
@@ -121,19 +122,32 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
             if (i.type === "gear") {
                 gear.push(i);
             } else if (i.type === "skill") {
-                if (!OD6S.flatSkills
-                    && typeof i.system.score !== "undefined"
-                    && typeof i.system.attribute !== "undefined") {
-                    if (!i.system.isAdvancedSkill) {
-                        i.system.score = (+i.system.score)
-                            + (+actorData.system.attributes[i.system.attribute.toLowerCase()].score);
-                    }
+                // Compute the display score *idempotently* from base/mod/attribute.
+                // Reading + writing `i.system.score` here used to compound across
+                // re-renders because prepareDerivedData() only resets score on
+                // actor re-prepare, not on every sheet render.
+                if (typeof i.system.attribute !== "undefined") {
+                    i.system.score = computeSkillDisplayScore({
+                        base: i.system.base,
+                        mod: i.system.mod,
+                        isAdvancedSkill: i.system.isAdvancedSkill,
+                        attributeScore:
+                            actorData.system.attributes?.[i.system.attribute.toLowerCase()]?.score,
+                        flatSkills: OD6S.flatSkills,
+                    });
                 }
                 skills.push(i);
             } else if (i.type === "specialization") {
-                if (!OD6S.flatSkills) {
-                    i.system.score = (+i.system.score)
-                        + (+actorData.system.attributes[i.system.attribute.toLowerCase()].score);
+                // Specializations always roll on the linked attribute; no
+                // advanced-skill exemption applies.
+                if (typeof i.system.attribute !== "undefined") {
+                    i.system.score = computeSkillDisplayScore({
+                        base: i.system.base,
+                        mod: i.system.mod,
+                        attributeScore:
+                            actorData.system.attributes?.[i.system.attribute.toLowerCase()]?.score,
+                        flatSkills: OD6S.flatSkills,
+                    });
                 }
                 specializations.push(i);
             } else if (i.type === "weapon") {

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -265,9 +265,24 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     async _onRender(context: object, options: object): Promise<void> {
         await super._onRender(context, options);
-        if (!this.isEditable) return;
 
         const root = this.element as HTMLElement;
+
+        const tabGroups = (this as any).tabGroups ?? {};
+        tabGroups.primary ??= "attributes";
+        (this as any).tabGroups = tabGroups;
+        new (foundry.applications.ux as any).Tabs({
+            navSelector: ".sheet-tabs",
+            contentSelector: ".sheet-body",
+            initial: tabGroups.primary,
+            group: "primary",
+            callback: (_ev: Event, _tabs: unknown, active: string) => {
+                (this as any).tabGroups.primary = active;
+            },
+        }).bind(root);
+
+        if (!this.isEditable) return;
+
         const html = [root];
 
         root.querySelectorAll(".alpha-item-sort-button").forEach((elem) =>

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -13,6 +13,7 @@ import {registerDragListeners} from "./sheet-listeners/drag";
 
 // Helper modules
 import {computeSkillDisplayScore} from "./actor-helpers/skill-score";
+import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
 import {deleteItem, addItem, onItemCreate} from "./sheet-helpers/item-crud";
 import {
     onDropCharacterTemplate, onDropSpeciesTemplate, onDropItemGroup,
@@ -282,18 +283,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         const root = this.element as HTMLElement;
 
-        const tabGroups = (this as any).tabGroups ?? {};
-        tabGroups.primary ??= "attributes";
-        (this as any).tabGroups = tabGroups;
-        new (foundry.applications.ux as any).Tabs({
-            navSelector: ".sheet-tabs",
-            contentSelector: ".sheet-body",
-            initial: tabGroups.primary,
-            group: "primary",
-            callback: (_ev: Event, _tabs: unknown, active: string) => {
-                (this as any).tabGroups.primary = active;
-            },
-        }).bind(root);
+        bindPrimaryTabs(this as any, root);
 
         if (!this.isEditable) return;
 

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -277,7 +277,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                             rollData.actor.system.attributes[item.system.attribute].score).dice * OD6S.pipsPerDice;
                     }
                 }
-                if(OD6S.autoSkillUsed) {
+                if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                     await item.update({'system.used.value': true});
                 }
             } else if (item.type === "skill") {
@@ -285,7 +285,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                     rollMin = od6sutilities.getDiceFromScore(item.system.score +
                         rollData.actor.system.attributes[item.system.attribute].score).dice * OD6S.pipsPerDice;
                 }
-                if(OD6S.autoSkillUsed) {
+                if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                     await item.update({'system.used.value': true});
                 }
             } else if (item.type === "weapon") {
@@ -302,7 +302,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                                 rollMin = od6sutilities.getDiceFromScore(spec.system.score +
                                     rollData.actor.system.attributes[skill.system.attribute].score).dice * OD6S.pipsPerDice;
                             }
-                            if(OD6S.autoSkillUsed) {
+                            if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                                 await spec.update({'system.used.value': true});
                             }
                         }
@@ -317,7 +317,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                             rollMin = od6sutilities.getDiceFromScore(skill.system.score +
                                 rollData.actor.system.attributes[skill.system.attribute].score).dice * OD6S.pipsPerDice;
                         }
-                        if(OD6S.autoSkillUsed) {
+                        if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                             await skill.update({'system.used.value': true});
                         }
                     }

--- a/src/module/data/item/weapon.ts
+++ b/src/module/data/item/weapon.ts
@@ -14,6 +14,16 @@ function blastZoneSchema() {
 }
 
 export default class WeaponData extends foundry.abstract.TypeDataModel {
+  static migrateData(source: Record<string, unknown>) {
+    if (source.range && typeof source.range === "object") {
+      const range = source.range as Record<string, unknown>;
+      for (const key of ["short", "medium", "long"]) {
+        if (typeof range[key] !== "number") range[key] = Number(range[key]) || 0;
+      }
+    }
+    return super.migrateData(source);
+  }
+
   static defineSchema() {
     return {
       ...baseSchema(),

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -1,4 +1,5 @@
 import {od6sutilities} from "../system/utilities";
+import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
 import OD6S from "../config/config-od6s";
 
 declare const foundry: any;
@@ -61,20 +62,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
         const root = this.element as HTMLElement;
 
-        if (root.querySelector(".sheet-tabs")) {
-            const tabGroups = (this as any).tabGroups ?? {};
-            tabGroups.primary ??= "attributes";
-            (this as any).tabGroups = tabGroups;
-            new (foundry.applications.ux as any).Tabs({
-                navSelector: ".sheet-tabs",
-                contentSelector: ".sheet-body",
-                initial: tabGroups.primary,
-                group: "primary",
-                callback: (_ev: Event, _tabs: unknown, active: string) => {
-                    (this as any).tabGroups.primary = active;
-                },
-            }).bind(root);
-        }
+        bindPrimaryTabs(this as any, root);
 
         if (!this.isEditable) return;
         const $ = (sel: string): NodeListOf<HTMLElement> => root.querySelectorAll(sel);

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -59,8 +59,24 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     async _onRender(context: object, options: object): Promise<void> {
         await super._onRender(context, options);
 
-        if (!this.isEditable) return;
         const root = this.element as HTMLElement;
+
+        if (root.querySelector(".sheet-tabs")) {
+            const tabGroups = (this as any).tabGroups ?? {};
+            tabGroups.primary ??= "attributes";
+            (this as any).tabGroups = tabGroups;
+            new (foundry.applications.ux as any).Tabs({
+                navSelector: ".sheet-tabs",
+                contentSelector: ".sheet-body",
+                initial: tabGroups.primary,
+                group: "primary",
+                callback: (_ev: Event, _tabs: unknown, active: string) => {
+                    (this as any).tabGroups.primary = active;
+                },
+            }).bind(root);
+        }
+
+        if (!this.isEditable) return;
         const $ = (sel: string): NodeListOf<HTMLElement> => root.querySelectorAll(sel);
 
         $(".editskill").forEach((el) => el.addEventListener("change", this._editSkill.bind(this)));

--- a/src/module/system/handlebars/skills.ts
+++ b/src/module/system/handlebars/skills.ts
@@ -9,10 +9,14 @@ export function registerSkillHelpers() {
         return actor.specializations.filter((s: any) => s.system.skill === skill.name).length > 0;
     })
 
-    Handlebars.registerHelper('skillUsed', function (_item) {
-        if (OD6S.skillUsed) {
-            // noop
-        }
+    /**
+     * Returns the world-level "skill used" rule flag. Templates use this to
+     * conditionally render the per-skill / per-spec "used this session"
+     * checkbox and the Reset Session button. When the rule is disabled, the
+     * controls hide and `system.used.value` is not written to anywhere.
+     */
+    Handlebars.registerHelper('skillUsed', function () {
+        return OD6S.skillUsed;
     });
 
     Handlebars.registerHelper('specializationDice', function () {

--- a/src/module/system/logger.ts
+++ b/src/module/system/logger.ts
@@ -2,9 +2,14 @@
  * Lightweight debug logger gated on `globalThis.od6sDebug`.
  *
  * Enable from the browser console:
- *   od6sDebug = true               // log everything
+ *   od6sDebug = true               // log everything (this session)
  *   od6sDebug = ['wounds','rolls'] // log only listed categories
  *   od6sDebug = false              // off
+ *
+ * To persist across reloads (e.g. to capture migrations on the next load):
+ *   localStorage.od6sDebug = 'true'
+ *   localStorage.od6sDebug = '["migration"]'
+ *   localStorage.removeItem('od6sDebug')
  *
  * Safe to call when disabled — short-circuits before formatting args.
  */
@@ -14,7 +19,15 @@ declare global {
 }
 
 export function isDebugEnabled(category?: string): boolean {
-    const flag = (globalThis as any).od6sDebug;
+    let flag: unknown = (globalThis as any).od6sDebug;
+    if (flag === undefined) {
+        try {
+            const stored = globalThis.localStorage?.getItem("od6sDebug");
+            if (stored) flag = JSON.parse(stored);
+        } catch {
+            // localStorage unavailable or stored value isn't valid JSON — treat as off
+        }
+    }
     if (!flag) return false;
     if (flag === true) return true;
     if (Array.isArray(flag) && category) return flag.includes(category);

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -3,7 +3,7 @@
  * Runs once per version bump via the system version stored in world settings.
  */
 
-const CURRENT_MIGRATION_VERSION = "2.0.0";
+const CURRENT_MIGRATION_VERSION = "2.2.0";
 
 /**
  * Check if migration is needed and run it.
@@ -22,6 +22,9 @@ export async function migrateWorld() {
     if (foundry.utils.isNewerVersion("2.0.0", lastMigration)) {
       await migrateExplosiveTemplateFlags();
       await migrateChatMessageFlags();
+    }
+    if (foundry.utils.isNewerVersion("2.2.0", lastMigration)) {
+      await migrateStatusEffectIcons();
     }
 
     // Record completion
@@ -45,6 +48,47 @@ export function registerMigrationSetting() {
     type: String,
     default: "0",
   });
+}
+
+/**
+ * Update active effect icons that still reference old .png paths to .svg equivalents.
+ * Affects any effect whose img ends with a known renamed icon.
+ */
+async function migrateStatusEffectIcons() {
+  console.log("od6s | Migrating status effect icons from .png to .svg...");
+  let count = 0;
+
+  for (const actor of game.actors) {
+    const updates = [];
+    for (const effect of (actor as any).effects) {
+      const img: string = effect.img ?? "";
+      if (img.startsWith("systems/od6s/") && img.endsWith(".png")) {
+        updates.push({ _id: effect.id, img: img.replace(/\.png$/, ".svg") });
+      }
+    }
+    if (updates.length > 0) {
+      await (actor as any).updateEmbeddedDocuments("ActiveEffect", updates);
+      count += updates.length;
+    }
+  }
+
+  for (const scene of game.scenes) {
+    for (const token of (scene as any).tokens) {
+      const updates = [];
+      for (const effect of token.actor?.effects ?? []) {
+        const img: string = effect.img ?? "";
+        if (img.startsWith("systems/od6s/") && img.endsWith(".png")) {
+          updates.push({ _id: effect.id, img: img.replace(/\.png$/, ".svg") });
+        }
+      }
+      if (updates.length > 0) {
+        await token.actor.updateEmbeddedDocuments("ActiveEffect", updates);
+        count += updates.length;
+      }
+    }
+  }
+
+  console.log(`od6s | Updated ${count} status effect icons.`);
 }
 
 /**

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -25,7 +25,12 @@ export async function migrateWorld() {
   const lastMigration = game.settings.get("od6s", "migrationVersion") ?? "0";
   if (!foundry.utils.isNewerVersion(CURRENT_MIGRATION_VERSION, lastMigration)) return;
 
-  ui.notifications.info("OpenD6 Space: Migrating world data — please be patient.", { permanent: true });
+  // V14 returns a Notification object with a bound .remove(); the project's
+  // type stubs predate this, so cast through unknown.
+  const inProgress = ui.notifications.info(
+    "OpenD6 Space: Migrating world data — please be patient.",
+    { permanent: true },
+  ) as unknown as { remove?: () => void } | undefined;
 
   debug("migration", "starting", {
     from: lastMigration,
@@ -51,6 +56,8 @@ export async function migrateWorld() {
   } catch (err) {
     console.error("od6s | Migration failed:", err);
     ui.notifications.error("OpenD6 Space: Migration failed. Check the console for details.");
+  } finally {
+    inProgress?.remove?.();
   }
 }
 

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -1,7 +1,17 @@
 /**
  * System data migration for world upgrades.
  * Runs once per version bump via the system version stored in world settings.
+ *
+ * To audit before/after document state, persist the debug flag *before*
+ * reloading the world (otherwise migrations fire on the `ready` hook before
+ * you can touch the console):
+ *
+ *   localStorage.od6sDebug = '["migration"]'
+ *
+ * Each touched actor will then log a `[before]` and `[after]` snapshot.
  */
+
+import { debug, isDebugEnabled } from "./logger";
 
 const CURRENT_MIGRATION_VERSION = "2.2.0";
 
@@ -16,6 +26,14 @@ export async function migrateWorld() {
   if (!foundry.utils.isNewerVersion(CURRENT_MIGRATION_VERSION, lastMigration)) return;
 
   ui.notifications.info("OpenD6 Space: Migrating world data — please be patient.", { permanent: true });
+
+  debug("migration", "starting", {
+    from: lastMigration,
+    to: CURRENT_MIGRATION_VERSION,
+    actors: game.actors.size,
+    items: game.items.size,
+    scenes: game.scenes.size,
+  });
 
   try {
     // Run all migrations in order
@@ -67,7 +85,9 @@ async function migrateStatusEffectIcons() {
       }
     }
     if (updates.length > 0) {
+      logActorBefore("icons", actor);
       await (actor as any).updateEmbeddedDocuments("ActiveEffect", updates);
+      logActorAfter("icons", actor);
       count += updates.length;
     }
   }
@@ -82,13 +102,25 @@ async function migrateStatusEffectIcons() {
         }
       }
       if (updates.length > 0) {
+        logActorBefore("icons", token.actor, ` (token in ${(scene as any).name})`);
         await token.actor.updateEmbeddedDocuments("ActiveEffect", updates);
+        logActorAfter("icons", token.actor, ` (token in ${(scene as any).name})`);
         count += updates.length;
       }
     }
   }
 
   console.log(`od6s | Updated ${count} status effect icons.`);
+}
+
+/** Snapshot an actor's full document state (deep-cloned via toObject) for audit logs. */
+function logActorBefore(step: string, actor: any, suffix = "") {
+  if (!isDebugEnabled("migration")) return;
+  debug("migration", `[${step}:before] ${actor.name}${suffix}`, actor.toObject());
+}
+function logActorAfter(step: string, actor: any, suffix = "") {
+  if (!isDebugEnabled("migration")) return;
+  debug("migration", `[${step}:after]  ${actor.name}${suffix}`, actor.toObject());
 }
 
 /**
@@ -115,7 +147,9 @@ async function migrateExplosiveTemplateFlags() {
       }
     }
     if (updates.length > 0) {
+      logActorBefore("explosive-flags", actor);
       await (actor as any).updateEmbeddedDocuments("Item", updates);
+      logActorAfter("explosive-flags", actor);
       count += updates.length;
     }
   }

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -13,7 +13,26 @@
 
 import { debug, isDebugEnabled } from "./logger";
 
-const CURRENT_MIGRATION_VERSION = "2.2.0";
+/**
+ * Migration steps in version order. Each entry runs when the world's stored
+ * `migrationVersion` is older than `since`. Add new steps to the end; the
+ * highest `since` becomes the recorded `migrationVersion` after a clean run.
+ */
+const MIGRATION_STEPS: Array<{ since: string; run: () => Promise<void> }> = [
+  {
+    since: "2.0.0",
+    run: async () => {
+      await migrateExplosiveTemplateFlags();
+      await migrateChatMessageFlags();
+    },
+  },
+  {
+    since: "2.2.0",
+    run: () => migrateStatusEffectIcons(),
+  },
+];
+
+const CURRENT_MIGRATION_VERSION = MIGRATION_STEPS[MIGRATION_STEPS.length - 1]!.since;
 
 /**
  * Check if migration is needed and run it.
@@ -41,13 +60,10 @@ export async function migrateWorld() {
   });
 
   try {
-    // Run all migrations in order
-    if (foundry.utils.isNewerVersion("2.0.0", lastMigration)) {
-      await migrateExplosiveTemplateFlags();
-      await migrateChatMessageFlags();
-    }
-    if (foundry.utils.isNewerVersion("2.2.0", lastMigration)) {
-      await migrateStatusEffectIcons();
+    for (const step of MIGRATION_STEPS) {
+      if (foundry.utils.isNewerVersion(step.since, lastMigration)) {
+        await step.run();
+      }
     }
 
     // Record completion
@@ -77,7 +93,7 @@ export function registerMigrationSetting() {
 
 /**
  * Update active effect icons that still reference old .png paths to .svg equivalents.
- * Affects any effect whose img ends with a known renamed icon.
+ * Affects any effect whose img is under systems/od6s/ and ends with .png.
  */
 async function migrateStatusEffectIcons() {
   console.log("od6s | Migrating status effect icons from .png to .svg...");

--- a/src/module/system/utilities/bind-tabs.ts
+++ b/src/module/system/utilities/bind-tabs.ts
@@ -17,12 +17,23 @@ interface AppWithTabGroups {
 export function bindPrimaryTabs(app: AppWithTabGroups, root: HTMLElement): void {
     if (!root.querySelector(".sheet-tabs")) return;
 
-    const firstTab = root
-        .querySelector<HTMLElement>(".sheet-tabs .item[data-tab]")
-        ?.dataset.tab;
+    // Collect every data-tab declared in the rendered nav. We use this to
+    // (a) supply a fallback when no tab has been previously selected and
+    // (b) validate any persisted selection — conditional tabs (e.g.
+    // metaphysics, vehicle) can disappear when actor flags toggle, leaving
+    // tabGroups.primary pointing at a tab that no longer exists.
+    const availableTabs = Array.from(
+        root.querySelectorAll<HTMLElement>(".sheet-tabs .item[data-tab]"),
+    )
+        .map((el) => el.dataset.tab)
+        .filter((t): t is string => !!t);
+
+    const firstTab = availableTabs[0] ?? "";
 
     const tabGroups = app.tabGroups ?? {};
-    tabGroups.primary ??= firstTab ?? "";
+    if (!tabGroups.primary || !availableTabs.includes(tabGroups.primary)) {
+        tabGroups.primary = firstTab;
+    }
     app.tabGroups = tabGroups;
 
     new foundry.applications.ux.Tabs({

--- a/src/module/system/utilities/bind-tabs.ts
+++ b/src/module/system/utilities/bind-tabs.ts
@@ -1,0 +1,37 @@
+/**
+ * Wires `foundry.applications.ux.Tabs` to a sheet's `.sheet-tabs` nav so the
+ * panes inside `.sheet-body` toggle correctly, persisting the active tab on
+ * the application's `tabGroups.primary` field.
+ *
+ * The previous tab is restored if available; otherwise the first
+ * `[data-tab]` element in the nav is used. This avoids hard-coding a default
+ * (e.g. "attributes") that may not exist on every sheet template.
+ */
+
+declare const foundry: any;
+
+interface AppWithTabGroups {
+    tabGroups?: Record<string, string>;
+}
+
+export function bindPrimaryTabs(app: AppWithTabGroups, root: HTMLElement): void {
+    if (!root.querySelector(".sheet-tabs")) return;
+
+    const firstTab = root
+        .querySelector<HTMLElement>(".sheet-tabs .item[data-tab]")
+        ?.dataset.tab;
+
+    const tabGroups = app.tabGroups ?? {};
+    tabGroups.primary ??= firstTab ?? "";
+    app.tabGroups = tabGroups;
+
+    new foundry.applications.ux.Tabs({
+        navSelector: ".sheet-tabs",
+        contentSelector: ".sheet-body",
+        initial: tabGroups.primary,
+        group: "primary",
+        callback: (_ev: Event, _tabs: unknown, active: string) => {
+            (app.tabGroups ??= {}).primary = active;
+        },
+    }).bind(root);
+}

--- a/src/templates/actor/character/body-sheet.html
+++ b/src/templates/actor/character/body-sheet.html
@@ -52,7 +52,7 @@
 <section class="sheet-mode">
     <div class="flexrow flex-group-left sheetmode">
         <label for="actor.system.sheetmode.value">{{localize 'OD6S.SHEETMODE'}}:</label>
-        <select name="system.sheetmode.value">
+        <select id="actor.system.sheetmode.value" name="system.sheetmode.value">
             <option value="normal" {{#if (eq "normal" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_NORMAL'}}</option>
             <option value="advance" {{#if (eq "advance" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_ADVANCE'}}</option>
             <option value="freeedit" {{#if (eq "freeedit" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
@@ -64,7 +64,7 @@
              visible whenever the character has it enabled. --}}
         {{#if (skillUsed)}}
             {{#if (ne actor.system.sheetmode.value "normal")}}
-                <button type="button" class="session-reset-button">Reset Session</button>
+                <button type="button" class="session-reset-button">{{localize 'OD6S.RESET_SESSION'}}</button>
             {{/if}}
         {{/if}}
     </div>

--- a/src/templates/actor/character/body-sheet.html
+++ b/src/templates/actor/character/body-sheet.html
@@ -58,11 +58,14 @@
             <option value="freeedit" {{#if (eq "freeedit" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
         </select>
 
-        {{!-- Reset-Session button — only visible in non-normal modes since
-             it's a GM/edit-mode tool. The metaphysics toggle stays in the
-             header so it's visible whenever the character has it enabled. --}}
-        {{#if (ne actor.system.sheetmode.value "normal")}}
-            <button type="button" class="session-reset-button">Reset Session</button>
+        {{!-- Reset-Session button — only meaningful when the skill-used
+             rule is on AND we're in a non-normal mode (it's a GM/edit-mode
+             tool). The metaphysics toggle stays in the header so it remains
+             visible whenever the character has it enabled. --}}
+        {{#if (skillUsed)}}
+            {{#if (ne actor.system.sheetmode.value "normal")}}
+                <button type="button" class="session-reset-button">Reset Session</button>
+            {{/if}}
         {{/if}}
     </div>
 </section>

--- a/src/templates/actor/character/body-sheet.html
+++ b/src/templates/actor/character/body-sheet.html
@@ -52,12 +52,31 @@
 <section class="sheet-mode">
     <div class="flexrow flex-group-left sheetmode">
         <label for="actor.system.sheetmode.value">{{localize 'OD6S.SHEETMODE'}}:</label>
-        <select name="system.sheetmode.value" style="width: 70px;">
-            
-                <option value="normal" {{#if (eq "normal" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_NORMAL'}}</option>
-                <option value="advance" {{#if (eq "advance" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_ADVANCE'}}</option>
-                <option value="freeedit" {{#if (eq "freeedit" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
-            
+        <select name="system.sheetmode.value">
+            <option value="normal" {{#if (eq "normal" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_NORMAL'}}</option>
+            <option value="advance" {{#if (eq "advance" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_ADVANCE'}}</option>
+            <option value="freeedit" {{#if (eq "freeedit" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
         </select>
+
+        {{!-- Metaphysics extranormal toggle. Always visible in non-normal
+             modes; in normal mode only shown (read-only) when already on. --}}
+        {{#if (ne actor.system.sheetmode.value "normal")}}
+            <label class="metaphysics-toggle" title="{{getMetaphysicsExtranormalName}}">
+                <input type="checkbox" name="system.metaphysicsextranormal.value"
+                       data-dtype="Boolean"
+                    {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
+                <span>{{getMetaphysicsExtranormalName}}</span>
+            </label>
+            <button type="button" class="session-reset-button">Reset Session</button>
+        {{else}}
+            {{#if actor.system.metaphysicsextranormal.value}}
+                <label class="metaphysics-toggle" title="{{getMetaphysicsExtranormalName}}">
+                    <input type="checkbox" name="system.metaphysicsextranormal.value"
+                           data-dtype="Boolean" disabled
+                        {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
+                    <span>{{getMetaphysicsExtranormalName}}</span>
+                </label>
+            {{/if}}
+        {{/if}}
     </div>
 </section>

--- a/src/templates/actor/character/body-sheet.html
+++ b/src/templates/actor/character/body-sheet.html
@@ -58,25 +58,11 @@
             <option value="freeedit" {{#if (eq "freeedit" actor.system.sheetmode.value)}}selected{{/if}}>{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
         </select>
 
-        {{!-- Metaphysics extranormal toggle. Always visible in non-normal
-             modes; in normal mode only shown (read-only) when already on. --}}
+        {{!-- Reset-Session button — only visible in non-normal modes since
+             it's a GM/edit-mode tool. The metaphysics toggle stays in the
+             header so it's visible whenever the character has it enabled. --}}
         {{#if (ne actor.system.sheetmode.value "normal")}}
-            <label class="metaphysics-toggle" title="{{getMetaphysicsExtranormalName}}">
-                <input type="checkbox" name="system.metaphysicsextranormal.value"
-                       data-dtype="Boolean"
-                    {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
-                <span>{{getMetaphysicsExtranormalName}}</span>
-            </label>
             <button type="button" class="session-reset-button">Reset Session</button>
-        {{else}}
-            {{#if actor.system.metaphysicsextranormal.value}}
-                <label class="metaphysics-toggle" title="{{getMetaphysicsExtranormalName}}">
-                    <input type="checkbox" name="system.metaphysicsextranormal.value"
-                           data-dtype="Boolean" disabled
-                        {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
-                    <span>{{getMetaphysicsExtranormalName}}</span>
-                </label>
-            {{/if}}
         {{/if}}
     </div>
 </section>

--- a/src/templates/actor/character/header-sheet.html
+++ b/src/templates/actor/character/header-sheet.html
@@ -156,27 +156,8 @@
             </div>
         {{/if}}
         {{> (getWoundsTemplate)}}
-        {{#if (ne actor.system.sheetmode.value "normal") }}
-            <div class="flexrow flex-group-center">
-                <label for="actor.system.metaphysicsextranormal.value">{{getMetaphysicsExtranormalName}}:</label>
-                <input type="checkbox" name="system.metaphysicsextranormal.value"
-                       id="actor.system.metaphysicsextranormal.value" data-dtype="Boolean"
-                    {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
-            </div>
-        <div>
-            <!--Session Reset Button-->
-            <button class="session-reset-button">Reset Session</button>
-        </div>
-        {{ else }}
-            {{#if actor.system.metaphysicsextranormal.value}}
-            <div class="flexrow flex-group-center">
-                <label for="actor.system.metaphysicsextranormal.value">{{getMetaphysicsExtranormalName}}:</label>
-                <input type="checkbox" name="system.metaphysicsextranormal.value"
-                       id="actor.system.metaphysicsextranormal.value" data-dtype="Boolean" disabled
-                    {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
-            </div>
-            {{/if}}
-        {{/if}}
+        {{!-- Metaphysics-extranormal toggle and Reset-Session button moved to
+             the footer next to the mode selector — see body-sheet.html. --}}
         {{#if (eq actor.system.created.value false)}}
             <div class="flexrow flex-group-center creation">
                 <button class="create-character">{{localize 'OD6S.CREATE'}}</button>

--- a/src/templates/actor/character/header-sheet.html
+++ b/src/templates/actor/character/header-sheet.html
@@ -156,8 +156,27 @@
             </div>
         {{/if}}
         {{> (getWoundsTemplate)}}
-        {{!-- Metaphysics-extranormal toggle and Reset-Session button moved to
-             the footer next to the mode selector — see body-sheet.html. --}}
+        {{!-- Reset-Session button moved to the footer next to the mode
+             selector — see body-sheet.html. The metaphysics-extranormal
+             toggle stays here so it remains visible at a glance whenever
+             the character has metaphysics enabled. --}}
+        {{#if (ne actor.system.sheetmode.value "normal") }}
+            <div class="flexrow flex-group-center">
+                <label for="actor.system.metaphysicsextranormal.value">{{getMetaphysicsExtranormalName}}:</label>
+                <input type="checkbox" name="system.metaphysicsextranormal.value"
+                       id="actor.system.metaphysicsextranormal.value" data-dtype="Boolean"
+                    {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
+            </div>
+        {{else}}
+            {{#if actor.system.metaphysicsextranormal.value}}
+                <div class="flexrow flex-group-center">
+                    <label for="actor.system.metaphysicsextranormal.value">{{getMetaphysicsExtranormalName}}:</label>
+                    <input type="checkbox" name="system.metaphysicsextranormal.value"
+                           id="actor.system.metaphysicsextranormal.value" data-dtype="Boolean" disabled
+                        {{#if actor.system.metaphysicsextranormal.value}}checked{{/if}}>
+                </div>
+            {{/if}}
+        {{/if}}
         {{#if (eq actor.system.created.value false)}}
             <div class="flexrow flex-group-center creation">
                 <button class="create-character">{{localize 'OD6S.CREATE'}}</button>

--- a/src/templates/actor/common/actor-sheet.html
+++ b/src/templates/actor/common/actor-sheet.html
@@ -3,11 +3,11 @@
     <header class="sheet-header flex-group-left">
         <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="200" width="200"
              alt="{{localize 'OD6S.ALT_ACTOR_IMAGE'}}"/>
-        <div>
-            <h1 class="charname">
+        <div class="header-right">
+            <h2 class="charname">
                 <input title="{{localize OD6S.CHAR_NAME}}" name="name" type="text" value="{{actor.name}}"
                        placeholder="{{localize OD6S.CHAR_NAME}}" data-dtype="String"/>
-            </h1>
+            </h2>
             {{> (getHeaderFormTemplate actor.type)}}
         </div>
     </header>

--- a/src/templates/actor/common/tabs/attribute-column.html
+++ b/src/templates/actor/common/tabs/attribute-column.html
@@ -54,6 +54,7 @@
                         {{else}} class="skills grid grid-3col-attributes"
                         {{/if}}>
                         <div class="skills-grid">
+                            {{#if (skillUsed)}}
                             <input type="checkbox" class="skill-used-checkbox"
                                    {{#if skill.system.used.value}}
                                    title="{{localize 'OD6S.SKILL_USED'}}"
@@ -63,6 +64,7 @@
                                    data-item-id="{{skill._id}}" name="skill-used-{{skill._id}}"
                                    id="skill-used-{{skill._id}}" data-dtype="Boolean"
                                    {{#if skill.system.used.value}}checked{{/if}}>
+                            {{/if}}
                             <div class="skilldialog flex-group-left{{#if
                                     (eq ../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                  data-item-id="{{skill._id}}"
@@ -137,10 +139,12 @@
                                     {{else}} class="item specialization grid grid-3col-attributes"
                                     {{/if}}>
                                     <div class="skills-grid">
+                                        {{#if (skillUsed)}}
                                         <input type="checkbox" class="spec-used-checkbox"
                                                data-item-id="{{spec._id}}" name="spec-used-{{spec._id}}"
                                                id="spec-used-{{spec._id}}" data-dtype="Boolean"
                                                {{#if spec.system.used.value}}checked{{/if}}>
+                                        {{/if}}
                                         <div class="specdialog indent flex-row flex-group-left{{#if
                                                 (eq ../../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                              data-item-id="{{spec._id}}"

--- a/tests/domain/skill-score.test.ts
+++ b/tests/domain/skill-score.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Domain drift tests: Skill display-score computation.
+ *
+ * Pure function under test: src/module/actor/actor-helpers/skill-score.ts
+ *
+ * Rules being verified (3 pips per die):
+ *   - Non-advanced skill: display = base + mod + attribute
+ *   - Advanced skill:     display = base + mod   (attribute not added)
+ *   - Flat-skill mode:    display = base + mod   (regardless of advanced flag)
+ *   - Idempotent: result derives only from current inputs, never from a
+ *     previously-computed `score` (regression for the compounding bug
+ *     where actor-sheet.ts mutated score in-place across renders).
+ *   - Pure: never mutates its input object.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeSkillDisplayScore } from '../../src/module/actor/actor-helpers/skill-score';
+
+// ---------------------------------------------------------------------------
+// Branch coverage
+// ---------------------------------------------------------------------------
+
+describe('computeSkillDisplayScore — non-advanced skill', () => {
+    it('adds the attribute to base + mod', () => {
+        // Mechanical 5D+1 (16 pips), skill +1D (3 pips), no mod
+        expect(computeSkillDisplayScore({
+            base: 3,
+            mod: 0,
+            isAdvancedSkill: false,
+            attributeScore: 16,
+        })).toBe(19); // 6D+1
+    });
+
+    it('handles negative base (skill below the linked attribute)', () => {
+        // -2D = -6 pips, attribute 6D (18 pips) → 4D
+        expect(computeSkillDisplayScore({
+            base: -6,
+            mod: 0,
+            isAdvancedSkill: false,
+            attributeScore: 18,
+        })).toBe(12);
+    });
+
+    it('includes mod in the sum', () => {
+        expect(computeSkillDisplayScore({
+            base: 3,
+            mod: 2,
+            isAdvancedSkill: false,
+            attributeScore: 12,
+        })).toBe(17);
+    });
+});
+
+describe('computeSkillDisplayScore — advanced skill', () => {
+    it('does not add the attribute', () => {
+        // (A) Skill at 2D advanced, attribute is irrelevant
+        expect(computeSkillDisplayScore({
+            base: 6,
+            mod: 0,
+            isAdvancedSkill: true,
+            attributeScore: 18,
+        })).toBe(6);
+    });
+
+    it('still respects mod', () => {
+        expect(computeSkillDisplayScore({
+            base: 6,
+            mod: 3,
+            isAdvancedSkill: true,
+            attributeScore: 18,
+        })).toBe(9);
+    });
+
+    it('preserves negative scores', () => {
+        // The reported failure mode: an "advanced" skill stored at -2D should
+        // surface as -2D, not get the attribute added on top.
+        expect(computeSkillDisplayScore({
+            base: -6,
+            mod: 0,
+            isAdvancedSkill: true,
+            attributeScore: 18,
+        })).toBe(-6);
+    });
+});
+
+describe('computeSkillDisplayScore — flat-skill mode', () => {
+    it('returns base + mod regardless of attribute', () => {
+        expect(computeSkillDisplayScore({
+            base: 3,
+            mod: 1,
+            isAdvancedSkill: false,
+            attributeScore: 18,
+            flatSkills: true,
+        })).toBe(4);
+    });
+
+    it('returns base + mod for advanced skills too', () => {
+        expect(computeSkillDisplayScore({
+            base: 6,
+            mod: 0,
+            isAdvancedSkill: true,
+            attributeScore: 18,
+            flatSkills: true,
+        })).toBe(6);
+    });
+});
+
+describe('computeSkillDisplayScore — defaults', () => {
+    it('treats missing attributeScore as 0', () => {
+        expect(computeSkillDisplayScore({ base: 3, mod: 0 })).toBe(3);
+    });
+
+    it('treats missing isAdvancedSkill as non-advanced', () => {
+        expect(computeSkillDisplayScore({
+            base: 3,
+            mod: 0,
+            attributeScore: 6,
+        })).toBe(9);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: compounding bug
+// ---------------------------------------------------------------------------
+// The original code at actor-sheet.ts:_prepareCharacterItems mutated
+// `i.system.score` in place — `score = score + attribute.score`. Because
+// prepareDerivedData() only re-resets `score = base + mod` when the actor is
+// re-prepared (not on every sheet render), a sheet rendered N times without
+// an actor update accumulated the attribute N times, producing
+//   score = base + mod + N × attributeScore
+// The reproduction reported in the wild had a player's "(A) Space Transport
+// Engineering" displaying 8D when its base was -4D and the linked attribute
+// (Technical) was 6D — i.e. -12 + 2 × 18 = 24 pips = 8D after two renders.
+
+describe('computeSkillDisplayScore — regression: compounding bug', () => {
+    it('returns the same value when called repeatedly with the same inputs', () => {
+        const inputs = {
+            base: -12,
+            mod: 0,
+            isAdvancedSkill: false,
+            attributeScore: 18,
+        };
+        const r1 = computeSkillDisplayScore(inputs);
+        const r2 = computeSkillDisplayScore(inputs);
+        const r3 = computeSkillDisplayScore(inputs);
+        expect(r1).toBe(6);  // -12 + 18; NOT 24, NOT 42
+        expect(r2).toBe(r1);
+        expect(r3).toBe(r1);
+    });
+
+    it('does not mutate its input object', () => {
+        const inputs = {
+            base: -12,
+            mod: 0,
+            isAdvancedSkill: false,
+            attributeScore: 18,
+        };
+        const snapshot = { ...inputs };
+        computeSkillDisplayScore(inputs);
+        computeSkillDisplayScore(inputs);
+        expect(inputs).toEqual(snapshot);
+    });
+
+    it('reproduces the reported user data and produces the correct score', () => {
+        // Azul's "(A) Space Transport Engineering":
+        //   base = -12 (player intended -4D), mod = 0, attribute "tec" = 18
+        // The buggy path produced 24 (8D). The pure helper must produce
+        // the right value for whichever flag the data actually carries.
+        const stored = { base: -12, mod: 0, attributeScore: 18 };
+
+        // As actually stored (isAdvancedSkill: false): -12 + 18 = 6 (= 2D)
+        expect(computeSkillDisplayScore({ ...stored, isAdvancedSkill: false })).toBe(6);
+
+        // If the flag is corrected to advanced: -12 (= -4D) is shown directly
+        expect(computeSkillDisplayScore({ ...stored, isAdvancedSkill: true })).toBe(-12);
+    });
+});


### PR DESCRIPTION
## Summary
End-to-end visual overhaul of the actor sheet and chat cards, plus the small TS/template/migration plumbing the redesign relies on.

### UI redesign (SCSS + tabs binding + header markup)
- Replaces the default Foundry-form look on the actor sheet with a cohesive dark/gold sci-fi theme — banner-style attribute headers, glowing pill dice readouts, hover accent rails on skill rows, filled-tab active state with indicator dot, chamfered sci-fi action buttons, polished header data strips.
- Themes the chat cards to match: dark panel with gold left rail, capsule dice formula, glowing gold dice total, banner result lines, red-gradient Roll Damage button, themed wild-die warning.
- Foundation work in design tokens — adds Rajdhani display font, palette extensions (gradients, glow, shadow, status colors). Neutralizes Foundry's stark default `1px solid #999` cell outlines inside `.od6s` (the main source of the previous tax-form appearance) and reintroduces intentional surfaces in the component layer.
- Wires `foundry.applications.ux.Tabs` on actor and item sheets so `.sheet-tabs` actually toggles panels (the new tab styles need the active state to function), and updates the actor sheet header markup (`<h1>` → `<h2>`, `.header-right` wrapper) to match the new typography/layout.

### Data migrations & fixes
- Bumps `CURRENT_MIGRATION_VERSION` to `2.2.0` and adds a step that rewrites status-effect icon paths under `systems/od6s/` from `.png` to `.svg` on world actors and scene tokens — pairs with the icon asset cleanup so existing worlds don't break.
- `WeaponData.migrateData` coerces `range.short/medium/long` to numbers when older worlds stored them as strings, so range arithmetic works after migration.

### Tooling
- New `foundry:init-config` Task that disables telemetry in the dev container's `options.json` before startup, plus `FOUNDRY_TELEMETRY=false` env var.
- Quoting fixes on the release task's version-precondition greps.

## Test plan
- [ ] `pnpm run build:css` builds clean
- [ ] `pnpm run typecheck` passes
- [ ] Open a character sheet — verify Attributes/Skills, Combat, Inventory, Special Abilities, Biography tabs all render with the new styling, switch correctly, and remain functional (rolls, edits, advance, freeedit modes)
- [ ] Open an item sheet that has tabs (e.g. weapon) — verify tab switching works
- [ ] Roll a skill check — verify the chat card uses the new dark theme with glowing dice total and banner success line
- [ ] Roll an attack with damage — verify Roll Damage button renders correctly and the wild-die warning shows when triggered
- [ ] Run a world from a pre-2.2.0 save — verify status effect icons load (no broken `.png` references) and weapon range fields work in arithmetic
- [ ] `task foundry:start` boots a container with telemetry disabled