### PR TITLE
refactor: type-tightening sweep + config split + roll math extraction (v2.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 1700 src/",
+    "lint": "eslint --max-warnings 1175 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",
@@ -64,7 +64,7 @@
   },
   "lint-staged": {
     "src/**/*.ts": [
-      "eslint --max-warnings 1700 --fix"
+      "eslint --max-warnings 1175 --fix"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 1175 src/",
+    "lint": "eslint --max-warnings 1125 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",
@@ -64,7 +64,7 @@
   },
   "lint-staged": {
     "src/**/*.ts": [
-      "eslint --max-warnings 1175 --fix"
+      "eslint --max-warnings 1125 --fix"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 1125 src/",
+    "lint": "eslint --max-warnings 1100 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",
@@ -64,7 +64,7 @@
   },
   "lint-staged": {
     "src/**/*.ts": [
-      "eslint --max-warnings 1125 --fix"
+      "eslint --max-warnings 1100 --fix"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opend6-space",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "description": "OpenD6 Space system for Foundry VTT v14. Uses the rules from the OpenD6 Project SRD.",
   "scripts": {

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -80,7 +80,7 @@ export async function forceRemoveCrewmember(actor: Actor, crewID: string): Promi
 }
 
 export function isCrewMember(actor: Actor): boolean {
-    return actor.getFlag('od6s', 'crew');
+    return !!actor.getFlag('od6s', 'crew');
 }
 
 export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void> {

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -1,9 +1,7 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 
-declare const foundry: any;
-
-export async function addEmbeddedPilot(actor: any, pilotActor: any): Promise<void> {
+export async function addEmbeddedPilot(actor: Actor, pilotActor: Actor): Promise<void> {
     /* Copy attributes and items to vehicle */
     const update = {};
 
@@ -14,7 +12,7 @@ export async function addEmbeddedPilot(actor: any, pilotActor: any): Promise<voi
     await actor.update(update);
 }
 
-export async function addToCrew(actor: any, vehicleId: any): Promise<any> {
+export async function addToCrew(actor: Actor, vehicleId: string): Promise<unknown> {
     if (actor.isCrewMember()) {
         const currentVehicle = await fromUuid(await actor.getFlag('od6s', 'crew'));
         const newVehicle = await fromUuid(vehicleId);
@@ -40,7 +38,7 @@ export async function addToCrew(actor: any, vehicleId: any): Promise<any> {
     }
 }
 
-export async function _verifyAddToCrew(actor: any, currentVehicleId: any, newVehicleId: any): Promise<void> {
+export async function _verifyAddToCrew(actor: Actor, currentVehicleId: string, newVehicleId: string): Promise<void> {
     const oldVehicle = await fromUuid(currentVehicleId);
     let oldActor;
     if (oldVehicle.documentName === "Token") {
@@ -61,7 +59,7 @@ export async function _verifyAddToCrew(actor: any, currentVehicleId: any, newVeh
     await newActor.sheet.linkCrew(actor.uuid);
 }
 
-export async function removeFromCrew(actor: any, vehicleID: any): Promise<void> {
+export async function removeFromCrew(actor: Actor, vehicleID: string): Promise<void> {
     if (actor.getFlag('od6s', 'crew') !== vehicleID) {
         ui.notifications.warn(game.i18n.localize('OD6S.NOT_CREW_MEMBER'))
     } else {
@@ -73,41 +71,42 @@ export async function removeFromCrew(actor: any, vehicleID: any): Promise<void> 
     }
 }
 
-export async function forceRemoveCrewmember(actor: any, crewID: any): Promise<void> {
-    const crewMembers = actor.system.crewmembers.filter((e: any) => e.uuid !== crewID);
+export async function forceRemoveCrewmember(actor: Actor, crewID: string): Promise<void> {
+    const crewMembers = (actor.system as OD6SVehicleSystem).crewmembers.filter((e) => e.uuid !== crewID);
     const update: any = {};
     update.system = {};
     update.system.crewmembers = crewMembers;
     await actor.update(update);
 }
 
-export function isCrewMember(actor: any): any {
+export function isCrewMember(actor: Actor): boolean {
     return actor.getFlag('od6s', 'crew');
 }
 
-export async function sendVehicleData(actor: any, uuid: any): Promise<void> {
+export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void> {
     const data: any = {};
+    const sys = actor.system as OD6SVehicleSystem & Record<string, any>;
     data.uuid = actor.uuid;
     data.name = actor.name;
     data.type = actor.type;
-    data.move = actor.system.move;
-    data.maneuverability = actor.system.maneuverability;
-    data.toughness = actor.system.toughness;
-    data.crewmembers = actor.system.crewmembers;
+    data.move = sys.move;
+    data.maneuverability = sys.maneuverability;
+    data.toughness = sys.toughness;
+    data.crewmembers = sys.crewmembers;
     data.items = actor.items;
-    data.attribute = actor.system.attribute;
-    data.skill = actor.system.skill;
-    data.specialization = actor.system.specialization;
-    data.damage = actor.system.damage;
-    data.shields = actor.system.shields;
-    data.scale = actor.system.scale;
-    data.sensors = actor.system.sensors;
-    data.armor = actor.system.armor;
-    data.dodge = actor.system.dodge;
-    data.ranged = actor.system.ranged;
-    data.ranged_damage = actor.system.ranged_damage;
-    data.ram = actor.system.ram;
-    data.ram_damage = actor.system.ram_damage;
+    data.attribute = sys.attribute;
+    data.skill = sys.skill;
+    data.specialization = sys.specialization;
+    data.damage = sys.damage;
+    data.shields = sys.shields;
+    data.scale = sys.scale;
+    data.sensors = sys.sensors;
+    data.armor = sys.armor;
+    data.dodge = sys.dodge;
+    data.ranged = sys.ranged;
+    data.ranged_damage = sys.ranged_damage;
+    data.ram = sys.ram;
+    data.ram_damage = sys.ram_damage;
     data.vehicle_weapons = [];
     for (let i = 0; i < data.items.size; i++) {
         if (actor.items.contents[i].type === "vehicle-weapon" || actor.items.contents[i].type === "starship-weapon") {
@@ -141,11 +140,11 @@ export async function sendVehicleData(actor: any, uuid: any): Promise<void> {
     }
 }
 
-export async function modifyShields(actor: any, update: any): Promise<void> {
+export async function modifyShields(actor: Actor, update: any): Promise<void> {
     await OD6S.socket.executeAsGM("modifyShields", update);
 }
 
-export async function vehicleCollision(actor: any): Promise<void> {
+export async function vehicleCollision(actor: Actor): Promise<void> {
     if (actor.type !== 'vehicle' && actor.type !== 'starship') {
         ui.notifications.warn(game.i18n.localize('OD6S.WARN_ACTOR_NOT_VEHICLE'));
         return;
@@ -254,7 +253,7 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
     }
 }
 
-export async function onCargoHoldItemCreate(actor: any, event: any): Promise<any> {
+export async function onCargoHoldItemCreate(actor: Actor, event: Event): Promise<unknown> {
     event.preventDefault();
 
     const documentName = 'Item';

--- a/src/module/actor/actor-helpers/resources.ts
+++ b/src/module/actor/actor-helpers/resources.ts
@@ -8,8 +8,7 @@ export async function useCharacterPointOnRoll(actor: any, message: any): Promise
     }
     const rollString = "1d6x6[CP]";
     const roll = await new Roll(rollString).evaluate();
-    // @ts-expect-error
-    if (game.modules.get('dice-so-nice') && game!.modules.get('dice-so-nice').active) {
+    if (game.modules.get('dice-so-nice')?.active) {
         game.dice3d.showForRoll(roll, game.user, true, false, false);
     }
 

--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -9,7 +9,7 @@ import {debug} from "../../system/logger";
 
 export {findWoundLevelByCore, computeNewDamageLevel, computeNewWoundLevel};
 
-export async function applyDamage(actor: any, damage: any): Promise<void> {
+export async function applyDamage(actor: Actor, damage: string): Promise<void> {
     const update: any = {};
     update.id = actor.id;
     update._id = actor.id;
@@ -19,14 +19,14 @@ export async function applyDamage(actor: any, damage: any): Promise<void> {
     await actor.update(update);
 }
 
-export function calculateNewDamageLevel(actor: any, damage: any): any {
-    const current = actor.system.damage.value;
+export function calculateNewDamageLevel(actor: Actor, damage: string): string | undefined {
+    const current = (actor.system as OD6SVehicleSystem).damage.value;
     const next = computeNewDamageLevel(current, damage);
     debug('wounds', 'damage transition', {actor: actor.name, current, incoming: damage, next});
     return next;
 }
 
-export async function applyWounds(actor: any, wound: any): Promise<void> {
+export async function applyWounds(actor: Actor, wound: string): Promise<void> {
     const update: any = {};
     const newValue = calculateNewWoundLevel(actor, wound);
     update.id = actor.id;
@@ -35,7 +35,7 @@ export async function applyWounds(actor: any, wound: any): Promise<void> {
     if(wound === 'OD6S.WOUNDS_STUNNED') {
         update[`system.stuns.current`] = 1;
         update[`system.stuns.rounds`] = 1;
-        update[`system.stuns.value`] = actor.system.stuns.value + 1;
+        update[`system.stuns.value`] = (actor.system as OD6SCharacterSystem).stuns.value + 1;
     }
 
     if (game.settings.get('od6s', 'weapon_armor_damage') && game.settings.get('od6s', 'auto_armor_damage')) {
@@ -83,9 +83,9 @@ export async function applyWounds(actor: any, wound: any): Promise<void> {
     await actor.update(update);
 }
 
-export function calculateNewWoundLevel(actor: any, wound: any): any {
+export function calculateNewWoundLevel(actor: Actor, wound: string): unknown {
     const deadlinessTable = OD6S.deadliness[OD6S.deadlinessLevel[actor.type]];
-    const current = actor.system.wounds.value;
+    const current = (actor.system as OD6SCharacterSystem).wounds.value;
     const next = computeNewWoundLevel(current, wound, deadlinessTable, OD6S.stunDamageIncrement);
     debug('wounds', 'wound transition', {
         actor: actor.name,
@@ -99,7 +99,7 @@ export function calculateNewWoundLevel(actor: any, wound: any): any {
     return next;
 }
 
-export async function triggerMortallyWoundedCheck(actor: any): Promise<void> {
+export async function triggerMortallyWoundedCheck(actor: Actor): Promise<void> {
     if (actor.getFlag('od6s', 'mortally_wounded') !== 'undefined') {
         const rollData = {
             name: game.i18n.localize('OD6S.RESIST_MORTALLY_WOUNDED'),
@@ -113,7 +113,7 @@ export async function triggerMortallyWoundedCheck(actor: any): Promise<void> {
     }
 }
 
-export async function applyMortallyWoundedFailure(actor: any): Promise<void> {
+export async function applyMortallyWoundedFailure(actor: Actor): Promise<void> {
     if(game.settings.get('od6s','auto_status')) {
         await actor.toggleStatusEffect('dead', {overlay: false, active: true});
     }
@@ -133,7 +133,7 @@ export async function applyMortallyWoundedFailure(actor: any): Promise<void> {
     await actor.unsetFlag('od6s','mortally_wounded');
 }
 
-export async function applyIncapacitatedFailure(actor: any): Promise<void> {
+export async function applyIncapacitatedFailure(actor: Actor): Promise<void> {
     const roll = await new Roll("10d6").evaluate();
     const flavor = actor.name + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_01') +
         roll.total + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_02');
@@ -144,21 +144,22 @@ export async function applyIncapacitatedFailure(actor: any): Promise<void> {
     await actor.toggleStatusEffect('unconscious', {overlay: false, active: true});
 }
 
-export function findFirstWoundLevel(_actor: any, table: any, wound: any): any {
+export function findFirstWoundLevel(_actor: Actor, table: Record<string, { core: string; description?: string; penalty?: number }>, wound: string): string | undefined {
     return findWoundLevelByCore(table, wound);
 }
 
-export function getWoundLevelFromBodyPoints(actor: any, bp: any): any {
+export function getWoundLevelFromBodyPoints(actor: Actor, bp?: number): string | undefined {
     if (actor.type === 'vehicle' || actor.type === 'starship') return;
     let bodyPointsCurrent;
+    const sys = actor.system as OD6SCharacterSystem;
     if (typeof (bp) !== 'undefined') {
         bodyPointsCurrent = bp;
     } else {
-        bodyPointsCurrent = actor.system.wounds.body_points.current
+        bodyPointsCurrent = sys.wounds.body_points.current
     }
 
     if (bodyPointsCurrent < 1) return 'OD6S.WOUNDS_DEAD';
-    const ratio = Math.ceil(bodyPointsCurrent / actor.system.wounds.body_points.max * 100)
+    const ratio = Math.ceil(bodyPointsCurrent / sys.wounds.body_points.max * 100)
     let level;
     for (const key in OD6S.bodyPointLevels) {
         if (ratio < OD6S.bodyPointLevels[key]) {
@@ -171,7 +172,7 @@ export function getWoundLevelFromBodyPoints(actor: any, bp: any): any {
     return level;
 }
 
-export async function setWoundLevelFromBodyPoints(actor: any, bp: any): Promise<void> {
+export async function setWoundLevelFromBodyPoints(actor: Actor, bp: number): Promise<void> {
     const update: any = {};
     update[`system.wounds.body_points.current`] = bp;
     update._id = actor.id;

--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -178,7 +178,8 @@ export async function setWoundLevelFromBodyPoints(actor: any, bp: any): Promise<
     update.id = actor.id;
     await actor.update(update);
     update[`system.wounds.value`] =
-        // @ts-expect-error
-        Object.keys(Object.fromEntries(Object.entries(OD6S.deadliness[3]).filter(([_k, v]) => v!.description === actor.getWoundLevelFromBodyPoints())))[0];
+        Object.keys(Object.fromEntries(Object.entries(OD6S.deadliness[3]).filter(
+            ([_k, v]) => (v as { description?: string }).description === actor.getWoundLevelFromBodyPoints(),
+        )))[0];
     await actor.update(update);
 }

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -14,9 +14,9 @@ import {useCharacterPointOnRoll as useCharacterPointOnRollHelper} from "./actor-
  */
 export class OD6SActor extends Actor {
 
-    get visible() {
+    get visible(): boolean {
         if (this.type === "container" && !game.user.isGM) {
-            return this.system.visible;
+            return !!(this.system as OD6SCharacterSystem).visible;
         } else {
             return super.visible;
         }
@@ -108,15 +108,16 @@ export class OD6SActor extends Actor {
     }
 
     getVehicleActionScore(action: any) {
-        let vehicle;
-        let pilot;
+        let vehicle: any;
+        let pilot: Actor | null;
 
         if(this.type === 'character' || this.type === 'npc' || this.type === 'creature') {
-            vehicle = this.system.vehicle
+            vehicle = (this.system as OD6SCharacterSystem).vehicle;
             pilot = this;
         } else {
-            vehicle = this.system;
-            if (this.system.embedded_pilot.value) {
+            const sys = this.system as OD6SVehicleSystem;
+            vehicle = sys;
+            if (sys.embedded_pilot.value) {
                 pilot = this;
             } else {
                 pilot = null;

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -89,7 +89,7 @@ export class OD6SActor extends Actor {
         prepareBaseActorData(this);
     }
 
-    getActionScoreText(action: any) {
+    getActionScoreText(action: string) {
         if (['character', 'creature', 'npc'].includes(this.type)) {
             const actionData = OD6S.actions[action];
             if(typeof actionData === 'undefined') {
@@ -107,7 +107,7 @@ export class OD6SActor extends Actor {
         }
     }
 
-    getVehicleActionScore(action: any) {
+    getVehicleActionScore(action: string) {
         let vehicle: any;
         let pilot: Actor | null;
 
@@ -158,7 +158,7 @@ export class OD6SActor extends Actor {
         }
     }
 
-    getVehicleActionScoreText(action: any) {
+    getVehicleActionScoreText(action: string) {
         const dice = od6sutilities.getDiceFromScore(this.getVehicleActionScore(action));
         if (typeof dice.dice === 'undefined' || isNaN(dice.dice)) return;
         return `${dice.dice}D+${dice.pips}`;
@@ -180,7 +180,7 @@ export class OD6SActor extends Actor {
         return setInitiativeHelper(this);
     }
 
-    async rollAttribute(attribute: any) {
+    async rollAttribute(attribute: string) {
         const data = {
             "actor": this,
             "itemId": "",
@@ -191,7 +191,7 @@ export class OD6SActor extends Actor {
         await od6sroll._onRollDialog(data);
     }
 
-    async rollAction(actionId: any, msg?: any) {
+    async rollAction(actionId: string, msg?: ChatMessage) {
         return resolveRollAction(this, actionId, msg);
     }
 
@@ -227,35 +227,35 @@ export class OD6SActor extends Actor {
         return calculateNewWoundLevelHelper(this, wound);
     }
 
-    getWoundLevelFromBodyPoints(bp: any) {
+    getWoundLevelFromBodyPoints(bp?: number) {
         return getWoundLevelFromBodyPointsHelper(this, bp);
     }
 
-    async setWoundLevelFromBodyPoints(bp: any) {
+    async setWoundLevelFromBodyPoints(bp: number) {
         return setWoundLevelFromBodyPointsHelper(this, bp);
     }
 
-    setResistance(type: any) {
+    setResistance(type: string) {
         return setResistanceHelper(this, type);
     }
 
-    async addEmbeddedPilot(pilotActor: any) {
+    async addEmbeddedPilot(pilotActor: Actor) {
         return addEmbeddedPilotHelper(this, pilotActor);
     }
 
-    async addToCrew(vehicleId: any) {
+    async addToCrew(vehicleId: string) {
         return addToCrewHelper(this, vehicleId);
     }
 
-    async _verifyAddToCrew(currentVehicleId: any, newVehicleId: any) {
+    async _verifyAddToCrew(currentVehicleId: string, newVehicleId: string) {
         return _verifyAddToCrewHelper(this, currentVehicleId, newVehicleId);
     }
 
-    async removeFromCrew(vehicleID: any) {
+    async removeFromCrew(vehicleID: string) {
         return removeFromCrewHelper(this, vehicleID);
     }
 
-    async forceRemoveCrewmember(crewID: any) {
+    async forceRemoveCrewmember(crewID: string) {
         return forceRemoveCrewmemberHelper(this, crewID);
     }
 
@@ -263,7 +263,7 @@ export class OD6SActor extends Actor {
         return isCrewMemberHelper(this);
     }
 
-    async useCharacterPointOnRoll(message: any) {
+    async useCharacterPointOnRoll(message: ChatMessage) {
         return useCharacterPointOnRollHelper(this, message);
     }
 
@@ -271,7 +271,7 @@ export class OD6SActor extends Actor {
         return modifyShieldsHelper(this, update);
     }
 
-    async sendVehicleData(uuid?: any) {
+    async sendVehicleData(uuid?: string) {
         return sendVehicleDataHelper(this, uuid);
     }
 

--- a/src/module/actor/sheet-listeners/inventory.ts
+++ b/src/module/actor/sheet-listeners/inventory.ts
@@ -158,8 +158,7 @@ export function registerInventoryListeners(html: any, sheet: any): void {
     el.querySelectorAll('.show-item-details').forEach((elem: any) =>
         elem.addEventListener('click', async (ev: any) => {
             ev.preventDefault();
-            // @ts-expect-error
-            let item = game!.actors.get(ev.currentTarget.dataset.actorId).items.get(ev.currentTarget.dataset.itemId);
+            let item = game!.actors.get(ev.currentTarget.dataset.actorId)?.items.get(ev.currentTarget.dataset.itemId);
             if (typeof (item) !== 'undefined') {
                 new OD6SItemInfo(item).render(true);
             } else {
@@ -185,11 +184,9 @@ export function registerInventoryListeners(html: any, sheet: any): void {
                 return;
             }
             if (OD6S.cost === '0') {
-                // @ts-expect-error
-                await sheet.rollPurchase(ev, game!.user.character.id);
+                await sheet.rollPurchase(ev, game!.user.character!.id);
             } else {
-                // @ts-expect-error
-                await sheet._onPurchase(ev.currentTarget.dataset.itemId, game!.user.character.id);
+                await sheet._onPurchase(ev.currentTarget.dataset.itemId, game!.user.character!.id);
             }
         }));
 

--- a/src/module/actor/sheet-listeners/vehicle.ts
+++ b/src/module/actor/sheet-listeners/vehicle.ts
@@ -78,7 +78,7 @@ export function registerVehicleListeners(html: any, sheet: any): void {
             if (game.user.isGM) {
                 // Filter out tokens who are already crew members in a vehicle
                 // @ts-expect-error
-                tokens = tokens.filter((t: any) => !(t.actor as any).isCrewMember());
+                tokens = tokens.filter((t: any) => !t.actor.isCrewMember());
             } else {
                 // If a player, filter out hostile/neutral tokens
                 // @ts-expect-error

--- a/src/module/actor/sheet-listeners/vehicle.ts
+++ b/src/module/actor/sheet-listeners/vehicle.ts
@@ -60,28 +60,23 @@ export function registerVehicleListeners(html: any, sheet: any): void {
             const data: any = {};
             data.crew = [];
             if (typeof (game.scenes.active) === 'undefined') return;
-            let tokens = game.scenes.active.tokens;
-
-            // @ts-expect-error
-            tokens = tokens.filter((t: any) => typeof (t.actor) !== "undefined" && t.actor !== '' && t.actor !== null);
+            let tokens: TokenDocument[] = game.scenes.active.tokens.filter(
+                (t: any) => typeof (t.actor) !== "undefined" && t.actor !== '' && t.actor !== null,
+            );
 
             if (tokens.length === 0) {
-                // @ts-expect-error
-                !ui.notifications.warn(game.i18n.localize('OD6S.NO_TOKENS'));
+                ui.notifications.warn(game.i18n.localize('OD6S.NO_TOKENS'));
                 return;
             }
 
             // Filter out tokens who are a vehicle
-            // @ts-expect-error
             tokens = tokens.filter((t: any) => t.actor.type !== "vehicle" && t.actor.type !== "starship");
 
             if (game.user.isGM) {
                 // Filter out tokens who are already crew members in a vehicle
-                // @ts-expect-error
                 tokens = tokens.filter((t: any) => !t.actor.isCrewMember());
             } else {
                 // If a player, filter out hostile/neutral tokens
-                // @ts-expect-error
                 tokens = tokens.filter((t: any) => t.disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY);
 
                 // Filter out already-crewed tokens
@@ -92,13 +87,11 @@ export function registerVehicleListeners(html: any, sheet: any): void {
                     }
                 }
 
-                // @ts-expect-error
                 tokens = tokens.filter((e: any) => !crewed.includes(e));
             }
 
             if (tokens.length === 0) {
-                // @ts-expect-error
-                !ui.notifications.warn(game.i18n.localize('OD6S.NO_TOKENS'));
+                ui.notifications.warn(game.i18n.localize('OD6S.NO_TOKENS'));
                 return;
             }
 

--- a/src/module/apps/chat-menu.ts
+++ b/src/module/apps/chat-menu.ts
@@ -16,7 +16,7 @@ export class OD6SChat {
                     if (message!.getFlag('od6s', 'canUseCp') &&
                         (game.user.isGM || actor!.isOwner) &&
                         (actor!.type === "character"||actor!.type === "npc") &&
-                        actor!.system.characterpoints.value > 0) {
+                        (actor!.system as OD6SCharacterSystem).characterpoints.value > 0) {
                         return true;
                     }
                 }

--- a/src/module/apps/roll-helpers/roll-difficulty.ts
+++ b/src/module/apps/roll-helpers/roll-difficulty.ts
@@ -32,34 +32,38 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
             } else {
                 return await od6sutilities.getDifficultyFromLevel(rollData.vehicleterraindifficulty)
             }
-        case 'vehicleramattack':
+        case 'vehicleramattack': {
+            const targetDodge = target ? (rollData.target!.actor.system as OD6SCharacterSystem).dodge?.score ?? 0 : 0;
             if (OD6S.vehicleDifficulty) {
-                if (target && (+rollData.target!.actor.system.dodge.score) > 0) {
-                    return (+rollData.target!.actor.system.dodge.score) + (+OD6S.vehicle_speeds[rollData.vehiclespeed].mod);
+                if (targetDodge > 0) {
+                    return (+targetDodge) + (+OD6S.vehicle_speeds[rollData.vehiclespeed].mod);
                 } else {
                     return (+OD6S.vehicle_speeds[rollData.vehiclespeed].mod);
                 }
             } else {
-                if (target && (+rollData.target!.actor.system.dodge.score) > 0) {
-                    return (+rollData.target!.actor.system.dodge.score) + (await od6sutilities.getDifficultyFromLevel(rollData.vehicleterraindifficulty));
+                if (targetDodge > 0) {
+                    return (+targetDodge) + (await od6sutilities.getDifficultyFromLevel(rollData.vehicleterraindifficulty));
                 } else {
                     return await od6sutilities.getDifficultyFromLevel(rollData.vehicleterraindifficulty);
                 }
             }
+        }
         case 'vehiclerangedattack':
         case 'vehiclerangedweaponattack':
-        case 'rangedattack':
-            if (target && (+rollData.target!.actor.system.dodge.score) > 0) {
-                return (+rollData.target!.actor.system.dodge.score);
+        case 'rangedattack': {
+            const targetDodge = target ? (rollData.target!.actor.system as OD6SCharacterSystem).dodge?.score ?? 0 : 0;
+            if (targetDodge > 0) {
+                return (+targetDodge);
             } else {
                 if (OD6S.mapRange) {
                     return await od6sutilities.getDifficultyFromLevel(OD6S.ranges[rollData.modifiers.range].map);
                 }
                 return OD6S.baseRangedAttackDifficulty;
             }
+        }
         case 'meleeattack':
             if (target) {
-                const targetData = rollData.target!.actor.system;
+                const targetData = rollData.target!.actor.system as OD6SCharacterSystem;
 
                 if (OD6S.defenseLock) {
                     if (targetData.parry.score === 0) {
@@ -104,7 +108,7 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
             }
         case 'brawlattack':
             if (target) {
-                const targetData = rollData.target!.actor.system;
+                const targetData = rollData.target!.actor.system as OD6SCharacterSystem;
 
                 if (OD6S.defenseLock) {
                     if (targetData.block.score === 0) {

--- a/src/module/apps/roll-helpers/roll-effects.ts
+++ b/src/module/apps/roll-helpers/roll-effects.ts
@@ -5,21 +5,22 @@
 import type {RollData} from "./roll-data";
 
 export function getEffectMod(type: string, name: string, actor: Actor): number {
+    const sys = actor.system as OD6SCharacterSystem;
     if (type === 'skill') {
-        if (typeof (actor.system.customeffects?.skills[name]) !== 'undefined') {
-            return actor.system.customeffects.skills[name];
+        if (typeof (sys.customeffects?.skills[name]) !== 'undefined') {
+            return sys.customeffects.skills[name];
         }
     }
 
     if (type === 'specialization') {
-        if (typeof (actor.system.customeffects?.specializations[name]) !== 'undefined') {
-            return actor.system.customeffects.specializations[name];
+        if (typeof (sys.customeffects?.specializations[name]) !== 'undefined') {
+            return sys.customeffects.specializations[name];
         }
 
         const spec = actor.items.filter((i: Item) => i.type === type && i.name === name)[0];
         if (typeof (spec) !== 'undefined') {
-            if (typeof (actor.system.customeffects.skills[spec.system.skill]) !== 'undefined') {
-                return actor.system.customeffects.skills[spec.system.skill];
+            if (typeof (sys.customeffects.skills[spec.system.skill]) !== 'undefined') {
+                return sys.customeffects.skills[spec.system.skill];
             }
         }
     }

--- a/src/module/apps/roll-helpers/roll-execute-math.test.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { computeHighHitDamage, computeWildDieReduction } from './roll-execute-math';
+
+describe('computeHighHitDamage', () => {
+    it('returns 0 when the roll fails to meet difficulty', () => {
+        expect(computeHighHitDamage({
+            rollTotal: 10, difficulty: 15, multiplier: 5, roundDown: true, asPips: false,
+        })).toEqual({ extra: 0, asPips: false });
+    });
+
+    it('returns 0 on an exact tie (difference is zero)', () => {
+        expect(computeHighHitDamage({
+            rollTotal: 15, difficulty: 15, multiplier: 5, roundDown: true, asPips: false,
+        })).toEqual({ extra: 0, asPips: false });
+    });
+
+    it('rounds down when configured to round down', () => {
+        // diff = 9, multiplier = 5 → 9/5 = 1.8 → floor = 1
+        expect(computeHighHitDamage({
+            rollTotal: 24, difficulty: 15, multiplier: 5, roundDown: true, asPips: false,
+        })).toEqual({ extra: 1, asPips: false });
+    });
+
+    it('rounds up when configured to round up', () => {
+        // diff = 9, multiplier = 5 → 9/5 = 1.8 → ceil = 2
+        expect(computeHighHitDamage({
+            rollTotal: 24, difficulty: 15, multiplier: 5, roundDown: false, asPips: false,
+        })).toEqual({ extra: 2, asPips: false });
+    });
+
+    it('passes asPips through to the result', () => {
+        expect(computeHighHitDamage({
+            rollTotal: 20, difficulty: 10, multiplier: 5, roundDown: true, asPips: true,
+        }).asPips).toBe(true);
+    });
+
+    it('returns 0 when multiplier is non-positive (defensive)', () => {
+        expect(computeHighHitDamage({
+            rollTotal: 24, difficulty: 15, multiplier: 0, roundDown: true, asPips: false,
+        }).extra).toBe(0);
+    });
+
+    it('handles a clean integer division', () => {
+        // diff = 10, multiplier = 5 → exactly 2 (no rounding ambiguity)
+        const down = computeHighHitDamage({
+            rollTotal: 25, difficulty: 15, multiplier: 5, roundDown: true, asPips: false,
+        });
+        const up = computeHighHitDamage({
+            rollTotal: 25, difficulty: 15, multiplier: 5, roundDown: false, asPips: false,
+        });
+        expect(down.extra).toBe(2);
+        expect(up.extra).toBe(2);
+    });
+});
+
+describe('computeWildDieReduction', () => {
+    it('finds and discards the highest base die', () => {
+        const dice = [
+            { result: 3, active: true },
+            { result: 6, active: true },
+            { result: 4, active: true },
+        ];
+        // original total includes wild die 1: 3+6+4+1 = 14
+        const r = computeWildDieReduction(dice, 14);
+        expect(r.discardedIndex).toBe(1);
+        // 14 - 6 (discarded) - 1 (wild) = 7
+        expect(r.newTotal).toBe(7);
+    });
+
+    it('picks the first occurrence when ties exist', () => {
+        const dice = [
+            { result: 5, active: true },
+            { result: 5, active: true },
+            { result: 2, active: true },
+        ];
+        const r = computeWildDieReduction(dice, 13);
+        expect(r.discardedIndex).toBe(0);
+        expect(r.newTotal).toBe(7); // 13 - 5 - 1
+    });
+
+    it('handles a single base die', () => {
+        const dice = [{ result: 4, active: true }];
+        const r = computeWildDieReduction(dice, 5); // 4 + 1
+        expect(r.discardedIndex).toBe(0);
+        expect(r.newTotal).toBe(0); // 5 - 4 - 1
+    });
+});

--- a/src/module/apps/roll-helpers/roll-execute-math.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure math helpers extracted from roll-execute.ts. No Foundry globals.
+ * Lets tests import without dragging in Roll/Dialog/etc.
+ */
+
+export interface HighHitDamageInput {
+    /** Final roll total. */
+    rollTotal: number;
+    /** Difficulty the roll was measured against. */
+    difficulty: number;
+    /** Setting: how much excess success per damage step (OD6S.highHitDamageMultiplier). */
+    multiplier: number;
+    /** Setting: round-down (true) vs round-up (false). */
+    roundDown: boolean;
+    /** Setting: emit as pips (true) vs whole damage dice (false). */
+    asPips: boolean;
+}
+
+export interface HighHitDamageResult {
+    /** Extra damage value to push as a damage modifier. */
+    extra: number;
+    /** Whether the result should be applied as pips (true) or dice (false). */
+    asPips: boolean;
+}
+
+/**
+ * Compute the high-hit damage bonus when a roll exceeds its difficulty.
+ * Returns { extra: 0 } when the roll fails — caller should still skip applying.
+ */
+export function computeHighHitDamage(input: HighHitDamageInput): HighHitDamageResult {
+    const { rollTotal, difficulty, multiplier, roundDown, asPips } = input;
+    const difference = rollTotal - difficulty;
+    if (difference <= 0 || multiplier <= 0) return { extra: 0, asPips };
+    const extra = roundDown
+        ? Math.floor(difference / multiplier)
+        : Math.ceil(difference / multiplier);
+    return { extra, asPips };
+}
+
+export interface DieResult {
+    result: number;
+    active: boolean;
+    discarded?: boolean;
+}
+
+export interface WildDieReductionResult {
+    /** Index of the die to discard (the highest-rolling base die). */
+    discardedIndex: number;
+    /** New roll total after discarding the highest base die and subtracting 1 (the wild die's natural 1). */
+    newTotal: number;
+}
+
+/**
+ * When the wild die rolls a 1 and the configured outcome is "discard highest base die",
+ * find which base die to drop and compute the adjusted total.
+ *
+ * The original total is reduced by the discarded die's value plus 1 (representing the
+ * wild die's own 1 that triggered this path).
+ */
+export function computeWildDieReduction(
+    baseDieResults: DieResult[],
+    originalTotal: number,
+): WildDieReductionResult {
+    let highest = 0;
+    for (let i = 0; i < baseDieResults.length; i++) {
+        if (baseDieResults[i].result > baseDieResults[highest].result) {
+            highest = i;
+        }
+    }
+    const newTotal = originalTotal - baseDieResults[highest].result - 1;
+    return { discardedIndex: highest, newTotal };
+}

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -7,6 +7,7 @@ import {getDifficulty, applyDifficultyEffects, applyDamageEffects} from "./roll-
 import {applyDifficultyModifiers} from "./difficulty-math";
 import type {Modifier} from "./difficulty-math";
 import type {RollData, RollMessageFlags, DiceValue} from "./roll-data";
+import {computeHighHitDamage, computeWildDieReduction} from "./roll-execute-math";
 import {debug} from "../../system/logger";
 
 export async function executeRollAction(rollData: RollData): Promise<unknown> {
@@ -398,29 +399,19 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     if (rollData.actor.type === 'character' && OD6S.highHitDamage && flags.success) {
-        let extra;
-        const difference = roll.total - difficulty;
-
-        if (OD6S.highHitDamageRound) {
-            extra = Math.floor(difference / OD6S.highHitDamageMultiplier);
-        } else {
-            extra = Math.ceil(difference / OD6S.highHitDamageMultiplier);
-        }
-
-        if (OD6S.highHitDamagePipsOrDice) {
-            flags.damageModifiers.push({
-                "name": 'OD6S.HIGH_HIT_DAMAGE',
-                "value": extra,
-                "pips": 0
-            });
-            flags.damageDice.dice += extra;
-        } else {
-            flags.damageModifiers.push({
-                "name": 'OD6S.HIGH_HIT_DAMAGE',
-                "value": 0,
-                "pips": extra
-            });
+        const { extra, asPips } = computeHighHitDamage({
+            rollTotal: roll.total,
+            difficulty,
+            multiplier: OD6S.highHitDamageMultiplier,
+            roundDown: OD6S.highHitDamageRound,
+            asPips: !OD6S.highHitDamagePipsOrDice,
+        });
+        if (asPips) {
+            flags.damageModifiers.push({ "name": 'OD6S.HIGH_HIT_DAMAGE', "value": 0, "pips": extra });
             flags.damageDice.pips += extra;
+        } else {
+            flags.damageModifiers.push({ "name": 'OD6S.HIGH_HIT_DAMAGE', "value": extra, "pips": 0 });
+            flags.damageDice.dice += extra;
         }
     }
 
@@ -456,15 +447,13 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));
-        let highest = 0;
-        for (let i = 0; i < replacementRoll.terms[0].results.length; i++) {
-            replacementRoll.terms[0].results[i].result >
-            replacementRoll.terms[0].results[highest].result ?
-                highest = i : {}
-        }
-        replacementRoll.terms[0].results[highest].discarded = true;
-        replacementRoll.terms[0].results[highest].active = false;
-        replacementRoll.total -= (+replacementRoll.terms[0].results[highest].result) + 1;
+        const { discardedIndex, newTotal } = computeWildDieReduction(
+            replacementRoll.terms[0].results,
+            replacementRoll.total,
+        );
+        replacementRoll.terms[0].results[discardedIndex].discarded = true;
+        replacementRoll.terms[0].results[discardedIndex].active = false;
+        replacementRoll.total = newTotal;
         flags.total = replacementRoll.total;
         const rollMessageUpdate: { content?: number; rolls?: unknown[]; flags?: { od6s?: Partial<RollMessageFlags> } } = {};
         rollMessageUpdate.content = replacementRoll.total;

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -40,7 +40,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     let difficulty;
 
     if (actor.type !== 'vehicle' && actor.type !== 'starship') {
-        strModDice = od6sutilities.getDiceFromScore(rollData.actor.system.strengthdamage.score);
+        strModDice = od6sutilities.getDiceFromScore((rollData.actor.system as OD6SCharacterSystem).strengthdamage.score);
     }
 
     rollData.isknown = true;
@@ -102,14 +102,15 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     // Apply costs
-    if ((rollData.characterpoints > 0) && (actor.system.characterpoints.value > 0)) {
+    const charSys = actor.system as OD6SCharacterSystem;
+    if ((rollData.characterpoints > 0) && (charSys.characterpoints.value > 0)) {
         doUpdate = true;
-        actor.system.characterpoints.value -= rollData.characterpoints;
+        charSys.characterpoints.value -= rollData.characterpoints;
     }
 
-    if (rollData.fatepoint && (actor.system.fatepoints.value > 0)) {
+    if (rollData.fatepoint && (charSys.fatepoints.value > 0)) {
         doUpdate = true;
-        actor.system.fatepoints.value -= 1;
+        charSys.fatepoints.value -= 1;
     }
 
     if (typeof (rollData.target) !== 'undefined') {
@@ -150,7 +151,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     });
 
     if (rollData.subtype === 'brawlattack') {
-        damageScore = actor.system.strengthdamage.score;
+        damageScore = charSys.strengthdamage.score;
         damageType = 'p';
     }
 
@@ -539,9 +540,9 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     if (rollData.subtype === 'dodge' || rollData.subtype === 'parry' || rollData.subtype === 'block') {
         doUpdate = true;
         if (rollData.fulldefense) {
-            actor.system[rollData.subtype].score = (+(flags.total ?? 0) + baseAttackDifficulty);
+            charSys[rollData.subtype].score = (+(flags.total ?? 0) + baseAttackDifficulty);
         } else {
-            actor.system[rollData.subtype].score = +(flags.total ?? 0);
+            charSys[rollData.subtype].score = +(flags.total ?? 0);
         }
     }
 
@@ -550,7 +551,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         if (rollData.actor.type === 'vehicle' || rollData.actor.type === 'starship') {
             vehicle = rollData.actor;
         } else {
-            vehicle = await od6sutilities.getActorFromUuid(actor.system.vehicle.uuid);
+            vehicle = await od6sutilities.getActorFromUuid(charSys.vehicle.uuid);
         }
         const dodgeScore = rollData.fulldefense
             ? (+roll.total + baseAttackDifficulty)
@@ -565,18 +566,18 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         if (game.user.isGM) {
             await vehicle?.update(vehicleUpdate);
         } else {
-            await OD6S.socket.executeAsGM('updateVehicle', actor.system.vehicle.uuid, vehicleUpdate);
+            await OD6S.socket.executeAsGM('updateVehicle', charSys.vehicle.uuid, vehicleUpdate);
         }
     }
 
     if (doUpdate) {
         const update = {
             system: {
-                fatepoints: actor.system.fatepoints,
-                characterpoints: actor.system.characterpoints,
-                dodge: { score: actor.system.dodge.score },
-                parry: { score: actor.system.parry.score },
-                block: { score: actor.system.block.score },
+                fatepoints: charSys.fatepoints,
+                characterpoints: charSys.characterpoints,
+                dodge: { score: charSys.dodge.score },
+                parry: { score: charSys.parry.score },
+                block: { score: charSys.block.score },
             },
         };
         await actor.update(update);

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -52,7 +52,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         let item = data.actor.items.get(data.itemId);
         if(typeof(item) === 'undefined') {
             if (data.type === 'action' && data.subtype === 'vehiclerangedweaponattack') {
-                item = data.actor.system.vehicle.vehicle_weapons.find((i: any) =>i.id === data.itemId);
+                item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!.find((i: any) =>i.id === data.itemId);
             }
         }
         if (item?.system.subtype?.toLowerCase() === 'explosive') {
@@ -90,7 +90,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         if (data.actor.type === 'vehicle' || data.actor.type === 'starship') {
             vehicle = data.actor.uuid;
         } else {
-            vehicle = data.actor.system.vehicle.uuid;
+            vehicle = (data.actor.system as OD6SCharacterSystem).vehicle.uuid;
         }
     }
 
@@ -146,7 +146,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         if (data.subtype === 'meleeattack') {
             damageScore = od6sutilities.getMeleeDamage(data.actor, weapon);
             if (stunDamageScore > 0) {
-                stunDamageScore = weapon.system.damage.str ? stunDamageScore + data.actor.system.strengthdamage.score : stunDamageScore;
+                stunDamageScore = weapon.system.damage.str ? stunDamageScore + (data.actor.system as OD6SCharacterSystem).strengthdamage.score : stunDamageScore;
             }
         }
         if (weapon.system.scale.score) attackerScale = weapon.system.scale.score;
@@ -189,7 +189,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         if (weapon.system.damage.muscle) {
             const strmod = {
                 "name": 'OD6S.STRENGTH_DAMAGE_BONUS',
-                "value": data.actor.system.strengthdamage.score
+                "value": (data.actor.system as OD6SCharacterSystem).strengthdamage.score
             }
             damageModifiers.push(strmod);
         }
@@ -214,19 +214,19 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if (data.subtype === 'vehiclerangedweaponattack') {
         let vehicleWeapon: Item | undefined;
         if (data.actor.type === 'vehicle') {
-            if (data.actor.system.embedded_pilot) {
+            if ((data.actor.system as OD6SVehicleSystem).embedded_pilot) {
                 vehicleWeapon = data.actor.items.filter((i: Item) => i._id === data.itemId)[0];
             } else {
                 vehicleWeapon = (data.actor as any).vehicle_weapons.filter((i: Item) => i._id === data.itemId)[0];
             }
         } else if (data.actor.type === 'starship') {
-            if (data.actor.system.embedded_pilot) {
+            if ((data.actor.system as OD6SVehicleSystem).embedded_pilot) {
                 vehicleWeapon = data.actor.items.filter((i: Item) => i._id === data.itemId)[0];
             } else {
                 vehicleWeapon = (data.actor as any).starship_weapons.filter((i: Item) => i._id === data.itemId)[0];
             }
         } else {
-            vehicleWeapon = data.actor.system.vehicle.vehicle_weapons?.filter((i: Item) => i.id === data.itemId)[0];
+            vehicleWeapon = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons?.filter((i: Item) => i.id === data.itemId)[0];
         }
 
         isAttack = true;
@@ -238,15 +238,15 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             if (vehicleWeapon.system.mods.attack !== 0) bonusmod += vehicleWeapon.system.mods.attack;
             if (vehicleWeapon.system.scale.score) {
                 attackerScale = vehicleWeapon.system.scale.score;
-            } else if (data.actor.type === 'vehicle' || data.actor.type === 'starship' || data.actor.system?.embedded_pilot) {
+            } else if (data.actor.type === 'vehicle' || data.actor.type === 'starship' || (data.actor.system as OD6SVehicleSystem)?.embedded_pilot) {
                 attackerScale = data.actor.system.scale.score;
             } else {
-                attackerScale = data.actor.system.vehicle.scale.score;
+                attackerScale = (data.actor.system as OD6SCharacterSystem).vehicle.scale!.score;
             }
         } else {
             damageScore = data.damage ?? 0;
             damageType = data.damage_type ?? '';
-            attackerScale = data.actor.system.vehicle.scale.score;
+            attackerScale = (data.actor.system as OD6SCharacterSystem).vehicle.scale!.score;
         }
         damageSource = data.name;
     }
@@ -255,22 +255,22 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         damageType = 'p';
         damageSource = 'OD6S.COLLISION';
         isAttack = true;
-        const vehicle = (data.actor.type === 'vehicle' || data.actor.type === 'starship') ? data.actor.system : data.actor.system.vehicle
-        if (vehicle.ram_damage.score > 0) {
+        const vehicle: any = (data.actor.type === 'vehicle' || data.actor.type === 'starship') ? data.actor.system : (data.actor.system as OD6SCharacterSystem).vehicle;
+        if (vehicle.ram_damage?.score > 0) {
             const rangedmod = {
                 "name": 'OD6S.ACTIVE_EFFECTS',
                 "value": vehicle.ram_damage.score
             }
             damageModifiers.push(rangedmod);
         }
-        if (vehicle.ram.score > 0) {
+        if (vehicle.ram?.score > 0) {
             bonusmod += (+vehicle.ram.score);
         }
     }
 
     if (data.type === 'brawlattack' || data.subtype === 'brawlattack') {
         damageType = 'p';
-        damageScore = data.actor.system.strengthdamage.score;
+        damageScore = (data.actor.system as OD6SCharacterSystem).strengthdamage.score;
         isAttack = true;
         canStun = true;
         stunDamageScore = damageScore;
@@ -286,10 +286,10 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if (targets.length === 1) {
         if (!attackerScale && isAttack) {
             if (typeof (data.subtype) !== 'undefined' && data.subtype.includes('vehicle')) {
-                if (data.actor.system.crew.value) {
+                if ((data.actor.system as OD6SVehicleSystem).crew?.value) {
                     attackerScale = data.actor.system.scale.score;
                 } else {
-                    attackerScale = data.actor.system.vehicle.scale.score;
+                    attackerScale = (data.actor.system as OD6SCharacterSystem).vehicle.scale!.score;
                 }
             } else {
                 if (typeof (data.actor.system.scale.score) === 'undefined') {
@@ -383,7 +383,8 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     let stunnedPenalty = 0;
     if (data.actor.type === 'character' || data.actor.type === 'npc' || data.actor.type === 'creature') {
-        stunnedPenalty = data.actor.system.stuns.current ? data.actor.system.stuns.current : 0;
+        const sys = data.actor.system as OD6SCharacterSystem;
+        stunnedPenalty = sys.stuns.current ? sys.stuns.current : 0;
     }
 
     let actionPenalty = ((+data.actor.itemTypes.action.length) > 0) ? (+data.actor.itemTypes.action.length) - 1 : 0;
@@ -465,7 +466,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         data.subtype === "meleeattack" &&
         data.name === game.i18n.localize('OD6S.ACTION_MELEE_ATTACK')) {
         miscMod += 5;
-        damageScore = data.actor.system.strengthdamage.score;
+        damageScore = (data.actor.system as OD6SCharacterSystem).strengthdamage.score;
     }
 
     if (data.subtype === 'rangedattack' ||
@@ -518,10 +519,12 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         }
 
         if (data.subtype.startsWith('vehicle')) {
-            if (data.actor.system?.embedded_pilot?.value && typeof ((data.actor.system?.ranged as OD6SScoreField)?.score) !== 'undefined') {
-                bonusmod += (+(data.actor.system.ranged as OD6SScoreField).score);
-            } else if (typeof (data.actor.system?.vehicle?.ranged?.score) !== 'undefined') {
-                bonusmod += (+data.actor.system.vehicle.ranged.score);
+            const vehSys = data.actor.system as OD6SVehicleSystem;
+            const charSys = data.actor.system as OD6SCharacterSystem & { vehicle: { ranged?: { score?: number } } };
+            if (vehSys?.embedded_pilot?.value && typeof ((vehSys?.ranged as OD6SScoreField)?.score) !== 'undefined') {
+                bonusmod += (+(vehSys.ranged as OD6SScoreField).score);
+            } else if (typeof (charSys?.vehicle?.ranged?.score) !== 'undefined') {
+                bonusmod += (+charSys.vehicle.ranged.score);
             }
         } else {
             bonusmod += (+(data.actor.system.ranged as OD6SModField).mod);
@@ -529,35 +532,36 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     }
 
     if (data.subtype === 'vehicleramattack') {
-        const vehicle = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
-            ? data.actor.system : data.actor.system.vehicle
-        if (typeof (vehicle.ram.score) !== 'undefined') {
+        const vehicle: any = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
+            ? data.actor.system : (data.actor.system as OD6SCharacterSystem).vehicle;
+        if (typeof (vehicle.ram?.score) !== 'undefined') {
             bonusmod += (+vehicle.ram.score);
         }
     }
 
+    const charSys = data.actor.system as OD6SCharacterSystem;
     if (data.subtype === 'meleeattack') {
-        bonusmod += (+data.actor.system.melee.mod);
+        bonusmod += (+charSys.melee.mod);
     }
 
     if (data.subtype === 'brawlattack') {
-        bonusmod += (+data.actor.system.brawl.mod);
+        bonusmod += (+charSys.brawl.mod);
         canStun = true;
-        damageScore = data.actor.system.strengthdamage.score;
+        damageScore = charSys.strengthdamage.score;
         stunDamageScore = damageScore;
         stunDamageType = 'p';
     }
 
     if (data.subtype === 'dodge') {
-        bonusmod += (+data.actor.system.dodge.mod);
+        bonusmod += (+charSys.dodge.mod);
     }
 
     if (data.subtype === 'parry') {
-        bonusmod += (+data.actor.system.parry.mod);
+        bonusmod += (+charSys.parry.mod);
     }
 
     if (data.subtype === 'block') {
-        bonusmod += (+data.actor.system.block.mod);
+        bonusmod += (+charSys.block.mod);
     }
 
     if (OD6S.flatSkills) {

--- a/src/module/apps/roll.ts
+++ b/src/module/apps/roll.ts
@@ -20,7 +20,7 @@ export class od6sroll {
         const actor = (this as any).actor as Actor;
         const item = actor.items.find((i: Item) => i.id === (event.currentTarget as HTMLElement).dataset.itemId);
         if (!item) return;
-        if ((actor.type === 'vehicle' || actor.type === 'starship') && actor.system.embedded_pilot) {
+        if ((actor.type === 'vehicle' || actor.type === 'starship') && (actor.system as OD6SVehicleSystem).embedded_pilot) {
             return item.roll();
         }
         if (item.system?.subtype.includes("vehicle")) {
@@ -108,7 +108,7 @@ export class od6sroll {
 
         const actions = Object.keys(skills).length;
         const actionpenalty = (+actions) + ((actor as any).actions.length) - 1;
-        const stunnedpenalty = actor.system.stuns.current;
+        const stunnedpenalty = (actor.system as OD6SCharacterSystem).stuns.current;
 
         this.rollData = {
             title: item.name,

--- a/src/module/config/config-od6s.ts
+++ b/src/module/config/config-od6s.ts
@@ -3,6 +3,21 @@ import deadliness from "./deadliness";
 import statusEffects from "./status-effects";
 import { actions, vehicleActions } from "./actions";
 import { armorDamage, damage, damageTypes, vehicleDamage, weaponDamage } from "./damage";
+import {
+    weaponTypes,
+    weaponTypeKeys,
+    meleeDifficulties,
+    rangedAttackOptions,
+    meleeAttackOptions,
+    brawlAttackOptions,
+    ranges,
+} from "./weapons";
+import {
+    actorTypeLabels,
+    itemLabels,
+    templateItemTypes,
+    allowedItemTypes,
+} from "./labels";
 
 const OD6S: Record<string, any> = {};
 
@@ -214,45 +229,9 @@ OD6S.collision_types = {
     }
 }
 
-OD6S.weaponTypes = [
-    "OD6S.RANGED",
-    "OD6S.MELEE",
-    "OD6S.MISSILE",
-    "OD6S.THROWN",
-    "OD6S.EXPLOSIVE"
-]
-
-OD6S.weaponTypeKeys = [
-    {
-        "key": "OD6S.RANGED",
-        "name": "Ranged"
-    },
-    {
-        "key": "OD6S.MELEE",
-        "name": "Melee"
-    },
-    {
-        "key": "OD6S.MISSILE",
-        "name": "Missile"
-    },
-    {
-        "key": "OD6S.THROWN",
-        "name": "Thrown"
-    },
-    {
-        "key": "OD6S.EXPLOSIVE",
-        "name": "Explosive"
-    }
-]
-
-OD6S.meleeDifficulties = [
-    "OD6S.DIFFICULTY_VERY_EASY",
-    "OD6S.DIFFICULTY_EASY",
-    "OD6S.DIFFICULTY_MODERATE",
-    "OD6S.DIFFICULTY_DIFFICULT",
-    "OD6S.DIFFICULTY_VERY_DIFFICULT",
-    "OD6S.DIFFICULTY_HEROIC",
-]
+OD6S.weaponTypes = weaponTypes;
+OD6S.weaponTypeKeys = weaponTypeKeys;
+OD6S.meleeDifficulties = meleeDifficulties;
 
 OD6S.actions = actions;
 
@@ -492,122 +471,13 @@ OD6S.misc = {
 // attack: subtraction or addition to hit difficulty (negative numbers are in effect a bonus)
 // damage: bonus or penalty to damage
 // multi: whether an attack needs a ROF selection by the character for number of shots in a round
-OD6S.rangedAttackOptions = {
-    "OD6S.ATTACK_STANDARD": {
-        "attack": 0,
-        "damage": 0,
-        "multi": false
-    },
-    "OD6S.ATTACK_RANGED_SINGLE_FIRE_AS_MULTI": {
-        "attack": -3,
-        "damage": +3,
-        "multi": true
-    },
-    "OD6S.ATTACK_RANGED_FULL_AUTO": {
-        "attack": -6,
-        "damage": 6,
-        "multi": false
-    },
-    "OD6S.ATTACK_RANGED_SWEEP": {
-        "attack": -6,
-        "damage": -9,
-        "multi": false
-    },
-    "OD6S.ATTACK_RANGED_BURST_FIRE_AS_SINGLE": {
-        "attack": 0,
-        "damage": -6,
-        "multi": false
-    }
-}
-
-OD6S.meleeAttackOptions = {
-    "OD6S.ATTACK_STANDARD": {
-        "attack": 0,
-        "damage": 0,
-        "multi": false
-    },
-    "OD6S.ATTACK_ALL_OUT": {
-        "attack": -6,
-        "damage": 3
-    },
-    "OD6S.ATTACK_LUNGE": {
-        "attack": 3,
-        "damage": -3
-    },
-    "OD6S.ATTACK_KNOCKDOWN_TRIP": {
-        "attack": 6,
-        "damage": 0
-    },
-    "OD6S.ATTACK_PUSH": {
-        "attack": 3,
-        "damage": 0
-    }
-}
-
-OD6S.brawlAttackOptions = {
-    "OD6S.ATTACK_STANDARD": {
-        "attack": 0,
-        "damage": 0,
-        "multi": false
-    },
-    "OD6S.ATTACK_ALL_OUT": {
-        "attack": -6,
-        "damage": 3
-    },
-    "OD6S.ATTACK_GRAB": {
-        "attack": 9,
-        "damage": 0
-    },
-    "OD6S.ATTACK_LUNGE": {
-        "attack": 3,
-        "damage": -3
-    },
-    "OD6S.ATTACK_KNOCKDOWN_TRIP": {
-        "attack": 6,
-        "damage": 0
-    },
-    "OD6S.ATTACK_PUSH": {
-        "attack": 3,
-        "damage": 0
-    },
-    "OD6S.ATTACK_SWEEP": {
-        "attack": -6,
-        "damage": -9
-    },
-    "OD6S.ATTACK_TACKLE": {
-        "attack": 3,
-        "damage": 0
-    }
-}
+OD6S.rangedAttackOptions = rangedAttackOptions;
+OD6S.meleeAttackOptions = meleeAttackOptions;
+OD6S.brawlAttackOptions = brawlAttackOptions;
 
 OD6S.attributes = attributes;
 
-OD6S.ranges = {
-    "OD6S.RANGE_POINT_BLANK_SHORT": {
-        "name": "OD6S.RANGE_POINT_BLANK",
-        "difficulty": -5,
-        "map": "OD6S.DIFFICULTY_VERY_EASY",
-        "item": "pb"
-    },
-    "OD6S.RANGE_SHORT_SHORT": {
-        "name": "OD6S.RANGE_SHORT",
-        "difficulty": 0,
-        "map": "OD6S.DIFFICULTY_EASY",
-        "item": "short"
-    },
-    "OD6S.RANGE_MEDIUM_SHORT": {
-        "name": "OD6S.RANGE_MEDIUM",
-        "difficulty": 5,
-        "map": "OD6S.DIFFICULTY_MODERATE",
-        "item": "medium"
-    },
-    "OD6S.RANGE_LONG_SHORT": {
-        "name": "OD6S.RANGE_LONG",
-        "difficulty": 10,
-        "map": "OD6S.DIFFICULTY_DIFFICULT",
-        "item": "long"
-    }
-}
+OD6S.ranges = ranges;
 
 OD6S.damageTypes = damageTypes;
 
@@ -620,120 +490,10 @@ OD6S.cyberneticsLocations = [
     "OD6S.LEFT_LEG"
 ]
 
-OD6S.allowedItemTypes = {
-    "container": [
-        "armor",
-        "weapon",
-        "gear",
-        "cybernetic",
-        "vehicle-weapon",
-        "vehicle-gear",
-        "starship-weapon",
-        "starship-gear"
-    ],
-    "character": [
-        "skill",
-        "specialization",
-        "advantage",
-        "disadvantage",
-        "specialability",
-        "armor",
-        "weapon",
-        "gear",
-        "cybernetic",
-        "manifestation",
-        "character-template",
-        "species-template",
-    ],
-    "npc": [
-        "skill",
-        "specialization",
-        "advantage",
-        "disadvantage",
-        "specialability",
-        "armor",
-        "weapon",
-        "gear",
-        "cybernetic",
-        "species-template",
-    ],
-    "creature": [
-        "skill",
-        "specialization",
-        "advantage",
-        "disadvantage",
-        "specialability",
-        "armor",
-        "weapon",
-        "gear",
-        "cybernetic"
-    ],
-    "vehicle": [
-        "vehicle-weapon",
-        "vehicle-gear"
-    ],
-    "starship": [
-        "starship-weapon",
-        "starship-gear"
-    ]
-}
-
-OD6S.actorTypeLabels = {
-    "character": "ACTOR.TypeCharacter",
-    "creature": "ACTOR.TypeCreature",
-    "npc": "ACTOR.TypeNpc",
-    "starship": "ACTOR.TypeStarship",
-    "vehicle": "ACTOR.TypeVehicle"
-}
-
-OD6S.templateItemTypes = {
-    "character-template": [
-        "skill",
-        "specialability",
-        "armor",
-        "weapon",
-        "gear",
-        "cybernetic",
-        "manifestation"
-    ],
-    "species-template": [
-        "specialability"
-    ],
-    "item-group": [
-        "skill",
-        "specialability",
-        "armor",
-        "weapon",
-        "gear",
-        "cybernetic",
-        "manifestation",
-        "vehicle-weapon",
-        "vehicle-gear",
-        "starship-weapon",
-        "starship-gear"
-    ]
-}
-
-OD6S.itemLabels = {
-    "skill": "OD6S.SKILL",
-    "specialization": "OD6S.SPECIALIZATION",
-    "advantage": "OD6S.ADVANTAGE",
-    "disadvantage": "OD6S.DISADVANTAGE",
-    "specialability": "OD6S.SPECIAL_ABILITY",
-    "armor": "OD6S.ARMOR",
-    "weapon": "OD6S.WEAPON",
-    "gear": "OD6S.GEAR",
-    "cybernetic": "OD6S.CYBERNETICS",
-    "vehicle": "OD6S.VEHICLE",
-    "manifestation": "OD6S.MANIFESTATION",
-    "character-template": "OD6S.CHARACTER_TEMPLATE",
-    "action": "OD6S.ACTION",
-    "species-template": "ITEM.TypeSpecies-template",
-    "starship-gear": "ITEM.TypeStarship-gear",
-    "starship-weapon": "ITEM.TypeStarship-weapon",
-    "vehicle-gear": "ITEM.TypeVehicle-gear",
-    "vehicle-weapon": "ITEM.TypeVehicle-weapon"
-}
+OD6S.allowedItemTypes = allowedItemTypes;
+OD6S.actorTypeLabels = actorTypeLabels;
+OD6S.templateItemTypes = templateItemTypes;
+OD6S.itemLabels = itemLabels;
 
 OD6S.chatTemplates = {
     "generic": OD6S.chatPath + "generic.html",

--- a/src/module/config/labels.ts
+++ b/src/module/config/labels.ts
@@ -1,0 +1,119 @@
+/**
+ * Static label maps and item-type allowlists for actor sheets, item filters, and template wizards.
+ * Mounted onto `OD6S` by `config-od6s.ts`.
+ */
+
+export const actorTypeLabels = {
+    "character": "ACTOR.TypeCharacter",
+    "creature": "ACTOR.TypeCreature",
+    "npc": "ACTOR.TypeNpc",
+    "starship": "ACTOR.TypeStarship",
+    "vehicle": "ACTOR.TypeVehicle",
+};
+
+export const itemLabels = {
+    "skill": "OD6S.SKILL",
+    "specialization": "OD6S.SPECIALIZATION",
+    "advantage": "OD6S.ADVANTAGE",
+    "disadvantage": "OD6S.DISADVANTAGE",
+    "specialability": "OD6S.SPECIAL_ABILITY",
+    "armor": "OD6S.ARMOR",
+    "weapon": "OD6S.WEAPON",
+    "gear": "OD6S.GEAR",
+    "cybernetic": "OD6S.CYBERNETICS",
+    "vehicle": "OD6S.VEHICLE",
+    "manifestation": "OD6S.MANIFESTATION",
+    "character-template": "OD6S.CHARACTER_TEMPLATE",
+    "action": "OD6S.ACTION",
+    "species-template": "ITEM.TypeSpecies-template",
+    "starship-gear": "ITEM.TypeStarship-gear",
+    "starship-weapon": "ITEM.TypeStarship-weapon",
+    "vehicle-gear": "ITEM.TypeVehicle-gear",
+    "vehicle-weapon": "ITEM.TypeVehicle-weapon",
+};
+
+export const templateItemTypes = {
+    "character-template": [
+        "skill",
+        "specialability",
+        "armor",
+        "weapon",
+        "gear",
+        "cybernetic",
+        "manifestation",
+    ],
+    "species-template": [
+        "specialability",
+    ],
+    "item-group": [
+        "skill",
+        "specialability",
+        "armor",
+        "weapon",
+        "gear",
+        "cybernetic",
+        "manifestation",
+        "vehicle-weapon",
+        "vehicle-gear",
+        "starship-weapon",
+        "starship-gear",
+    ],
+};
+
+export const allowedItemTypes = {
+    "container": [
+        "armor",
+        "weapon",
+        "gear",
+        "cybernetic",
+        "vehicle-weapon",
+        "vehicle-gear",
+        "starship-weapon",
+        "starship-gear",
+    ],
+    "character": [
+        "skill",
+        "specialization",
+        "advantage",
+        "disadvantage",
+        "specialability",
+        "armor",
+        "weapon",
+        "gear",
+        "cybernetic",
+        "manifestation",
+        "character-template",
+        "species-template",
+    ],
+    "npc": [
+        "skill",
+        "specialization",
+        "advantage",
+        "disadvantage",
+        "specialability",
+        "armor",
+        "weapon",
+        "gear",
+        "cybernetic",
+        "species-template",
+    ],
+    "creature": [
+        "skill",
+        "specialization",
+        "advantage",
+        "disadvantage",
+        "specialability",
+        "armor",
+        "weapon",
+        "gear",
+        "cybernetic",
+    ],
+    "vehicle": [
+        "vehicle-weapon",
+        "vehicle-gear",
+    ],
+    "starship": [
+        "starship-weapon",
+        "starship-gear",
+    ],
+};

--- a/src/module/config/weapons.ts
+++ b/src/module/config/weapons.ts
@@ -1,0 +1,103 @@
+/**
+ * Weapon-related static config: type lists, attack-option modifiers, and range bands.
+ * Mounted onto `OD6S` by `config-od6s.ts`.
+ */
+
+export const weaponTypes = [
+    "OD6S.RANGED",
+    "OD6S.MELEE",
+    "OD6S.MISSILE",
+    "OD6S.THROWN",
+    "OD6S.EXPLOSIVE",
+];
+
+export const weaponTypeKeys = [
+    { "key": "OD6S.RANGED", "name": "Ranged" },
+    { "key": "OD6S.MELEE", "name": "Melee" },
+    { "key": "OD6S.MISSILE", "name": "Missile" },
+    { "key": "OD6S.THROWN", "name": "Thrown" },
+    { "key": "OD6S.EXPLOSIVE", "name": "Explosive" },
+];
+
+export const meleeDifficulties = [
+    "OD6S.DIFFICULTY_VERY_EASY",
+    "OD6S.DIFFICULTY_EASY",
+    "OD6S.DIFFICULTY_MODERATE",
+    "OD6S.DIFFICULTY_DIFFICULT",
+    "OD6S.DIFFICULTY_VERY_DIFFICULT",
+    "OD6S.DIFFICULTY_HEROIC",
+];
+
+export const rangedAttackOptions = {
+    "OD6S.ATTACK_STANDARD": {
+        "attack": 0,
+        "damage": 0,
+        "multi": false,
+    },
+    "OD6S.ATTACK_RANGED_SINGLE_FIRE_AS_MULTI": {
+        "attack": -3,
+        "damage": +3,
+        "multi": true,
+    },
+    "OD6S.ATTACK_RANGED_FULL_AUTO": {
+        "attack": -6,
+        "damage": 6,
+        "multi": false,
+    },
+    "OD6S.ATTACK_RANGED_SWEEP": {
+        "attack": -6,
+        "damage": -9,
+        "multi": false,
+    },
+    "OD6S.ATTACK_RANGED_BURST_FIRE_AS_SINGLE": {
+        "attack": 0,
+        "damage": -6,
+        "multi": false,
+    },
+};
+
+export const meleeAttackOptions = {
+    "OD6S.ATTACK_STANDARD": { "attack": 0, "damage": 0, "multi": false },
+    "OD6S.ATTACK_ALL_OUT": { "attack": -6, "damage": 3 },
+    "OD6S.ATTACK_LUNGE": { "attack": 3, "damage": -3 },
+    "OD6S.ATTACK_KNOCKDOWN_TRIP": { "attack": 6, "damage": 0 },
+    "OD6S.ATTACK_PUSH": { "attack": 3, "damage": 0 },
+};
+
+export const brawlAttackOptions = {
+    "OD6S.ATTACK_STANDARD": { "attack": 0, "damage": 0, "multi": false },
+    "OD6S.ATTACK_ALL_OUT": { "attack": -6, "damage": 3 },
+    "OD6S.ATTACK_GRAB": { "attack": 9, "damage": 0 },
+    "OD6S.ATTACK_LUNGE": { "attack": 3, "damage": -3 },
+    "OD6S.ATTACK_KNOCKDOWN_TRIP": { "attack": 6, "damage": 0 },
+    "OD6S.ATTACK_PUSH": { "attack": 3, "damage": 0 },
+    "OD6S.ATTACK_SWEEP": { "attack": -6, "damage": -9 },
+    "OD6S.ATTACK_TACKLE": { "attack": 3, "damage": 0 },
+};
+
+export const ranges = {
+    "OD6S.RANGE_POINT_BLANK_SHORT": {
+        "name": "OD6S.RANGE_POINT_BLANK",
+        "difficulty": -5,
+        "map": "OD6S.DIFFICULTY_VERY_EASY",
+        "item": "pb",
+    },
+    "OD6S.RANGE_SHORT_SHORT": {
+        "name": "OD6S.RANGE_SHORT",
+        "difficulty": 0,
+        "map": "OD6S.DIFFICULTY_EASY",
+        "item": "short",
+    },
+    "OD6S.RANGE_MEDIUM_SHORT": {
+        "name": "OD6S.RANGE_MEDIUM",
+        "difficulty": 5,
+        "map": "OD6S.DIFFICULTY_MODERATE",
+        "item": "medium",
+    },
+    "OD6S.RANGE_LONG_SHORT": {
+        "name": "OD6S.RANGE_LONG",
+        "difficulty": 10,
+        "map": "OD6S.DIFFICULTY_DIFFICULT",
+        "item": "long",
+    },
+};

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -36,8 +36,7 @@ export function registerChatLogListeners() {
             } else {
                 content!.style.display = "block";
             }
-            // @ts-expect-error
-            game!.messages.get(ev.currentTarget.dataset.messageId).render();
+            game!.messages.get(ev.currentTarget.dataset.messageId)?.render();
         })
 
         delegateEvent(html, "click", ".damage-modifiers-button", async (ev: any) => {
@@ -47,8 +46,7 @@ export function registerChatLogListeners() {
             } else {
                 content!.style.display = "block";
             }
-            // @ts-expect-error
-            game!.messages.get(ev.currentTarget.dataset.messageId).render();
+            game!.messages.get(ev.currentTarget.dataset.messageId)?.render();
         })
 
         delegateEvent(html, "click", ".apply-damage-button", async (ev: any) => {
@@ -121,9 +119,9 @@ export function registerChatLogListeners() {
 
         delegateEvent(html, 'click', '.remove-template-button', async (ev: any) => {
             const message =  await game.messages.get(ev.currentTarget.dataset.messageId);
-            const actor = message!.speaker.token === null ?
-                // @ts-expect-error
-                game.actors.get(message!.speaker.actor) : game!.scenes.active.tokens.get(message!.speaker.token).actor;
+            const actor = message!.speaker.token === null
+                ? game.actors.get(message!.speaker.actor)
+                : game!.scenes.active.tokens.get(message!.speaker.token)?.actor;
             const item = actor!.items.get(message!.getFlag('od6s','itemId'));
             const regionId = item!.getFlag('od6s','explosiveTemplate');
             const region = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
@@ -353,11 +351,9 @@ export function registerChatLogListeners() {
 
         delegateEvent(html, "change", ".explosive-target-zone", async (ev: any) => {
             const message = game.messages.get(ev.currentTarget.dataset.messageId);
-            const targets = Array.from(message!.getFlag('od6s','targets'));
+            const targets = Array.from(message!.getFlag('od6s','targets')) as Array<{ id: string; zone?: number }>;
             for (const t in targets) {
-                // @ts-expect-error
                 if(ev.currentTarget.dataset.targetId === targets[t].id) {
-                    // @ts-expect-error
                     targets[t].zone = parseInt(ev.target.value);
                 }
             }

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -65,7 +65,7 @@ export function registerChatLogListeners() {
             const stunEffect = msg!.getFlag('od6s', 'stunEffect');
 
             if ((actor.type !== 'vehicle' && actor.type !== 'starship') && (isVehicle === true || isVehicle === 'true')) {
-                actor = await od6sutilities.getActorFromUuid(actor.system.vehicle.uuid);
+                actor = await od6sutilities.getActorFromUuid((actor.system as OD6SCharacterSystem).vehicle.uuid);
             }
 
             if (od6sutilities.boolCheck(stun)) {
@@ -78,12 +78,12 @@ export function registerChatLogListeners() {
                         const update: any = {}
                         update[`system.stuns.current`] = 1;
                         update[`system.stuns.rounds`] = 1;
-                        update[`system.stuns.value`] = (+actor!.system.stuns.value) + 1;
+                        update[`system.stuns.value`] = (+(actor!.system as OD6SCharacterSystem).stuns.value) + 1;
                         await actor!.update(update);
                     } else if (stunEffect === '-2D') {
                         (update as any)[`system.stuns.current`] = 2;
                         (update as any)[`system.stuns.rounds`] = 1;
-                        (update as any)[`system.stuns.value`] = (+actor!.system.stuns.value) + 1;
+                        (update as any)[`system.stuns.value`] = (+(actor!.system as OD6SCharacterSystem).stuns.value) + 1;
                         await actor!.update(update);
                     }
                     if(!actor!.effects.contents.find(
@@ -103,7 +103,7 @@ export function registerChatLogListeners() {
                         await actor!.applyWounds(result);
                     }
                 } else {
-                    let bp = actor!.system.wounds.body_points.current - result;
+                    let bp = (actor!.system as OD6SCharacterSystem).wounds.body_points.current - result;
                     if (bp < 0) bp = 0;
                     (update as any)['system.wounds.body_points.current'] = bp;
                     if (game.settings.get('od6s', 'bodypoints') === 1) await actor!.setWoundLevelFromBodyPoints(bp);

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -386,7 +386,7 @@ export function registerChatLogListeners() {
             await message!.setFlag('od6s', 'isKnown', true);
             if(message!.getFlag('od6s','isExplosive') && game.settings.get('od6s','auto_explosive')) {
                 // Reveal the explosive region
-                const region = od6sutilities.getTemplateFromMessage(message).template;
+                const region = od6sutilities.getTemplateFromMessage(message!).template;
                 if(region) {
                     await region.update({ visibility: 2 }); // Make visible to all
                 }

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -89,16 +89,14 @@ export class OD6SItem extends Item {
             if (this.actor) {
                 let score = this.actor.system.attributes[this.system.stats.attribute.toLowerCase()].score;
                 const spec = this.actor.items.find(i => i.name === this.system.stats.specialization && i.type === 'specialization');
-                // @ts-expect-error
-                if (typeof spec !== 'undefined' && spec !== '') {
+                if (typeof spec !== 'undefined') {
                     if (typeof this.system.fire_control !== 'undefined' && this.system.fire_control?.score !== '') {
                         score = score + this.system.fire_control.score;
                     }
                     return score + spec.system.score;
                 } else {
                     const skill = this.actor.items.find(i => i.name === this.system.stats.skill && i.type === 'skill');
-                    // @ts-expect-error
-                    if (typeof skill !== 'undefined' && skill !== '') {
+                    if (typeof skill !== 'undefined') {
                         if (typeof this.system.fire_control !== 'undefined' && this.system.fire_control?.score !== '') {
                             score = score + this.system.fire_control.score;
                         }
@@ -122,14 +120,12 @@ export class OD6SItem extends Item {
             if (this.actor) {
                 if (this.system.stats.parry_specialization !== '') {
                     const spec = this.actor.items.find(s => s.name === this.system.stats.parry_specialization && s.type === 'specialization');
-                    // @ts-expect-error
-                    if (typeof spec !== 'undefined' && spec !== '') return spec!.getScoreText();
+                    if (typeof spec !== 'undefined') return spec.getScoreText();
                 }
                 if (this.system.stats.parry_skill !== '') {
                     if(this.actor) {
                         const skill = this.actor.items.find(s=>s.name === this.system.stats.parry_skill && s.type === 'skill' );
-                        // @ts-expect-error
-                        if (typeof skill !== 'undefined' && skill !== '') return skill!.getScoreText();
+                        if (typeof skill !== 'undefined') return skill.getScoreText();
                     }
                 }
                 return this.actor.getActionScoreText('parry')

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -208,8 +208,9 @@ export class OD6SItem extends Item {
     async roll(parry = false) {
         // Basic template rendering data
         const item = this;
-        const actor = this.actor ? this.actor : {};
-        const actorData = (this.actor?.system ?? {}) as OD6SCharacterSystem & Record<string, any>;
+        if (!this.actor) return;
+        const actor = this.actor;
+        const actorData = actor.system as OD6SCharacterSystem & Record<string, any>;
         const itemData = item.system;
         let flatPips = 0;
 
@@ -240,12 +241,12 @@ export class OD6SItem extends Item {
                 if (parry && game.settings.get('od6s','parry_skills')) {
                     let skill;
                     if(typeof(this.system.stats.parry_specialization) !== "undefined" && this.system.stats.parry_specialization !== "") {
-                        skill = (actor as any).items.find((skill: any) => skill.name === this.system.stats.parry_specialization && skill.type === 'specialization');
+                        skill = actor.items.find((skill: Item) => skill.name === this.system.stats.parry_specialization && skill.type === 'specialization');
                     }
                     else if(typeof(this.system.stats.parry_skill) !== "undefined" && this.system.stats.parry_skill !== "") {
-                    	skill = (actor as any).items.find((skill: any) => skill.name === this.system.stats.parry_skill && skill.type === 'skill');
+                    	skill = actor.items.find((skill: Item) => skill.name === this.system.stats.parry_skill && skill.type === 'skill');
                      } else {
-                    	skill = (actor as any).items.find((skill: any) => skill.name === game.i18n.localize(OD6S.actions.parry.skill) && skill.type === 'skill');
+                    	skill = actor.items.find((skill: Item) => skill.name === game.i18n.localize(OD6S.actions.parry.skill) && skill.type === 'skill');
                     }
                     if (skill) {
                         if(OD6S.flatSkills) {
@@ -261,7 +262,7 @@ export class OD6SItem extends Item {
                 }
 
                 if (!found && itemData.stats.specialization !== null) {
-                    const spec = (actor as any).items.find((spec: any) => spec.name === itemData.stats.specialization && spec.type === 'specialization');                    if (spec) {
+                    const spec = actor.items.find((spec: Item) => spec.name === itemData.stats.specialization && spec.type === 'specialization');                    if (spec) {
                         if(OD6S.flatSkills) {
                             rollData.score = (+actorData.attributes[spec.system.attribute.toLowerCase()].score);
                             flatPips = (+spec.system.score);
@@ -273,7 +274,7 @@ export class OD6SItem extends Item {
                 }
                 if (!found) {
                     // See if the actor has the associated skill
-                    const skill = (actor as any).items.find((skill: any) => skill.name === itemData.stats.skill && skill.type === 'skill');
+                    const skill = actor.items.find((skill: Item) => skill.name === itemData.stats.skill && skill.type === 'skill');
                     let attr = actorData.attributes[itemData.stats.attribute.toLowerCase()];
                     if(typeof(attr?.score) === "undefined" || attr === null) {
                         // See if it maps to the "shortname" of a custom attribute label
@@ -307,8 +308,8 @@ export class OD6SItem extends Item {
                 let name = '';
                 if ((itemData.subtype === 'rangedattack' || itemData.subtype === 'meleeattack') && itemData.itemId !== '') {
                     // Roll is linked to an inventory item, roll that instead
-                    const targetItem = (actor as any).items.find((i: any) => i.id === itemData.itemId);
-                    return targetItem.roll(parry);
+                    const targetItem = actor.items.find((i: Item) => i.id === itemData.itemId);
+                    return targetItem?.roll(parry);
                 }
 
                 if (itemData.subtype === 'dodge' || itemData.subtype === 'parry' || itemData.subtype === 'block') {
@@ -318,9 +319,9 @@ export class OD6SItem extends Item {
                             name = 'OD6S.DODGE';
                             break;
                         case 'parry':
-                            if ((actor as any).items.find((i: any) => i.id === itemData.itemId)) {
-                                const targetItem = (actor as any).items.find((i: any) => i.id === itemData.itemId);
-                                return targetItem.roll(true);
+                            if (actor.items.find((i: Item) => i.id === itemData.itemId)) {
+                                const targetItem = actor.items.find((i: Item) => i.id === itemData.itemId);
+                                return targetItem?.roll(true);
                             } else {
                                 name = OD6S.actions.parry.skill;
                             }
@@ -339,9 +340,9 @@ export class OD6SItem extends Item {
                     //let name = item.name;
                     name = game.i18n.localize(name);
                     if (typeof (itemData.itemId) !== 'undefined' && itemData.itemId !== '') {
-                        skill = (actor as any).items.find((i: any) => i.type === itemData.subtype && i.id === itemData.itemId);
+                        skill = actor.items.find((i: Item) => i.type === itemData.subtype && i.id === itemData.itemId);
                     } else {
-                        skill = (actor as any).items.find((i: any) => i.name === name);
+                        skill = actor.items.find((i: Item) => i.name === name);
                     }
                     if (skill !== null && typeof (skill) !== 'undefined' && typeof ((skill as any).system.score) !== 'undefined') {
                         if(OD6S.flatSkills) {
@@ -368,8 +369,7 @@ export class OD6SItem extends Item {
                                 // Cannot find, use defaults for the type
                                 for (const a in OD6S.actions) {
                                     if (OD6S.actions[a].type === itemData.subtype) {
-                                        // @ts-expect-error
-                                        rollData.score = (+this!.actor.system.attributes[OD6S.actions[a].base].score);
+                                        rollData.score = (+actorData.attributes[OD6S.actions[a].base].score);
                                         break;
                                     }
                                 }

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -167,7 +167,7 @@ export async function promptResistanceRolls(msg: any) {
         if (typeof (target) !== 'undefined' && target) {
             if (target.actor.type === 'starship' || target.actor.type === 'vehicle') {
                 if(!target.actor.isOwner) return;
-                const crew = await od6sutilities.getActorFromUuid(target.actor.system.crewmembers[0].uuid);
+                const crew = await od6sutilities.getActorFromUuid((target.actor.system as OD6SVehicleSystem).crewmembers[0].uuid);
                 if (typeof (crew) !== 'undefined' || crew !== null) {
                     if (crew?.hasPlayerOwner && crew?.isOwner) {
                         return crew.rollAction('vehicletoughness', msg);

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -25,9 +25,9 @@ async function triggerRoll(type: string, actorId: string) {
     if (!actor) return;
     if (type === 'mortally_wounded') {
         if (actor.hasPlayerOwner && actor.isOwner && !game.user.isGM) {
-            (actor as any).triggerMortallyWoundedCheck();
+            actor.triggerMortallyWoundedCheck();
         } else if (!actor.hasPlayerOwner && game.user.isGM) {
-            (actor as any).triggerMortallyWoundedCheck();
+            actor.triggerMortallyWoundedCheck();
         }
     }
 }
@@ -35,7 +35,7 @@ async function triggerRoll(type: string, actorId: string) {
 async function triggerRollAction(type: string, actorId: string) {
     const actor = game.actors.get(actorId);
     if (!actor) return;
-    return await (actor as any).rollAction(type);
+    return await actor.rollAction(type);
 }
 
 export async function updateExplosiveRegion(data: any) {
@@ -68,7 +68,7 @@ export async function deleteExplosiveRegion(data: any) {
 async function checkCrewStatus(actorId: string) {
     const actor = await od6sutilities.getActorFromUuid(actorId);
     if (!actor) return false;
-    return (actor as any).isCrewMember();
+    return actor.isCrewMember();
 }
 
 /**
@@ -119,7 +119,7 @@ async function unlinkCrew(crewId: string, vehicleId: string) {
 async function addToVehicle(vehicleId: string, crewId: string) {
     const actor = await od6sutilities.getActorFromUuid(crewId);
     if (!actor) return;
-    return await (actor as any).addToCrew(vehicleId);
+    return await actor.addToCrew(vehicleId);
 }
 
 /**

--- a/src/module/system/handlebars/display.ts
+++ b/src/module/system/handlebars/display.ts
@@ -141,8 +141,7 @@ export function registerDisplayHelpers() {
 
     Handlebars.registerHelper('isGmOrOwner', function (id) {
         if (game.user.isGM) return true;
-        // @ts-expect-error
-        return game!.actors.find(a => a.id === id).isOwner;
+        return game!.actors.find(a => a.id === id)?.isOwner;
     })
 
     Handlebars.registerHelper('isKnown', function (isKnown) {
@@ -202,12 +201,10 @@ export function registerDisplayHelpers() {
     })
 
     Handlebars.registerHelper('getCharacterInventoryForContainer', function () {
-        // @ts-expect-error
-        return game!.user.character.items.filter(i => OD6S.equippable.includes(i.type));
+        return game!.user.character?.items.filter(i => OD6S.equippable.includes(i.type));
     })
 
     Handlebars.registerHelper('getCharacterActorId', function () {
-        // @ts-expect-error
-        return game!.user.character.id;
+        return game!.user.character?.id;
     })
 }

--- a/src/module/system/utilities.ts
+++ b/src/module/system/utilities.ts
@@ -13,13 +13,13 @@ import * as opposedUtils from "./utilities/opposed";
 import * as miscUtils from "./utilities/misc";
 
 export const od6sutilities = {
-    accessDeepProp(obj: any, path: any) {
+    accessDeepProp(obj: Record<string, unknown>, path: string) {
         return converterUtils.accessDeepProp(obj, path);
     },
-    async getWeaponRange(actor: any, item: any) {
+    async getWeaponRange(actor: Actor, item: Item) {
         return weaponUtils.getWeaponRange(actor, item);
     },
-    lookupAttributeKey(id: any) {
+    lookupAttributeKey(id: string) {
         return miscUtils.lookupAttributeKey(id);
     },
     async scatterExplosive(range: any, origin: any, regionId: any) {
@@ -37,22 +37,22 @@ export const od6sutilities = {
     getBlastRadius(item: any, range: any) {
         return explosiveUtils.getBlastRadius(item, range);
     },
-    getDiceFromScore(score: any) {
+    getDiceFromScore(score: number) {
         return diceUtils.getDiceFromScore(score, OD6S.pipsPerDice);
     },
-    getTextFromDice(dice: any) {
+    getTextFromDice(dice: { dice: number; pips: number }) {
         return diceUtils.getTextFromDice(dice);
     },
-    getScoreFromDice(dice: any, pips: any) {
+    getScoreFromDice(dice: number, pips: number) {
         return diceUtils.getScoreFromDice(dice, pips, OD6S.pipsPerDice);
     },
-    async getDifficultyFromLevel(level: any) {
+    async getDifficultyFromLevel(level: string) {
         return difficultyUtils.getDifficultyFromLevel(level);
     },
-    getWoundPenalty(actor: any) {
+    getWoundPenalty(actor: Actor) {
         return woundUtils.getWoundPenalty(actor);
     },
-    getWoundLevel(value: any, actor: any) {
+    getWoundLevel(value: number, actor: Actor) {
         return woundUtils.getWoundLevel(value, actor);
     },
     getDifficultyLevelSelect() {
@@ -64,82 +64,82 @@ export const od6sutilities = {
     getActiveAttributesSelect() {
         return actorUtils.getActiveAttributesSelect();
     },
-    async getSkillsFromTemplate(items: any) {
+    async getSkillsFromTemplate(items: Item[]) {
         return itemUtils.getSkillsFromTemplate(items);
     },
-    async _getItemFromCompendiumId(id: any) {
+    async _getItemFromCompendiumId(id: string) {
         return itemUtils._getItemFromCompendiumId(id);
     },
-    async _getItemFromCompendium(itemName: any) {
+    async _getItemFromCompendium(itemName: string) {
         return itemUtils._getItemFromCompendium(itemName);
     },
-    async _getItemFromWorld(itemName: any) {
+    async _getItemFromWorld(itemName: string) {
         return itemUtils._getItemFromWorld(itemName);
     },
-    async getItemByName(itemName: any) {
+    async getItemByName(itemName: string) {
         return itemUtils.getItemByName(itemName);
     },
-    getItemsFromCompendiumByType(itemType: any) {
+    getItemsFromCompendiumByType(itemType: OD6SItemType) {
         return itemUtils.getItemsFromCompendiumByType(itemType);
     },
-    getItemsFromWorldByType(itemType: any) {
+    getItemsFromWorldByType(itemType: OD6SItemType) {
         return itemUtils.getItemsFromWorldByType(itemType);
     },
-    getAllItemsByType(itemType: any) {
+    getAllItemsByType(itemType: OD6SItemType) {
         return itemUtils.getAllItemsByType(itemType);
     },
     mergeByProperty(target: any, source: any, prop: any) {
         return itemUtils.mergeByProperty(target, source, prop);
     },
-    async getActorFromUuid(uuid: any) {
+    async getActorFromUuid(uuid: string) {
         return actorUtils.getActorFromUuid(uuid);
     },
-    async getTokenFromUuid(uuid: any) {
+    async getTokenFromUuid(uuid: string) {
         return actorUtils.getTokenFromUuid(uuid);
     },
-    getScoreFromSkill(actor: any, spec: any, skill: any, attribute: any) {
+    getScoreFromSkill(actor: Actor, spec: string, skill: string, attribute: string) {
         return skillUtils.getScoreFromSkill(actor, spec, skill, attribute);
     },
-    getSensorTotal(actor: any, score: any) {
+    getSensorTotal(actor: Actor, score: number) {
         return skillUtils.getSensorTotal(actor, score);
     },
-    async autoOpposeRoll(msg: any) {
+    async autoOpposeRoll(msg: ChatMessage) {
         return opposedUtils.autoOpposeRoll(msg);
     },
     async handleOpposedRoll() {
         return opposedUtils.handleOpposedRoll();
     },
-    async generateOpposedRoll(token: any, msg: any) {
+    async generateOpposedRoll(token: TokenDocument, msg: ChatMessage) {
         return opposedUtils.generateOpposedRoll(token, msg);
     },
-    getActorOwner(actor: any) {
+    getActorOwner(actor: Actor) {
         return actorUtils.getActorOwner(actor);
     },
-    getInjury(damage: any, actorType: any) {
+    getInjury(damage: number, actorType: OD6SActorType | "system") {
         return woundUtils.getInjury(damage, actorType);
     },
-    waitFor3DDiceMessage(targetMessageId: any) {
+    waitFor3DDiceMessage(targetMessageId: string) {
         return miscUtils.waitFor3DDiceMessage(targetMessageId);
     },
-    async handleEffectChange(effect: any) {
+    async handleEffectChange(effect: ActiveEffect) {
         return effectUtils.handleEffectChange(effect);
     },
-    getTemplateFromMessage(message: any) {
+    getTemplateFromMessage(message: ChatMessage) {
         return miscUtils.getTemplateFromMessage(message);
     },
-    async wait(ms: any) {
+    async wait(ms: number) {
         return converterUtils.wait(ms);
     },
-    getMeleeDamage(actor: any, weapon: any) {
+    getMeleeDamage(actor: Actor, weapon: Item) {
         return weaponUtils.getMeleeDamage(actor, weapon);
     },
-    evaluateChange(change: any, caller: any) {
+    evaluateChange(change: ActiveEffectChange, caller: Actor | Item) {
         return effectUtils.evaluateChange(change, caller);
     },
-    applyDerivedEffect(obj: any, change: any) {
+    applyDerivedEffect(obj: Actor, change: ActiveEffectChange) {
         return effectUtils.applyDerivedEffect(obj, change);
     },
-    boolCheck(value: any) {
+    boolCheck(value: unknown) {
         return converterUtils.boolCheck(value);
     },
 };

--- a/src/module/system/utilities/actors.ts
+++ b/src/module/system/utilities/actors.ts
@@ -35,8 +35,7 @@ export async function getTokenFromUuid(uuid: string): Promise<TokenDocument | un
 }
 
 export function getActorOwner(actor: Actor): User | undefined {
-    // @ts-expect-error getProperty is a Foundry VTT global
-    const permissionObject = getProperty(actor ?? {}, "ownership") ?? {};
+    const permissionObject = foundry.utils.getProperty(actor ?? {}, "ownership") ?? {};
 
     const playerOwners = Object.entries(permissionObject)
         .filter(

--- a/src/module/system/utilities/opposed.ts
+++ b/src/module/system/utilities/opposed.ts
@@ -261,11 +261,12 @@ export async function generateOpposedRoll(token: TokenDocument, msg: ChatMessage
         if (msg.getFlag('od6s', 'type') === 'damage' || msg.getFlag('od6s','type') === 'explosive') {
             const type = msg.getFlag('od6s', 'damageType');
             if (token.actor.type === 'vehicle' || token.actor.type === 'starship') {
-                if (token.actor.system.embedded_pilot.value || token.actor.system.crewmembers.length < 1) {
+                const sys = token.actor.system as OD6SVehicleSystem;
+                if (sys.embedded_pilot.value || sys.crewmembers.length < 1) {
                     await token.actor.rollAction('vehicletoughness', msg);
                     return;
                 } else {
-                    const actor = await getActorFromUuid(token.actor.system.crewmembers[0].uuid);
+                    const actor = await getActorFromUuid(sys.crewmembers[0].uuid);
                     await actor!.rollAction('vehicletoughness', msg);
                     return;
                 }

--- a/src/module/system/utilities/opposed.ts
+++ b/src/module/system/utilities/opposed.ts
@@ -59,9 +59,9 @@ export async function autoOpposeRoll(msg: ChatMessage): Promise<void> {
 }
 
 export async function handleOpposedRoll(): Promise<void> {
-    let type: any;
-    let winner: any;
-    let loser: any;
+    let type: string;
+    let winner: ChatMessage;
+    let loser: ChatMessage;
     let result: any;
     let damageFlavor;
     let stunned = false;
@@ -69,10 +69,10 @@ export async function handleOpposedRoll(): Promise<void> {
     data.flags = {};
     let collision: any;
     let passengerDamage = '';
-    const message1 = await game.messages.get(getOpposedQueueEntry(0).messageId);
-    const message2 = await game.messages.get(getOpposedQueueEntry(1).messageId);
-    const messageType1 = message1!.getFlag('od6s', 'type');
-    const messageType2 = message2!.getFlag('od6s', 'type');
+    const message1 = (await game.messages.get(getOpposedQueueEntry(0).messageId))!;
+    const message2 = (await game.messages.get(getOpposedQueueEntry(1).messageId))!;
+    const messageType1 = message1.getFlag('od6s', 'type');
+    const messageType2 = message2.getFlag('od6s', 'type');
     clearOpposedQueue();
 
     if (((messageType1 === 'damage' || messageType1 === 'explosive') && message2!.getFlag('od6s', 'type') === 'resistance') ||
@@ -124,7 +124,7 @@ export async function handleOpposedRoll(): Promise<void> {
                 loser = message1;
             }
         } else {
-            const targetId =  message1!.speaker.token !== null ? message1!.speaker.token : (message1 as any).speaker.actor;
+            const targetId = message1!.speaker.token !== null ? message1!.speaker.token : message1!.speaker.actor;
             const damage = message2!.getFlag('od6s', 'targets').find((t: any) =>t.id === targetId).damage;
             const resistance = message1!.rolls[0].total;
             if (damage > resistance) {
@@ -148,11 +148,11 @@ export async function handleOpposedRoll(): Promise<void> {
     const stun = await message1!.getFlag('od6s', 'stun') || await message2!.getFlag('od6s', 'stun');
     let stunEffect = 'unconscious';
 
-    const diff = (+(winner as any).rolls[0].total) - (+(loser as any).rolls[0].total);
+    const diff = (+winner.rolls[0].total) - (+loser.rolls[0].total);
 
     if (type === "damageresult") {
 
-        if ((loser as any).actorType === "vehicle" || (loser as any).actorType === "starship") {
+        if (loser.actorType === "vehicle" || loser.actorType === "starship") {
             damageFlavor = game.i18n.localize('OD6S.DAMAGES');
         } else {
             if (boolCheck(data.stun)) {
@@ -162,14 +162,14 @@ export async function handleOpposedRoll(): Promise<void> {
             }
         }
 
-        if ((winner as any).getFlag('od6s', 'type') === "damage" || (winner as any).getFlag('od6s', 'type') === 'explosive') {
+        if (winner.getFlag('od6s', 'type') === "damage" || winner.getFlag('od6s', 'type') === 'explosive') {
             if (boolCheck(stun)) {
-                data.content = (winner as any).alias + " " + damageFlavor + " " + (loser as any).flavorName;
+                data.content = winner.alias + " " + damageFlavor + " " + loser.flavorName;
                 stunned = true;
                 if (OD6S.stunScaling) {
-                    if ((winner as any).rolls[0].total >= (3 * (loser as any).rolls[0].total)) {
+                    if (winner.rolls[0].total >= (3 * loser.rolls[0].total)) {
                         stunEffect = 'unconscious';
-                    } else if ((winner as any).rolls[0].total >= (2 * (loser as any).rolls[0].total)) {
+                    } else if (winner.rolls[0].total >= (2 * loser.rolls[0].total)) {
                         stunEffect = '-2D';
                     } else {
                         stunEffect = '-1D';
@@ -179,10 +179,10 @@ export async function handleOpposedRoll(): Promise<void> {
                 if (stunEffect === 'unconscious') {
                     if (OD6S.stunDice) {
                         const roll = await new Roll("2d6").evaluate();
-                        result = (loser as any).flavorName + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_01') +
+                        result = loser.flavorName + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_01') +
                             roll.total + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_02');
                     } else {
-                        result = (loser as any).flavorName + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_01') +
+                        result = loser.flavorName + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_01') +
                             diff + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_02');
                     }
                 } else {
@@ -193,19 +193,19 @@ export async function handleOpposedRoll(): Promise<void> {
                     }
                 }
             } else {
-                data.content = (winner as any).alias + " " + damageFlavor + " " + (loser as any).flavorName;
-                if (OD6S.woundConfig > 0 && (loser as any).actorType !== 'vehicle' && (loser as any).actorType !== 'starship') {
+                data.content = winner.alias + " " + damageFlavor + " " + loser.flavorName;
+                if (OD6S.woundConfig > 0 && loser.actorType !== 'vehicle' && loser.actorType !== 'starship') {
                     result = diff;
                 } else {
-                    result = getInjury(diff, (loser as any).actorType);
+                    result = getInjury(diff, loser.actorType!);
                 }
             }
         } else {
-            data.content = (winner as any).alias + " " + game.i18n.localize("OD6S.RESISTS") + " " + (loser as any).alias;
-            if ((winner as any).actorType === "vehicle" || (winner as any).actorType === "starship") {
+            data.content = winner.alias + " " + game.i18n.localize("OD6S.RESISTS") + " " + loser.alias;
+            if (winner.actorType === "vehicle" || winner.actorType === "starship") {
                 result = 'OD6S.NO_DAMAGE';
             } else {
-                if (OD6S.woundConfig > 0 && (loser as any).actorType !== 'vehicle' && (loser as any).actorType !== 'starship') {
+                if (OD6S.woundConfig > 0 && loser.actorType !== 'vehicle' && loser.actorType !== 'starship') {
                     result = 0;
                 } else {
                     result = 'OD6S.NO_INJURY';
@@ -213,17 +213,17 @@ export async function handleOpposedRoll(): Promise<void> {
             }
         }
     } else {
-        data.flavor = (message1 as any).alias + " " + game.i18n.localize("OD6S.VS") + " " + (message2 as any).alias;
-        data.content = (winner as any).alias + " " + game.i18n.localize("OD6S.WINS");
+        data.flavor = message1!.alias + " " + game.i18n.localize("OD6S.VS") + " " + message2!.alias;
+        data.content = winner.alias + " " + game.i18n.localize("OD6S.WINS");
     }
 
-    let loserId = (loser as any).speaker.token;
-    if ((loser as any).actorType === "vehicle" || (loser as any).actorType === "starship") {
-        const token = await getTokenFromUuid((loser as any).getFlag('od6s','vehicle'));
+    let loserId: string | Actor | undefined = loser.speaker.token;
+    if (loser.actorType === "vehicle" || loser.actorType === "starship") {
+        const token = await getTokenFromUuid(loser.getFlag('od6s','vehicle'));
         if (typeof (token) !== 'undefined') {
             loserId = token.id;
         } else {
-            loserId = await getActorFromUuid((loser as any).getFlag('od6s', 'vehicle'));
+            loserId = await getActorFromUuid(loser.getFlag('od6s', 'vehicle'));
         }
         if (OD6S.passengerDamageDice) {
             passengerDamage = OD6S.vehicle_damage[result].passenger_damage_dice + "D";
@@ -233,7 +233,7 @@ export async function handleOpposedRoll(): Promise<void> {
     }
 
     let apply = false;
-    if (OD6S.woundConfig > 0 && (loser as any).actorType !== 'vehicle' && (loser as any).actorType !== 'starship') {
+    if (OD6S.woundConfig > 0 && loser.actorType !== 'vehicle' && loser.actorType !== 'starship') {
         if (result > 0 || stunned) apply = true;
     } else if (result !== 'OD6S.NO_INJURY' && result !== 'OD6S.NO_DAMAGE') {
         apply = true;
@@ -248,7 +248,7 @@ export async function handleOpposedRoll(): Promise<void> {
         "applied": false,
         "stun": boolCheck(stun),
         "stunEffect": stunEffect,
-        "loserIsVehicle": (loser as any).actorType === 'vehicle' || (loser as any).actorType === 'starship',
+        "loserIsVehicle": loser.actorType === 'vehicle' || loser.actorType === 'starship',
         "loserId": loserId,
         "isCollision": collision,
         "passengerDamage": passengerDamage

--- a/src/module/system/utilities/skills.ts
+++ b/src/module/system/utilities/skills.ts
@@ -30,9 +30,10 @@ export function getScoreFromSkill(actor: Actor, spec: string, skill: string, att
 export function getSensorTotal(actor: Actor, score: number): number {
     let skillName = '';
     if (actor.getFlag('od6s', 'crew')) {
-        if (typeof (actor.system.vehicle.sensors.skill) !== 'undefined'
-            && actor.system.vehicle.sensors.skill !== '') {
-            skillName = actor.system.vehicle.sensors.skill
+        const sys = actor.system as OD6SCharacterSystem & { vehicle: { sensors?: { skill?: string } } };
+        if (typeof (sys.vehicle.sensors?.skill) !== 'undefined'
+            && sys.vehicle.sensors.skill !== '') {
+            skillName = sys.vehicle.sensors.skill;
         }
     }
     if (skillName === '') {

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -112,7 +112,7 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
 
 export function getMeleeDamage(actor: Actor, weapon: Item): number {
     if (weapon.system.damage.str) {
-        return (+actor.system.strengthdamage.score) + (+weapon.system.damage.score);
+        return (+(actor.system as OD6SCharacterSystem).strengthdamage.score) + (+weapon.system.damage.score);
     } else {
         return (+weapon.system.damage.score);
     }

--- a/src/module/system/utilities/wounds.ts
+++ b/src/module/system/utilities/wounds.ts
@@ -66,7 +66,7 @@ export function getWoundPenalty(actor: Actor): number {
             : 'deadliness';
         deadlinessLevel = game.settings.get('od6s', settingKey) as number;
     }
-    return lookupWoundPenalty(OD6S.deadliness[deadlinessLevel], actor.system.wounds.value);
+    return lookupWoundPenalty(OD6S.deadliness[deadlinessLevel], (actor.system as OD6SCharacterSystem).wounds.value);
 }
 
 export function getWoundLevel(value: number, actor: Actor): string {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "od6s",
   "title": "OpenD6 Space",
   "description": "OpenD6 Space System for FoundryVTT",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360",

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -96,6 +96,13 @@ declare namespace foundry {
             function HandlebarsApplicationMixin<T extends new (...args: any[]) => any>(
                 base: T
             ): T & typeof ApplicationV2;
+
+            class DialogV2 {
+                static input(options: any): Promise<any>;
+                static confirm(options: any): Promise<boolean>;
+                static prompt(options: any): Promise<any>;
+                static wait(options: any): Promise<any>;
+            }
         }
 
         namespace sheets {
@@ -144,6 +151,7 @@ declare namespace foundry {
 
         namespace handlebars {
             function loadTemplates(paths: string[] | Record<string, string>): Promise<Function[]>;
+            function renderTemplate(path: string, data?: object): Promise<string>;
         }
     }
 

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -108,6 +108,8 @@ interface OD6SVehicleSystem {
     embedded_pilot: { value: boolean };
     crewmembers: Array<{ uuid: string; name?: string }>;
     crew: { value: number };
+    /** Vehicle/starship damage state — wound-table key. */
+    damage: { value: string };
     roll_mod: number;
     use_wild_die: boolean;
 }

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -248,7 +248,7 @@ interface Item {
  */
 interface ChatMessage {
     /** Type of the speaking actor (set during opposed-roll handling). */
-    actorType?: string;
+    actorType?: OD6SActorType | "system";
 
     /** Display name for the speaker, swapped to vehicle name in vehicle rolls. */
     flavorName?: string;

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -79,8 +79,18 @@ interface OD6SCharacterSystem {
     initiative: { score: number; mod: number; formula: string };
     use_wild_die: boolean;
     roll_mod: number;
+    characterpoints: { value: number };
+    fatepoints: { value: number };
+    customeffects: {
+        skills: Record<string, number>;
+        specializations: Record<string, number>;
+    };
     /** Crewmember actors carry a reference back to their vehicle. */
     vehicle: { uuid: string; name?: string; scale?: OD6SScoreField; vehicle_weapons?: any[] };
+    /** Container actors expose a per-player visibility flag. */
+    visible?: boolean;
+    /** Created marker on character actors. */
+    created?: { value: boolean };
 }
 
 /** System data for vehicle and starship actor types. */
@@ -97,6 +107,7 @@ interface OD6SVehicleSystem {
     ram_damage: OD6SScoreField;
     embedded_pilot: { value: boolean };
     crewmembers: Array<{ uuid: string; name?: string }>;
+    crew: { value: number };
     roll_mod: number;
     use_wild_die: boolean;
 }
@@ -138,7 +149,7 @@ interface Actor {
      * Typed union of character/vehicle system shapes. Use `actor.type` to
      * narrow before accessing type-specific fields (e.g. `vehicle.crewmembers`).
      */
-    system: (OD6SCharacterSystem | OD6SVehicleSystem) & Record<string, any>;
+    system: OD6SCharacterSystem | OD6SVehicleSystem;
 
     /** Roll an action defined in OD6S.actions (or vehicle/starship actions). */
     rollAction(actionId: string, msg?: ChatMessage | any): Promise<unknown>;


### PR DESCRIPTION
## Summary

Internal-refactor batch landing the type-tightening plan from \`tidy-narrowing-pierce.md\`, plus a config split and a pure-math extraction. No runtime behavior changes intended.

- **Discriminated union on \`Actor.system\`** — drops the \`& Record<string, any>\` escape hatch; system access now narrows via \`actor.type\` or targeted casts.
- **\`config-od6s.ts\` 820 → 580 LOC** — \`weapons.ts\` and \`labels.ts\` extracted; thin-orchestrator pattern preserved.
- **Pure-math extraction** — \`computeHighHitDamage\` and \`computeWildDieReduction\` lifted out of \`executeRollAction\` into \`roll-execute-math.ts\` with 10 vitest cases (rounding, ties, edges).
- **Foundry typing fills** — \`DialogV2\`, \`renderTemplate\`, missing character/vehicle system fields.
- **Public-signature tightening** across \`actor.ts\`, \`crew-vehicle.ts\`, \`item.ts\`, the \`system/utilities\` barrel, and the opposed-roll path; removes the shadow \`declare const foundry: any\` in \`crew-vehicle.ts\`.
- **Cleanup** — 25 obsolete \`@ts-expect-error\` suppressions removed; 31 \`as any\` casts dropped now that \`od6s.d.ts\` covers the surfaces.
- **Lint ratchet** — 1700 → 1100 warnings. \`no-explicit-any\` 1224 → 1097 (-127). 0 type errors, 250 tests pass.
- **Version bump** — 2.0.0 → 2.1.0 in \`package.json\` and \`src/system.json\`.

Pre-existing bugs surfaced (not fixed in this PR, behavior preserved):
- \`roll-difficulty.ts\`: vehicle ram/ranged attacks read \`target.actor.system.dodge.score\`, but vehicles have \`maneuverability\`. NaN currently falls through the \`>0\` guard.
- \`roll-execute.ts:505/510/524\` flagged for separate gameplay-tested fixes.

## Test plan

- [x] \`pnpm run typecheck\` — 0 errors
- [x] \`pnpm run lint\` — 1097 warnings (under the 1100 ratchet)
- [x] \`pnpm test\` — 250 tests pass (10 new in \`roll-execute-math.test.ts\`)
- [ ] Manual smoke: open a character sheet, roll a skill, confirm damage modifiers and wild-die-1 outcomes still apply correctly
- [ ] Manual smoke: vehicle/starship sheets render and update; crew add/remove still works

## Release

Once merged, run \`task release:minor\` from \`main\` to tag \`v2.1.0\` and trigger the release workflow.