### PR TITLE
refactor(types): clear ~370 no-explicit-any warnings across codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 1088 src/",
+    "lint": "eslint --max-warnings 954 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 933 src/",
+    "lint": "eslint --max-warnings 826 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 1098 src/",
+    "lint": "eslint --max-warnings 1088 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 1100 src/",
+    "lint": "eslint --max-warnings 1098 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 954 src/",
+    "lint": "eslint --max-warnings 933 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 745 src/",
+    "lint": "eslint --max-warnings 720 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "pnpm run build:css && pnpm run watch:ts & pnpm run watch:css",
     "watch:ts": "esbuild src/module/od6s.ts --bundle --format=esm --outfile=src/module/od6s.js --sourcemap --watch",
     "watch:css": "sass scss/od6s.scss src/css/od6s.css --style=expanded --no-source-map --watch",
-    "lint": "eslint --max-warnings 826 src/",
+    "lint": "eslint --max-warnings 745 src/",
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit",

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sroll} from "../apps/roll";
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
@@ -23,7 +25,6 @@ import {
 import {onDrop, onDropItem, onDropActor} from "./sheet-helpers/drops";
 import {onSortItem, onSortCrew, onSortCargoItem, onSortContainerItem} from "./sheet-helpers/sorting";
 
-declare const foundry: any;
 
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
 const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -131,14 +131,14 @@ export class OD6SActor extends Actor {
                 const spec = pilot.items.find(i => i.type === "specialization" &&
                     i.name === vehicle.specialization.value);
                 if (typeof spec !== 'undefined') {
-                    score = (+score) + (+spec.system.score) + (pilot.system.attributes[vehicle.attribute.value].score)
+                    score = (+score) + (+(spec.system as OD6SSpecializationItemSystem).score) + (pilot.system.attributes[vehicle.attribute.value].score)
                     found = true;
                 }
 
                 if (!found) {
                     const skill = pilot.items.find(i => i.type === "skill" && i.name === vehicle.skill.value);
                     if (typeof (skill) !== 'undefined') {
-                        score = (+score) + (+skill.system.score) + (pilot.system.attributes[vehicle.attribute.value].score);
+                        score = (+score) + (+(skill.system as OD6SSkillItemSystem).score) + (pilot.system.attributes[vehicle.attribute.value].score);
                         found = true;
                     }
                 }

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -25,15 +25,15 @@ export class OD6SActor extends Actor {
     /**
      * Augment the basic actor data with additional dynamic data.
      */
-    async _preCreate(data: any, options: any, user: any) {
+    async _preCreate(data: object, options: object, user: User) {
         await super._preCreate(data, options, user);
     }
 
-    async _onCreate(data: any, options: any, user: any) {
+    async _onCreate(data: object, options: object, user: User) {
         await super._onCreate(data, options, user);
         if (game.user.isGM || this.isOwner) {
             if (this.type === 'character') {
-                const update: any = {};
+                const update: Record<string, unknown> = {};
                 update.system = {
                     'created.value': false
                 }
@@ -63,7 +63,7 @@ export class OD6SActor extends Actor {
                     actorLink: true,
                     disposition: 0
                 });
-                const update: any = {};
+                const update: Record<string, unknown> = {};
                 update.id = this.id;
                 update[`ownership.default`] = CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
                 await this.update(update);
@@ -108,6 +108,7 @@ export class OD6SActor extends Actor {
     }
 
     getVehicleActionScore(action: string) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let vehicle: any;
         let pilot: Actor | null;
 
@@ -195,15 +196,15 @@ export class OD6SActor extends Actor {
         return resolveRollAction(this, actionId, msg);
     }
 
-    async applyDamage(damage: any) {
+    async applyDamage(damage: string) {
         return applyDamageHelper(this, damage);
     }
 
-    calculateNewDamageLevel(damage: any) {
+    calculateNewDamageLevel(damage: string) {
         return calculateNewDamageLevelHelper(this, damage);
     }
 
-    async applyWounds(wound: any) {
+    async applyWounds(wound: string) {
         return applyWoundsHelper(this, wound);
     }
 
@@ -219,11 +220,11 @@ export class OD6SActor extends Actor {
         return applyIncapacitatedFailureHelper(this);
     }
 
-    findFirstWoundLevel(table: any, wound: any) {
+    findFirstWoundLevel(table: Record<string, { core: string; description?: string; penalty?: number }>, wound: string) {
         return findFirstWoundLevelHelper(this, table, wound);
     }
 
-    calculateNewWoundLevel(wound: any) {
+    calculateNewWoundLevel(wound: string) {
         return calculateNewWoundLevelHelper(this, wound);
     }
 
@@ -267,7 +268,7 @@ export class OD6SActor extends Actor {
         return useCharacterPointOnRollHelper(this, message);
     }
 
-    async modifyShields(update: any) {
+    async modifyShields(update: Record<string, unknown>) {
         return modifyShieldsHelper(this, update);
     }
 
@@ -279,7 +280,7 @@ export class OD6SActor extends Actor {
         return vehicleCollisionHelper(this);
     }
 
-    async onCargoHoldItemCreate(event: any) {
+    async onCargoHoldItemCreate(event: Event) {
         return onCargoHoldItemCreateHelper(this, event);
     }
 }

--- a/src/module/actor/add-crew.ts
+++ b/src/module/actor/add-crew.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/actor/add-embedded-crew.ts
+++ b/src/module/actor/add-embedded-crew.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/actor/add-item.ts
+++ b/src/module/actor/add-item.ts
@@ -1,7 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import {OD6SItem} from "../item/item";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/actor/advance-dialog.ts
+++ b/src/module/actor/advance-dialog.ts
@@ -1,7 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/actor/advance.ts
+++ b/src/module/actor/advance.ts
@@ -4,7 +4,7 @@ import {AdvanceDialog} from "./advance-dialog";
 
 export class od6sadvance {
 
-    activateListeners(html: any)
+    activateListeners(html: HTMLElement | JQuery)
     {
         // @ts-expect-error super reference in mixin-style class
         super.activateListeners(html);
@@ -13,12 +13,12 @@ export class od6sadvance {
     async _onAdvance(event: Event) {
         event.preventDefault();
         const element = event.currentTarget as HTMLElement;
-        const dataset = (element as any).dataset;
+        const dataset = element.dataset;
         let originalScore = 0;
         const cpcost = 0;
         const base = dataset.base;
         const freeAdvance = Boolean(false);
-        let itemid = 0;
+        let itemid: string | number = 0;
         let used = false;
         let metaPhysicsSkill = false;
         const metaphysicsteacher = false;
@@ -38,10 +38,10 @@ export class od6sadvance {
             if (skill.system.attribute === 'met') {
                 metaPhysicsSkill = true;
             }
-            itemid = dataset.itemId;
+            itemid = dataset.itemId!;
             used = skill.system.used.value;
         } else if (dataset.type === "attribute") {
-            const attrname = dataset.attrname;
+            const attrname = dataset.attrname!;
             originalScore = actorData.attributes[attrname].base;
         } else if (dataset.type === "specialization") {
             const spec = (this as any).actor.getEmbeddedDocument("Item", dataset.itemId);
@@ -54,7 +54,7 @@ export class od6sadvance {
                         originalScore += (+actorData.attributes[attribute].base)
                 }
             }
-            itemid = dataset.itemId;
+            itemid = dataset.itemId!;
         }
 
         /* Structure to pass to dialog */
@@ -99,18 +99,18 @@ export class od6sadvance {
         }
     }
 
-    static async advanceAction(actor: any, advanceData: any, event: Event, dice?: any, pips?: any) {
+    static async advanceAction(actor: Actor, advanceData: any, event: Event, dice?: number, pips?: number) {
 
-        const actorData = actor.system;
+        const actorData = actor.system as OD6SCharacterSystem;
         const actorUpdate: any = {};
         const updates: any[] = [];
         actorUpdate.system = {};
-        let specs: any[] = [];
+        let specs: Item[] = [];
 
         /* freeadvance was checked, use form data instead */
         if (advanceData.freeadvance) {
             OD6S.flatSkills ? advanceData.score = advanceData.base :
-                advanceData.score = od6sutilities.getScoreFromDice(dice, pips);
+                advanceData.score = od6sutilities.getScoreFromDice(dice!, pips!);
         }
 
         /* Character Point cost is too high. */
@@ -121,20 +121,22 @@ export class od6sadvance {
             }
         }
 
+        const dataset = (event.currentTarget as HTMLElement).dataset;
+
         /* Determine item or attribute */
-        if ((event.currentTarget as any).dataset.type === "attribute") {
+        if (dataset.type === "attribute") {
             actorUpdate.system.attributes = {};
-            actorUpdate.system.attributes[(event.currentTarget as any).dataset.attrname] = {};
-            actorUpdate.system.attributes[(event.currentTarget as any).dataset.attrname].base = advanceData.score;
+            actorUpdate.system.attributes[dataset.attrname!] = {};
+            actorUpdate.system.attributes[dataset.attrname!].base = advanceData.score;
         }
 
-        if((event.currentTarget as any).dataset.type === "skill") {
+        if(dataset.type === "skill") {
             const skill = actor.items.get(advanceData.itemid);
 
             if(OD6S.specLink) {
                 /* Also advance any specializations derived from this skill */
-                specs = actor.items.filter((i: any) => i.type === 'specialization' &&
-                    i.system.skill === skill.name);
+                specs = actor.items.filter((i: Item) => i.type === 'specialization' &&
+                    (i.system as OD6SSpecializationItemSystem).skill === skill?.name);
             }
 
             /* Add/subtract to item score, not displayed/aggregate score */
@@ -157,7 +159,7 @@ export class od6sadvance {
                     let newSpecScore;
                     if (!OD6S.flatSkills) {
                         newSpecScore = (+newScore) +
-                            (+specs[spec].system.base);
+                            (+(specs[spec].system as OD6SSpecializationItemSystem).base);
                     }
                     updates.push({
                         _id: specs[spec]._id,
@@ -167,7 +169,7 @@ export class od6sadvance {
             }
         }
 
-        if((event.currentTarget as any).dataset.type === "specialization") {
+        if(dataset.type === "specialization") {
             /* Add/subtract to item score, not displayed/aggregate score */
             let newScore;
             OD6S.flatSkills ? newScore = advanceData.base : newScore = advanceData.score - advanceData.originalscore;

--- a/src/module/actor/attribute-edit.ts
+++ b/src/module/actor/attribute-edit.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 
-declare const foundry: any;
 
 export class od6sattributeedit {
 

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -36,18 +36,21 @@ export async function onDrop(sheet: any, event: any) {
                     return onDropItemGroup(sheet, event, item, data);
                 case "species-template":
                     return onDropSpeciesTemplate(sheet, event, item, data);
-                case "skill":
-                    if (typeof (item.system.attribute) === 'undefined' || item.system.attribute === '') {
+                case "skill": {
+                    const sys = item.system as OD6SSkillItemSystem;
+                    if (typeof (sys.attribute) === 'undefined' || sys.attribute === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_ATTRIBUTE'))
                         return;
                     } else {
                         return onDropItem(sheet, event, data);
                     }
-                case "specialization":
-                    if (typeof (item.system.attribute) === 'undefined' || item.system.attribute === '') {
+                }
+                case "specialization": {
+                    const sys = item.system as OD6SSpecializationItemSystem;
+                    if (typeof (sys.attribute) === 'undefined' || sys.attribute === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_ATTRIBUTE'))
                         return;
-                    } else if (typeof (item.system.attribute) === 'undefined' || item.system.skill === '') {
+                    } else if (typeof (sys.attribute) === 'undefined' || sys.skill === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_SKILL'))
                         return;
                     } else if (!(actor.items.find((i: any) => i.type === 'specialization' && i.name === item.name))) {
@@ -56,6 +59,7 @@ export async function onDrop(sheet: any, event: any) {
                     } else {
                         return onDropItem(sheet, event, data);
                     }
+                }
                 default:
                     return onDropItem(sheet, event, data);
             }

--- a/src/module/actor/sheet-helpers/item-crud.ts
+++ b/src/module/actor/sheet-helpers/item-crud.ts
@@ -3,26 +3,26 @@ import OD6S from "../../config/config-od6s";
 /**
  * Delete an item from the actor, with confirmation dialog.
  */
-export async function deleteItem(sheet: any, ev: any) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function deleteItem(sheet: any, ev: Event) {
+    const ct = ev.currentTarget as HTMLElement;
     // If this is a skill, deny if there are existing specializations.
-    if (ev.currentTarget.dataset.type === "skill") {
+    if (ct.dataset.type === "skill") {
         for (const i in sheet.document.items) {
-            if (sheet.document.items[i].type === "specialization") {
-                if (sheet.document.items[i].skill === ev.currentTarget.dataset.itemId) {
-                    ui.notifications.error(game.i18n.localize("OD6S.ERR_SKILL_HAS_SPEC"));
-                    return;
-                }
+            const docItem = sheet.document.items[i] as Item & { skill?: string };
+            if (docItem.type === "specialization" && docItem.skill === ct.dataset.itemId) {
+                ui.notifications.error(game.i18n.localize("OD6S.ERR_SKILL_HAS_SPEC"));
+                return;
             }
         }
     }
-    if (ev.currentTarget.dataset.confirm !== "false") {
+    if (ct.dataset.confirm !== "false") {
         let itemId;
-        if (typeof (ev.currentTarget.dataset.itemId) !== 'undefined' &&
-            ev.currentTarget.dataset.itemId !== '') {
-            itemId = ev.currentTarget.dataset.itemId
+        if (typeof ct.dataset.itemId !== 'undefined' && ct.dataset.itemId !== '') {
+            itemId = ct.dataset.itemId;
         } else {
-            const li = ev.currentTarget.closest(".item");
-            itemId = li?.dataset?.itemId;
+            const li = ct.closest<HTMLElement>(".item");
+            itemId = li?.dataset.itemId;
         }
         const confirmText = "<p>" + game.i18n.localize("OD6S.DELETE_CONFIRM") + "</p>";
         await Dialog.prompt({
@@ -34,7 +34,7 @@ export async function deleteItem(sheet: any, ev: any) {
             }
         })
     } else {
-        await sheet.document.deleteEmbeddedDocuments('Item', [ev.currentTarget.dataset.itemId]);
+        await sheet.document.deleteEmbeddedDocuments('Item', [ct.dataset.itemId]);
         sheet.render(false);
     }
 }
@@ -42,51 +42,58 @@ export async function deleteItem(sheet: any, ev: any) {
 /**
  * Add an item to the actor using the add-item dialog.
  */
-export async function addItem(sheet: any, ev: any, caller?: any) {
+export async function addItem(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+    ev: Event,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    caller?: any,
+) {
     // Lazy-import to avoid circular dependency
     const {OD6SAddItem} = await import("../add-item.js");
     const {od6sutilities} = await import("../../system/utilities.js");
 
     caller = caller ?? sheet;
-    const data: any = {};
-    data.type = ev.currentTarget.dataset.type;
-    data.attrname = ev.currentTarget.dataset.attrname;
-    data.new = !(typeof (ev.currentTarget.dataset.new) !== 'undefined' && ev.currentTarget.dataset.new === 'false');
-    let worldItems: any = {};
-    let compendiumItems = [];
+    const ct = ev.currentTarget as HTMLElement;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: Record<string, any> = {};
+    data.type = ct.dataset.type!;
+    data.attrname = ct.dataset.attrname;
+    data.new = !(typeof ct.dataset.new !== 'undefined' && ct.dataset.new === 'false');
+    let worldItems: Item[] = [];
+    let compendiumItems: Item[] = [];
 
-    data.type = ev.currentTarget.dataset.type;
     data.label = game.i18n.localize('OD6S.ADD') + " " + game.i18n.localize(OD6S.itemLabels[data.type])
     data.label_empty = game.i18n.localize('OD6S.ADD_EMPTY') + " " + game.i18n.localize(OD6S.itemLabels[data.type])
 
-    worldItems = game.items.filter((i: any) => i.type === data.type);
+    worldItems = game.items.filter((i: Item) => i.type === data.type);
     const cEntries = od6sutilities.getItemsFromCompendiumByType(data.type);
 
     if (data.type === 'skill') {
         worldItems = worldItems.filter((i: Item) => (i.system as OD6SSkillItemSystem).attribute === data.attrname);
         for (const i of cEntries) {
-            const item = await od6sutilities._getItemFromCompendium((i as any).name);
+            const item = await od6sutilities._getItemFromCompendium((i as Item).name);
             if (item && (item.system as OD6SSkillItemSystem).attribute === data.attrname) {
                 compendiumItems.push(item);
             }
         }
     } else {
         for (const i of cEntries) {
-            const item = await od6sutilities._getItemFromCompendium((i as any).name);
+            const item = await od6sutilities._getItemFromCompendium((i as Item).name);
             if (item) compendiumItems.push(item);
         }
     }
 
     //if it is a skill, do not include skills the actor already has
     if (data.type === 'skill') {
-        worldItems = worldItems.filter((i: any) => !sheet.document.items.find((r: any) => r.name === i.name));
-        compendiumItems = compendiumItems.filter((i: any) => !sheet.document.items.find((r: any) => r.name === i.name));
+        worldItems = worldItems.filter((i: Item) => !sheet.document.items.find((r: Item) => r.name === i.name));
+        compendiumItems = compendiumItems.filter((i: Item) => !sheet.document.items.find((r: Item) => r.name === i.name));
     }
 
     // Prefer world items
-    compendiumItems = compendiumItems.filter((i: any) => !worldItems.find((r: any) => r.name === i.name));
+    compendiumItems = compendiumItems.filter((i: Item) => !worldItems.find((r: Item) => r.name === i.name));
 
-    data.items = [...worldItems, ...compendiumItems].sort(function (a: any, b: any) {
+    data.items = [...worldItems, ...compendiumItems].sort((a: Item, b: Item) => {
         const x = a.name.toUpperCase();
         const y = b.name.toUpperCase();
         return x === y ? 0 : x > y ? 1 : -1;
@@ -114,21 +121,24 @@ export async function addItem(sheet: any, ev: any, caller?: any) {
 /**
  * Handle creating a new Owned Item for the actor using initial data defined in the HTML dataset.
  */
-export function onItemCreate(sheet: any, event: any) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function onItemCreate(sheet: any, event: Event) {
     event.preventDefault();
-    const header = event.currentTarget;
+    const header = event.currentTarget as HTMLElement;
     // Get the type of item to create.
-    const type = header.dataset.type;
+    const type = header.dataset.type!;
+    // String.prototype.capitalize is provided by Foundry at runtime.
+    const capType = (type as string & {capitalize?: () => string}).capitalize?.() ?? type;
 
     // Grab any data associated with this control.
     const data = foundry.utils.deepClone(header.dataset);
     // Initialize a default name.
-    const name = game.i18n.localize('OD6S.NEW') + ' ' + game.i18n.localize('ITEM.Type' + type.capitalize());
+    const name = game.i18n.localize('OD6S.NEW') + ' ' + game.i18n.localize('ITEM.Type' + capType);
     // Prepare the item object.
-    const itemData = {
-        name: name,
-        type: type,
-        data: data
+    const itemData: { name: string; type: string; data: Record<string, string | undefined> } = {
+        name,
+        type,
+        data,
     };
     // Remove the type from the dataset since it's in the itemData.type prop.
     delete itemData.data["type"];

--- a/src/module/actor/sheet-helpers/item-crud.ts
+++ b/src/module/actor/sheet-helpers/item-crud.ts
@@ -63,10 +63,10 @@ export async function addItem(sheet: any, ev: any, caller?: any) {
     const cEntries = od6sutilities.getItemsFromCompendiumByType(data.type);
 
     if (data.type === 'skill') {
-        worldItems = worldItems.filter((i: any) => i.system.attribute === data.attrname);
+        worldItems = worldItems.filter((i: Item) => (i.system as OD6SSkillItemSystem).attribute === data.attrname);
         for (const i of cEntries) {
             const item = await od6sutilities._getItemFromCompendium((i as any).name);
-            if (item && item.system.attribute === data.attrname) {
+            if (item && (item.system as OD6SSkillItemSystem).attribute === data.attrname) {
                 compendiumItems.push(item);
             }
         }

--- a/src/module/actor/sheet-helpers/sorting.ts
+++ b/src/module/actor/sheet-helpers/sorting.ts
@@ -21,7 +21,7 @@ export function onSortItem(sheet: any, event: any, itemData: any) {
 
     // Perform the sort
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target, siblings});
-    const updateData = sortUpdates.map((u: any) => {
+    const updateData = sortUpdates.map((u) => {
         const update = u.update;
         update._id = u.target._id;
         return update;
@@ -36,23 +36,23 @@ export function onSortItem(sheet: any, event: any, itemData: any) {
  */
 export async function onSortCrew(sheet: any, event: any, data: any) {
     const crewMembers = [...sheet.document.system.crewmembers];
-    const source = crewMembers.filter((c: any) => c.uuid === data.crewUuid)[0];
+    const source = crewMembers.filter((c: {uuid: string; sort?: number}) => c.uuid === data.crewUuid)[0];
     const dropTarget = event.target.closest("li[data-crew-uuid]");
     if (!dropTarget) return;
-    const target = crewMembers.filter((c: any) => c.uuid === dropTarget.dataset.crewUuid)[0];
+    const target = crewMembers.filter((c: {uuid: string; sort?: number}) => c.uuid === dropTarget.dataset.crewUuid)[0];
 
     // Identify sibling items based on adjacent HTML elements
     const siblings = [];
     for (const el of dropTarget.parentElement.children) {
         const siblingId = el.dataset.crewUuid;
-        if (siblingId && (siblingId !== source.uuid)) siblings.push(crewMembers.filter((c: any) => c.uuid === el.dataset.crewUuid)[0]);
+        if (siblingId && (siblingId !== source.uuid)) siblings.push(crewMembers.filter((c: {uuid: string; sort?: number}) => c.uuid === el.dataset.crewUuid)[0]);
     }
 
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target, siblings});
 
-    const updateData = sortUpdates.map((u: any) => {
+    const updateData = sortUpdates.map((u) => {
         const update = u.update;
-        update.uuid = u.target.uuid;
+        update.uuid = (u.target as {uuid: string}).uuid;
         return update;
     });
 
@@ -64,15 +64,7 @@ export async function onSortCrew(sheet: any, event: any, data: any) {
         }
     }
 
-    crewMembers.sort((a: any, b: any) => {
-        if (a.sort < b.sort) {
-            return -1;
-        }
-        if (a.sort > b.sort) {
-            return 1;
-        }
-        return 0;
-    })
+    crewMembers.sort((a: {sort?: number}, b: {sort?: number}) => (a.sort ?? 0) - (b.sort ?? 0));
 
     const updateObject = {
         system: {
@@ -89,18 +81,18 @@ export async function onSortCrew(sheet: any, event: any, data: any) {
 export async function onSortCargoItem(sheet: any, event: any, itemData: any) {
     // Get the drag source and its siblings
     const source = sheet.document.items.get(itemData._id);
-    const siblings = sheet.document.items.filter((i: any) => {
+    const siblings = sheet.document.items.filter((i: Item) => {
         return (i._id !== source!._id);
     });
 
     // Get the drop target
     const dropTarget = event.target.closest("[data-item-id]");
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
-    const target = siblings.find((s: any) => s._id === targetId);
+    const target = siblings.find((s: Item) => s._id === targetId);
 
     // Perform the sort
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target: target, siblings});
-    const updateData = sortUpdates.map((u: any) => {
+    const updateData = sortUpdates.map((u) => {
         const update = u.update;
         update._id = u.target._id;
         return update;
@@ -116,21 +108,21 @@ export async function onSortCargoItem(sheet: any, event: any, itemData: any) {
 export async function onSortContainerItem(sheet: any, event: any, itemData: any) {
     // Get the drag source and its siblings
     const source = sheet.document.items.get(itemData._id);
-    const siblings = sheet.document.items.filter((i: any) => {
+    const siblings = sheet.document.items.filter((i: Item) => {
         return (i.type === source!.type) && (i._id !== source!._id);
     });
 
     // Get the drop target
     const dropTarget = event.target.closest("[data-item-id]");
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
-    const target = siblings.find((s: any) => s._id === targetId);
+    const target = siblings.find((s: Item) => s._id === targetId);
 
     // Ensure we are only sorting like-types
     if (target && (source!.type !== target.type)) return;
 
     // Perform the sort
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target: target, siblings});
-    const updateData = sortUpdates.map((u: any) => {
+    const updateData = sortUpdates.map((u) => {
         const update = u.update;
         update._id = u.target._id;
         return update;

--- a/src/module/actor/sheet-helpers/templates.ts
+++ b/src/module/actor/sheet-helpers/templates.ts
@@ -128,8 +128,8 @@ export async function templateItems(sheet: any, itemList: any) {
         }
 
         // Metaphysics skills get 1D if the attribute is not used
-        if (templateItem.type === 'skill' && templateItem.system.attribute === 'met' && game.settings.get('od6s', 'metaphysics_attribute_optional')) {
-            templateItem.system.base = OD6S.pipsPerDice;
+        if (templateItem.type === 'skill' && (templateItem.system as OD6SSkillItemSystem).attribute === 'met' && game.settings.get('od6s', 'metaphysics_attribute_optional')) {
+            (templateItem.system as OD6SSkillItemSystem).base = OD6S.pipsPerDice;
         }
 
         result.push(templateItem);

--- a/src/module/actor/sheet-helpers/templates.ts
+++ b/src/module/actor/sheet-helpers/templates.ts
@@ -8,7 +8,7 @@ export async function onDropCharacterTemplate(sheet: any, event: any, item: any,
     if (!sheet.document.isOwner) return false;
     if (sheet.document.type !== 'character') return false;
     // Check if a template has already been assigned to this actor
-    if (sheet.document.items.find((E: any) => E.type === 'character-template')) {
+    if (sheet.document.items.find((E: Item) => E.type === 'character-template')) {
         ui.notifications.error(game.i18n.localize("OD6S.ERROR_TEMPLATE_ALREADY_ASSIGNED"));
         return false;
     } else {
@@ -25,7 +25,7 @@ export async function onDropSpeciesTemplate(sheet: any, event: any, item: any, _
 
     if (!sheet.document.isOwner) return false;
     if (sheet.document.type !== 'character' && sheet.document.type !== 'npc') return false;
-    if (sheet.document.items.find((E: any) => E.type === 'species-template')) {
+    if (sheet.document.items.find((E: Item) => E.type === 'species-template')) {
         ui.notifications.error(game.i18n.localize("OD6S.ERROR_SPECIES_TEMPLATE_ALREADY_ASSIGNED"));
         return false;
     }
@@ -122,7 +122,7 @@ export async function templateItems(sheet: any, itemList: any) {
         // Filter out duplicate skills/specializations by name
         if (i.type === 'skill' || i.type === 'specialization' || i.type === 'specialability' ||
             i.type === 'disadvantage' || i.type === 'advanatage') {
-            if (sheet.document.items.filter((e: any) => e.type === i.type && e.name === i.name).length) {
+            if (sheet.document.items.filter((e: Item) => e.type === i.type && e.name === i.name).length) {
                 continue;
             }
         }
@@ -142,7 +142,7 @@ export async function templateItems(sheet: any, itemList: any) {
  */
 export async function onClearCharacterTemplate(sheet: any) {
     // Find the template
-    const item = sheet.document.items.find((E: any) => E.type === 'character-template');
+    const item = sheet.document.items.find((E: Item) => E.type === 'character-template');
     if (item) {
         const itemData = item.system;
         const update: any = {};
@@ -154,7 +154,7 @@ export async function onClearCharacterTemplate(sheet: any) {
         }
 
         update.system['chartype.content'] = "";
-        const speciesTemplate = sheet.document.items.find((E: any) => E.type === 'species-template');
+        const speciesTemplate = sheet.document.items.find((E: Item) => E.type === 'species-template');
         if (!speciesTemplate) update.system['species.content'] = "";
         update.system['fatepoints.value'] = 0;
         update.system['characterpoints.value'] = 0;
@@ -168,7 +168,7 @@ export async function onClearCharacterTemplate(sheet: any) {
 
         if (itemData.items !== null && typeof(itemData.items !== 'undefined')) {
             for (const templateItem of itemData.items) {
-                const actorItem = sheet.document.items.find((I: any) => I.name === templateItem.name);
+                const actorItem = sheet.document.items.find((I: Item) => I.name === templateItem.name);
                 if (typeof (actorItem) !== 'undefined') {
                     await sheet.document.deleteEmbeddedDocuments('Item', [actorItem.id]);
                 }
@@ -192,7 +192,7 @@ export async function onClearSpeciesTemplate(sheet: any) {
     const update: any = {};
     update.system = {};
 
-    const item = sheet.document.items.find((E: any) => E.type === 'species-template');
+    const item = sheet.document.items.find((E: Item) => E.type === 'species-template');
     if (item) {
         const itemData = item.system;
 
@@ -206,7 +206,7 @@ export async function onClearSpeciesTemplate(sheet: any) {
         }
 
         // Clear the species name from the template; check if a character template is applied and replace it from there
-        const characterTemplate = sheet.document.items.find((E: any) => E.type === 'character-template');
+        const characterTemplate = sheet.document.items.find((E: Item) => E.type === 'character-template');
         if (characterTemplate) {
             update[`system.species.content`] = characterTemplate.system.species;
         } else {
@@ -216,7 +216,7 @@ export async function onClearSpeciesTemplate(sheet: any) {
         // Remove items
         if (itemData.items !== null && typeof(itemData.items !== 'undefined')) {
             for (const templateItem of itemData.items) {
-                const actorItem = sheet.document.items.find((I: any) => I.name === templateItem.name);
+                const actorItem = sheet.document.items.find((I: Item) => I.name === templateItem.name);
                 if (typeof (actorItem) !== 'undefined') {
                     await sheet.document.deleteEmbeddedDocuments('Item', [actorItem.id]);
                 }

--- a/src/module/actor/sheet-listeners/combat-actions.ts
+++ b/src/module/actor/sheet-listeners/combat-actions.ts
@@ -1,45 +1,50 @@
 /**
  * Register combat action-related event listeners on the actor sheet.
  */
-export function registerCombatActionListeners(html: any, sheet: any): void {
+export function registerCombatActionListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
     const el = html[0];
 
     // Add/remove actions
-    el.querySelectorAll('.addaction').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.addaction').forEach((elem: HTMLElement) =>
         elem.addEventListener('click', () => {
             sheet._onActionAdd();
         }));
 
-    el.querySelectorAll('.combat-action').forEach((elem: any) =>
-        elem.addEventListener('contextmenu', (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
+        elem.addEventListener('contextmenu', (ev: Event) => {
             sheet._onAvailableActionAdd(ev);
         }));
 
     // Roll available action
-    el.querySelectorAll('.combat-action').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
+        elem.addEventListener('click', async (ev: Event) => {
             await sheet._rollAvailableAction(ev);
         }));
 
     // Roll available vehicle action
-    el.querySelectorAll('.vehicle-action').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.vehicle-action').forEach((elem: HTMLElement) =>
+        elem.addEventListener('click', async (ev: Event) => {
             await sheet._rollAvailableVehicleAction(ev);
         }));
 
     // Edit misc action
-    el.querySelectorAll('.editmiscaction').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const update: any = {};
-            update._id = ev.currentTarget.dataset.itemId;
-            update.name = ev.target.value;
-            const action = await sheet.document.items.find((i: any) => i.id === update._id);
+    el.querySelectorAll<HTMLElement>('.editmiscaction').forEach((elem: HTMLElement) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const update: Record<string, unknown> = {};
+            const ct = ev.currentTarget as HTMLElement;
+            update._id = ct.dataset.itemId;
+            update.name = (ev.target as HTMLInputElement).value;
+            const action = await sheet.document.items.find((i: Item) => i.id === update._id);
             await action!.update(update);
             sheet.render();
         }));
 
     // Fate point in effect checkbox
-    el.querySelectorAll('.fatepointeffect').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.fatepointeffect').forEach((elem: HTMLElement) =>
         elem.addEventListener('change', async () => {
             // Don't allow if actor has 0 points
             if (sheet.document.system.fatepoints.value < 1) {
@@ -52,12 +57,15 @@ export function registerCombatActionListeners(html: any, sheet: any): void {
             await sheet.document.setFlag('od6s', 'fatepointeffect', !inEffect);
             inEffect = sheet.document.getFlag('od6s', 'fatepointeffect');
             if (inEffect) {
-                const update: any = {};
-                update.system = {};
-                update.system.fatepoints = {};
-                update.id = sheet.document.id;
-                update._id = sheet.document._id;
-                update.system.fatepoints.value = sheet.document.system.fatepoints.value -= 1;
+                const update: Record<string, unknown> = {
+                    id: sheet.document.id,
+                    _id: sheet.document._id,
+                    system: {
+                        fatepoints: {
+                            value: sheet.document.system.fatepoints.value -= 1,
+                        },
+                    },
+                };
                 await sheet.document.update(update, {diff: true});
             }
         }));

--- a/src/module/actor/sheet-listeners/drag.ts
+++ b/src/module/actor/sheet-listeners/drag.ts
@@ -1,34 +1,38 @@
 /**
  * Register drag event listeners on the actor sheet.
  */
-export function registerDragListeners(html: any, sheet: any): void {
+export function registerDragListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
     const el = html[0];
 
     if (sheet.document.isOwner) {
-        const handler = (ev: any) => sheet._onDragStart(ev);
+        const handler = (ev: DragEvent) => sheet._onDragStart(ev);
 
         if (sheet.document.type === 'container' && !game.user.isGM) return;
 
         // Items
-        el.querySelectorAll('li.item').forEach((li: any) => {
+        el.querySelectorAll<HTMLElement>('li.item').forEach((li) => {
             if (li.classList.contains("inventory-header")) return;
-            li.setAttribute("draggable", true);
+            li.setAttribute("draggable", "true");
             li.addEventListener("dragstart", handler, false);
         });
 
         // Combat Actions
-        el.querySelectorAll('li.availableaction').forEach((li: any) => {
-            li.setAttribute("draggable", true);
+        el.querySelectorAll<HTMLElement>('li.availableaction').forEach((li) => {
+            li.setAttribute("draggable", "true");
             li.addEventListener("dragstart", sheet._dragAvailableCombatAction, false);
         });
-        el.querySelectorAll('li.assignedaction').forEach((li: any) => {
-            li.setAttribute("draggable", true);
+        el.querySelectorAll<HTMLElement>('li.assignedaction').forEach((li) => {
+            li.setAttribute("draggable", "true");
             li.addEventListener("dragstart", sheet._dragAssignedCombatAction, false);
         });
 
         // Crewmembers
-        el.querySelectorAll('li.crew-list').forEach((li: any) => {
-            li.setAttribute('draggable', true);
+        el.querySelectorAll<HTMLElement>('li.crew-list').forEach((li) => {
+            li.setAttribute('draggable', "true");
             li.addEventListener("dragstart", sheet._dragCrewMember, false);
         });
     }

--- a/src/module/actor/sheet-listeners/effects.ts
+++ b/src/module/actor/sheet-listeners/effects.ts
@@ -1,43 +1,52 @@
 /**
  * Register active effect and manifestation event listeners on the actor sheet.
  */
-export function registerEffectListeners(html: any, sheet: any): void {
+export function registerEffectListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
     const el = html[0];
 
     // Update Effect
-    el.querySelectorAll('.effect-edit').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            const effect = sheet.document.effects.get(ev.currentTarget.dataset.effectId);
+    el.querySelectorAll<HTMLElement>('.effect-edit').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const effect = sheet.document.effects.get(ct.dataset.effectId);
             await effect!.sheet.render(true);
         }));
 
     // Delete Effect
-    el.querySelectorAll('.effect-delete').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            await sheet.document.deleteEmbeddedDocuments('ActiveEffect', [ev.currentTarget.dataset.effectId]);
+    el.querySelectorAll<HTMLElement>('.effect-delete').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            await sheet.document.deleteEmbeddedDocuments('ActiveEffect', [ct.dataset.effectId]);
         }));
 
     // Activate a manifestation
-    el.querySelectorAll('.active-checkbox').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.active-checkbox').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
-            const item = sheet.document.items.find((i: any) => i.id === ev.currentTarget.dataset.itemId);
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.find((i: Item) => i.id === ct.dataset.itemId);
 
             if (item) {
-                if (item.system.attack) {
+                const itemSys = item.system as OD6SManifestationItemSystem;
+                if (itemSys.attack) {
                     return;
                 }
 
-                const update: any = {};
-                update.id = item.id;
-                update['system.active'] = !item.system.active;
+                const update: Record<string, unknown> = {
+                    id: item.id,
+                    'system.active': !itemSys.active,
+                };
 
                 await item.update(update);
                 const actorEffectsList = sheet.document.getEmbeddedCollection('ActiveEffect');
 
                 if (actorEffectsList.size > 0) {
-                    const actorUpdate: any[] = [];
-                    actorEffectsList.forEach((e: any) => {
+                    const actorUpdate: Array<Record<string, unknown>> = [];
+                    actorEffectsList.forEach((e: ActiveEffect) => {
                         const parts = e.origin?.split(".") ?? [];
                         const parentType = parts[0];
                         let documentType = parts[2];
@@ -47,13 +56,14 @@ export function registerEffectListeners(html: any, sheet: any): void {
                             documentId = parts[5];
                         }
                         if (documentType === "Item") {
-                            const effectItem = sheet.document.items.find((i: any) => i.id === documentId);
-                            if (effectItem && !effectItem.system.consumable && effectItem.type === 'manifestation') {
-                                if (e.disabled === effectItem.system.active) {
-                                    const effectUpdate: any = {};
-                                    effectUpdate._id = e.id;
-                                    effectUpdate.disabled = !item.system.active;
-                                    actorUpdate.push(effectUpdate);
+                            const effectItem = sheet.document.items.find((i: Item) => i.id === documentId);
+                            if (effectItem && effectItem.type === 'manifestation') {
+                                const effSys = effectItem.system as OD6SManifestationItemSystem & { consumable?: boolean };
+                                if (!effSys.consumable && e.disabled === effSys.active) {
+                                    actorUpdate.push({
+                                        _id: e.id,
+                                        disabled: !itemSys.active,
+                                    });
                                 }
                             }
                         }

--- a/src/module/actor/sheet-listeners/inventory.ts
+++ b/src/module/actor/sheet-listeners/inventory.ts
@@ -5,32 +5,39 @@ import OD6S from "../../config/config-od6s";
 /**
  * Register inventory-related event listeners on the actor sheet.
  */
-export function registerInventoryListeners(html: any, sheet: any): void {
+export function registerInventoryListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
     const el = html[0];
 
     // Edit item quantity
-    el.querySelectorAll('.edit-quantity').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const item = await sheet.document.items.get(ev.currentTarget.dataset.itemId);
-            const update = {};
-            (update as any)[`system.quantity`] = ev.target.value
-            await item!.update(update);
+    el.querySelectorAll<HTMLElement>('.edit-quantity').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.get(ct.dataset.itemId);
+            await item!.update({
+                'system.quantity': (ev.target as HTMLInputElement).value,
+            });
         }));
 
     // Use a consumable
-    el.querySelectorAll('.use-consumable').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            const item = await sheet.document.items.get(ev.currentTarget.dataset.itemId);
-            const update: any = {};
-            update.id = item!._id;
-            update[`system.quantity`] = item!.system.quantity - 1;
-            await item!.update(update);
+    el.querySelectorAll<HTMLElement>('.use-consumable').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.get(ct.dataset.itemId);
+            const itemSys = item!.system as OD6SEquipment;
+            await item!.update({
+                id: item!._id,
+                'system.quantity': itemSys.quantity - 1,
+            });
 
             const actorEffectsList = sheet.document.getEmbeddedCollection('ActiveEffect');
 
             if (actorEffectsList.size > 0) {
-                const actorUpdate: any[] = [];
-                actorEffectsList.forEach((e: any) => {
+                const actorUpdate: Array<Record<string, unknown>> = [];
+                actorEffectsList.forEach((e: ActiveEffect) => {
                     const parts = e.origin?.split(".") ?? [];
                     const parentType = parts[0];
                     let documentType = parts[2];
@@ -40,14 +47,9 @@ export function registerInventoryListeners(html: any, sheet: any): void {
                         documentId = parts[5];
                     }
                     if (documentType === "Item") {
-                        const effectItem = sheet.document.items.find((i: any) => i.id === documentId);
-                        if (effectItem) {
-                            if (e.disabled === true) {
-                                const effectUpdate: any = {};
-                                effectUpdate._id = e.id;
-                                effectUpdate.disabled = false;
-                                actorUpdate.push(effectUpdate);
-                            }
+                        const effectItem = sheet.document.items.find((i: Item) => i.id === documentId);
+                        if (effectItem && e.disabled === true) {
+                            actorUpdate.push({_id: e.id, disabled: false});
                         }
                     }
                 })
@@ -56,22 +58,23 @@ export function registerInventoryListeners(html: any, sheet: any): void {
         }));
 
     // Equip an item
-    el.querySelectorAll('.equip-checkbox').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const item = sheet.document.items.find((i: any) => i.id === ev.currentTarget.dataset.itemId);
+    el.querySelectorAll<HTMLElement>('.equip-checkbox').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.find((i: Item) => i.id === ct.dataset.itemId);
 
             if (item) {
-                const update: any = {};
-                update.id = item.id;
-                update['system.equipped.value'] = !item.system.equipped.value;
-
-                await item.update(update);
+                const itemSys = item.system as OD6SEquip;
+                await item.update({
+                    id: item.id,
+                    'system.equipped.value': !itemSys.equipped.value,
+                });
                 const actorEffectsList = sheet.document.getEmbeddedCollection('ActiveEffect');
 
                 if (actorEffectsList.size > 0) {
-                    const actorUpdate: any[] = [];
-                    const itemUpdates: any[] = [];
-                    actorEffectsList.forEach((e: any) => {
+                    const actorUpdate: Array<Record<string, unknown>> = [];
+                    const itemUpdates: Array<Record<string, unknown>> = [];
+                    actorEffectsList.forEach((e: ActiveEffect) => {
                         const parts = e.origin?.split(".") ?? [];
                         const parentType = parts[0];
                         let documentType = parts[2];
@@ -81,38 +84,32 @@ export function registerInventoryListeners(html: any, sheet: any): void {
                             documentId = parts[5];
                         }
                         if (documentType === "Item") {
-                            const effectItem = sheet.document.items.find((i: any) => i.id === documentId);
-                            if (effectItem && !effectItem.system.consumable &&
-                                OD6S.equippable.includes(effectItem.type)) {
-                                if (e.disabled === effectItem.system.equipped.value) {
-                                    if (!effectItem.system.equipped.value) {
-                                        for (let i = 0; i < e.changes.length; i++) {
-                                            const c = e.changes[i];
-                                            if (c.key.startsWith('system.items.skills')) {
-                                                if (c.mode === 2) {
-                                                    const t = c.key.split('.');
-                                                    const foundItem = sheet.document.items.find((i: any) => i.name === t[3]);
-                                                    const itemUpdate: any = {};
-                                                    itemUpdate.id = foundItem!.id;
-                                                    itemUpdate.system = {};
-                                                    itemUpdate.system.mod = 0;
-                                                    itemUpdates.push(itemUpdate);
-                                                }
-                                            }
-                                        }
+                            const effectItem = sheet.document.items.find((i: Item) => i.id === documentId);
+                            if (!effectItem || !OD6S.equippable.includes(effectItem.type)) return;
+                            const effSys = effectItem.system as OD6SEquip & {consumable?: boolean};
+                            if (effSys.consumable || e.disabled !== effSys.equipped.value) return;
+                            if (!effSys.equipped.value) {
+                                for (const c of e.changes) {
+                                    if (c.key.startsWith('system.items.skills') && c.mode === 2) {
+                                        const t = c.key.split('.');
+                                        const foundItem = sheet.document.items.find((i: Item) => i.name === t[3]);
+                                        itemUpdates.push({
+                                            id: foundItem!.id,
+                                            system: {mod: 0},
+                                        });
                                     }
-                                    const effectUpdate: any = {};
-                                    effectUpdate._id = e.id;
-                                    effectUpdate.disabled = !item.system.equipped.value;
-                                    actorUpdate.push(effectUpdate);
                                 }
                             }
+                            actorUpdate.push({
+                                _id: e.id,
+                                disabled: !itemSys.equipped.value,
+                            });
                         }
                     })
                     await sheet.document.updateEmbeddedDocuments('ActiveEffect', actorUpdate);
-                    for (let u = 0; u < itemUpdates.length; u++) {
-                        const a = sheet.document.items.find((i: any) => i.id === itemUpdates[u].id);
-                        await a!.update(itemUpdates[u]);
+                    for (const u of itemUpdates) {
+                        const a = sheet.document.items.find((i: Item) => i.id === u.id);
+                        await a!.update(u);
                     }
                 }
             }
@@ -120,49 +117,50 @@ export function registerInventoryListeners(html: any, sheet: any): void {
         }));
 
     // Update Inventory Item
-    el.querySelectorAll('.item-edit').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.item-edit').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
             let itemId;
-            if (typeof (ev.currentTarget.dataset.itemId) !== 'undefined' &&
-                ev.currentTarget.dataset.itemId !== '') {
-                itemId = ev.currentTarget.dataset.itemId
+            if (typeof ct.dataset.itemId !== 'undefined' && ct.dataset.itemId !== '') {
+                itemId = ct.dataset.itemId;
             } else {
-                const li = ev.currentTarget.closest(".item");
-                itemId = li?.dataset?.itemId;
+                const li = ct.closest<HTMLElement>(".item");
+                itemId = li?.dataset.itemId;
             }
             const item = sheet.document.items.get(itemId);
             item!.sheet.render(true);
         }));
 
     // Delete Inventory Item
-    el.querySelectorAll('.item-delete').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.item-delete').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             await sheet.deleteItem(ev);
         }));
 
     // Add Inventory Item
-    el.querySelectorAll('.item-create').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.item-create').forEach((elem) =>
         elem.addEventListener('click', sheet._onItemCreate.bind(sheet)));
-    el.querySelectorAll('.cargo-hold-add').forEach((elem: any) =>
-        elem.addEventListener('click', (sheet.document as any).onCargoHoldItemCreate.bind(sheet.document)));
+    el.querySelectorAll<HTMLElement>('.cargo-hold-add').forEach((elem) =>
+        elem.addEventListener('click', sheet.document.onCargoHoldItemCreate.bind(sheet.document)));
 
     // Add Item to actor using a button
-    el.querySelectorAll('.item-add').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.item-add').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             await sheet.addItem(ev);
         }));
 
     // Show item details
-    el.querySelectorAll('.show-item-details').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.show-item-details').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
-            let item = game!.actors.get(ev.currentTarget.dataset.actorId)?.items.get(ev.currentTarget.dataset.itemId);
-            if (typeof (item) !== 'undefined') {
+            const ct = ev.currentTarget as HTMLElement;
+            let item = game.actors.get(ct.dataset.actorId!)?.items.get(ct.dataset.itemId!);
+            if (typeof item !== 'undefined') {
                 new OD6SItemInfo(item).render(true);
             } else {
-                const itemName = ev.currentTarget.dataset.itemName;
+                const itemName = ct.dataset.itemName!;
                 item = await od6sutilities._getItemFromWorld(itemName);
                 if (item) {
                     new OD6SItemInfo(item.data).render(true);
@@ -177,64 +175,61 @@ export function registerInventoryListeners(html: any, sheet: any): void {
         }));
 
     // Purchase click event
-    el.querySelectorAll('.item-purchase').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            if (typeof (game.user.character) === 'undefined') {
+    el.querySelectorAll<HTMLElement>('.item-purchase').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            if (typeof game.user.character === 'undefined') {
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_NO_CHARACTER_ASSIGNED'));
                 return;
             }
+            const ct = ev.currentTarget as HTMLElement;
             if (OD6S.cost === '0') {
-                await sheet.rollPurchase(ev, game!.user.character!.id);
+                await sheet.rollPurchase(ev, game.user.character!.id);
             } else {
-                await sheet._onPurchase(ev.currentTarget.dataset.itemId, game!.user.character!.id);
+                await sheet._onPurchase(ct.dataset.itemId, game.user.character!.id);
             }
         }));
 
     // Transfer click event
-    el.querySelectorAll('.item-transfer').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            if (typeof (game.user.character) === 'undefined') {
+    el.querySelectorAll<HTMLElement>('.item-transfer').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            if (typeof game.user.character === 'undefined') {
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_NO_CHARACTER_ASSIGNED'));
                 return;
             }
-            await sheet._onTransfer(ev.currentTarget.dataset.itemId,
-                ev.currentTarget.dataset.senderId,
-                ev.currentTarget.dataset.recId);
+            const ct = ev.currentTarget as HTMLElement;
+            await sheet._onTransfer(ct.dataset.itemId, ct.dataset.senderId, ct.dataset.recId);
         }));
 
     // Merchant owner edit quantity
-    el.querySelectorAll('.merchant-quantity-owner').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const item = sheet.document.items.get(ev.currentTarget.dataset.itemId);
-            const update: any = {};
-            update._id = item!.id;
-            update.system = {};
-            update.system.quantity = ev.target.value;
-
-            await sheet.document.updateEmbeddedDocuments('Item', [update]);
+    el.querySelectorAll<HTMLElement>('.merchant-quantity-owner').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.get(ct.dataset.itemId);
+            await sheet.document.updateEmbeddedDocuments('Item', [{
+                _id: item!.id,
+                system: {quantity: (ev.target as HTMLInputElement).value},
+            }]);
         }));
 
     // Merchant owner edit cost
-    el.querySelectorAll('.merchant-cost-owner').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const item = sheet.document.items.get(ev.currentTarget.dataset.itemId);
-            const update: any = {};
-            update._id = item!.id;
-            update.system = {};
-            update.system.cost = ev.target.value;
-
-            await sheet.document.updateEmbeddedDocuments('Item', [update]);
+    el.querySelectorAll<HTMLElement>('.merchant-cost-owner').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.get(ct.dataset.itemId);
+            await sheet.document.updateEmbeddedDocuments('Item', [{
+                _id: item!.id,
+                system: {cost: (ev.target as HTMLInputElement).value},
+            }]);
         }));
 
     // Merchant owner edit price
-    el.querySelectorAll('.merchant-price-owner').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const item = sheet.document.items.get(ev.currentTarget.dataset.itemId);
-            const update: any = {};
-            update._id = item!.id;
-            update.system = {};
-            update.system.price = ev.target.value;
-
-            await sheet.document.updateEmbeddedDocuments('Item', [update]);
+    el.querySelectorAll<HTMLElement>('.merchant-price-owner').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const item = sheet.document.items.get(ct.dataset.itemId);
+            await sheet.document.updateEmbeddedDocuments('Item', [{
+                _id: item!.id,
+                system: {price: (ev.target as HTMLInputElement).value},
+            }]);
         }));
 }

--- a/src/module/actor/sheet-listeners/scores.ts
+++ b/src/module/actor/sheet-listeners/scores.ts
@@ -6,127 +6,115 @@ import {od6sattributeedit} from "../attribute-edit";
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 
+interface DiceScore { dice: number; pips: number }
+
+/**
+ * Build an updated score for an "edit-X" two-input control: one input changes
+ * dice while the other holds pips (or vice versa). Returns the new total score.
+ */
+function recalcScoreFromInput(
+    target: HTMLInputElement,
+    diceInputId: string,
+    pipsInputId: string,
+    oldScore: DiceScore,
+): number {
+    const newScore: DiceScore = {dice: 0, pips: 0};
+    if (target.id === diceInputId) {
+        newScore.pips = oldScore.pips;
+        newScore.dice = +target.value;
+    } else if (target.id === pipsInputId) {
+        newScore.dice = oldScore.dice;
+        newScore.pips = +target.value;
+    } else {
+        return od6sutilities.getScoreFromDice(oldScore.dice, oldScore.pips);
+    }
+    return od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
+}
+
 /**
  * Register score-related event listeners (attributes, skills, specializations,
  * advances, funds, toughness, maneuverability, body points, etc.) on the actor sheet.
  */
-export function registerScoreListeners(html: any, sheet: any): void {
+export function registerScoreListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
     const el = html[0];
 
     // Rollable abilities.
     const rollDialog = new (od6sroll);
-    el.querySelectorAll('.rolldialog').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.rolldialog').forEach((elem) =>
         elem.addEventListener('click', rollDialog._onRollEvent.bind(sheet)));
-    el.querySelectorAll('.initrolldialog').forEach((elem: any) =>
-        elem.addEventListener('click', od6sInitRoll._onInitRollDialog.bind(sheet)));
-    el.querySelectorAll('.actionroll').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.initrolldialog').forEach((elem) =>
+        elem.addEventListener('click', od6sInitRoll._onInitRollDialog.bind(sheet) as unknown as EventListener));
+    el.querySelectorAll<HTMLElement>('.actionroll').forEach((elem) =>
         elem.addEventListener('click', rollDialog._onRollItem.bind(sheet)));
 
     // Attribute/skill advances
     const advanceDialog = new (od6sadvance);
-    el.querySelectorAll('.advancedialog').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.advancedialog').forEach((elem) =>
         elem.addEventListener('click', advanceDialog._onAdvance.bind(sheet)));
 
     // Attribute context menu (no-op handlers preserved)
-    el.querySelectorAll('.attributedialog').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.attributedialog').forEach((elem) =>
         elem.addEventListener('contextmenu', () => {}));
 
     // Skill context menu (no-op handlers preserved)
-    el.querySelectorAll('.skilldialog').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.skilldialog').forEach((elem) =>
         elem.addEventListener('contextmenu', () => {}));
 
     // Skill specialization
     const specializeDialog = new (od6sspecialize);
-    el.querySelectorAll('.specializedialog').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.specializedialog').forEach((elem) =>
         elem.addEventListener('click', specializeDialog._onSpecialize.bind(sheet)));
 
     // Free edit attribute
     const attributeEditDialog = new od6sattributeedit();
-    el.querySelectorAll('.attribute-edit').forEach((elem: any) =>
+    el.querySelectorAll<HTMLElement>('.attribute-edit').forEach((elem) =>
         elem.addEventListener('click', attributeEditDialog._onAttributeEdit.bind(sheet)));
 
     // Edit funds
-    el.querySelectorAll('.edit-funds').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const newScore: any = {};
-            newScore.dice = 0;
-            newScore.pips = 0;
-            let updateScore = 0;
+    el.querySelectorAll<HTMLElement>('.edit-funds').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const target = ev.target as HTMLInputElement;
             const oldScore = od6sutilities.getDiceFromScore(sheet.document.system.funds.score);
-            if (ev.target.id === 'funds-dice') {
-                newScore.pips = oldScore.pips;
-                newScore.dice = (+ev.target.value);
-                updateScore = od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
-            } else if (ev.target.id === 'funds-pips') {
-                newScore.dice = oldScore.dice;
-                newScore.pips = (+ev.target.value);
-                updateScore = od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
-            }
-            const update: any = {};
-            update.id = sheet.document.id;
-            update[`system.funds.score`] = updateScore;
-            await sheet.document.update(update);
+            const updateScore = recalcScoreFromInput(target, 'funds-dice', 'funds-pips', oldScore);
+            await sheet.document.update({id: sheet.document.id, 'system.funds.score': updateScore});
             sheet.render();
         }));
 
     // Edit maneuverability
-    el.querySelectorAll('.edit-maneuverability').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const newScore: any = {};
-            newScore.dice = 0;
-            newScore.pips = 0;
-            let updateScore = 0;
+    el.querySelectorAll<HTMLElement>('.edit-maneuverability').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const target = ev.target as HTMLInputElement;
             const oldScore = od6sutilities.getDiceFromScore(sheet.document.system.maneuverability.score);
-            if (ev.target.id === 'maneuverability-dice') {
-                newScore.pips = oldScore.pips;
-                newScore.dice = (+ev.target.value);
-                updateScore = od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
-            } else if (ev.target.id === 'maneuverability-pips') {
-                newScore.dice = oldScore.dice;
-                newScore.pips = (+ev.target.value);
-                updateScore = od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
-            }
-            const update: any = {};
-            update.id = sheet.document.id;
-            update[`system.maneuverability.score`] = updateScore;
-            await sheet.document.update(update);
+            const updateScore = recalcScoreFromInput(target, 'maneuverability-dice', 'maneuverability-pips', oldScore);
+            await sheet.document.update({id: sheet.document.id, 'system.maneuverability.score': updateScore});
             sheet.render();
         }));
 
     // Edit toughness
-    el.querySelectorAll('.edit-toughness').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            const newScore: any = {};
-            newScore.dice = 0;
-            newScore.pips = 0;
-            let updateScore = 0;
+    el.querySelectorAll<HTMLElement>('.edit-toughness').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const target = ev.target as HTMLInputElement;
             const oldScore = od6sutilities.getDiceFromScore(sheet.document.system.toughness.score);
-            if (ev.target.id === 'toughness-dice') {
-                newScore.pips = oldScore.pips;
-                newScore.dice = (+ev.target.value);
-                updateScore = od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
-            } else if (ev.target.id === 'toughness-pips') {
-                newScore.dice = oldScore.dice;
-                newScore.pips = (+ev.target.value);
-                updateScore = od6sutilities.getScoreFromDice(newScore.dice, newScore.pips);
-            }
-            const update: any = {};
-            update.id = sheet.document.id;
-            update[`system.toughness.score`] = updateScore;
-            await sheet.document.update(update);
+            const updateScore = recalcScoreFromInput(target, 'toughness-dice', 'toughness-pips', oldScore);
+            await sheet.document.update({id: sheet.document.id, 'system.toughness.score': updateScore});
             sheet.render();
         }));
 
     // Edit body points
-    el.querySelectorAll('.editbodypoints').forEach((elem: any) =>
-        elem.addEventListener('change', async (ev: any) => {
-            await (sheet.document as any).setWoundLevelFromBodyPoints(ev.target.value);
+    el.querySelectorAll<HTMLElement>('.editbodypoints').forEach((elem) =>
+        elem.addEventListener('change', async (ev: Event) => {
+            const target = ev.target as HTMLInputElement;
+            await sheet.document.setWoundLevelFromBodyPoints(+target.value);
             sheet.render();
         }));
 
     // Roll Body Points
-    el.querySelectorAll('.rollbodypoints').forEach((elem: any) =>
-        elem.addEventListener('click', async (_ev: any) => {
+    el.querySelectorAll<HTMLElement>('.rollbodypoints').forEach((elem) =>
+        elem.addEventListener('click', async () => {
             const confirmText = "<p>" + game.i18n.localize("OD6S.CONFIRM_ROLL_BODYPOINTS") + "</p>";
             await Dialog.prompt({
                 title: game.i18n.localize("OD6S.ROLL") + " " + game.i18n.localize(OD6S.bodyPointsName),
@@ -138,32 +126,33 @@ export function registerScoreListeners(html: any, sheet: any): void {
         }));
 
     // Edit active effect (score-related effects)
-    el.querySelectorAll('.edit-effect').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.edit-effect').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             await sheet._editEffect(ev);
         }));
 
     // Event listener for skill usage checkboxes
-    el.querySelectorAll('.skill-used-checkbox, .spec-used-checkbox').forEach((elem: any) =>
-        elem.addEventListener('change', async (event: any) => {
-            const itemId = event.currentTarget.dataset.itemId;
+    el.querySelectorAll<HTMLInputElement>('.skill-used-checkbox, .spec-used-checkbox').forEach((elem) =>
+        elem.addEventListener('change', async (event: Event) => {
+            const ct = event.currentTarget as HTMLInputElement;
+            const itemId = ct.dataset.itemId;
             const item = sheet.document.items.get(itemId);
 
             if (item) {
-                await item.update({'system.used.value': event.currentTarget.checked})
-                    .catch((err: any) => console.error('Failed to update item used status:', err));
+                await item.update({'system.used.value': ct.checked})
+                    .catch((err: unknown) => console.error('Failed to update item used status:', err));
             }
         }));
 
     // Event listener for Session Reset button
-    el.querySelectorAll('.session-reset-button').forEach((elem: any) =>
-        elem.addEventListener('click', (_event: any) => {
-            const checkboxes = el.querySelectorAll('.skill-used-checkbox, .spec-used-checkbox');
-            checkboxes.forEach((checkbox: any) => {
+    el.querySelectorAll<HTMLElement>('.session-reset-button').forEach((elem) =>
+        elem.addEventListener('click', () => {
+            const checkboxes = el.querySelectorAll<HTMLInputElement>('.skill-used-checkbox, .spec-used-checkbox');
+            checkboxes.forEach((checkbox) => {
                 const itemId = checkbox.dataset.itemId;
                 const item = sheet.document.items.get(itemId);
                 if (item) {
-                    item.update({'system.used.value': false}).catch((err: any) => console.error(err));
+                    item.update({'system.used.value': false}).catch((err: unknown) => console.error(err));
                     checkbox.checked = false;
                 } else {
                     console.error("Item not found for reset: ", itemId);

--- a/src/module/actor/sheet-listeners/vehicle.ts
+++ b/src/module/actor/sheet-listeners/vehicle.ts
@@ -6,31 +6,36 @@ import OD6S from "../../config/config-od6s";
 /**
  * Register vehicle-related event listeners on the actor sheet.
  */
-export function registerVehicleListeners(html: any, sheet: any): void {
+export function registerVehicleListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
     const el = html[0];
 
     // Embedded Pilot
-    el.querySelectorAll('.embedded-pilot-add').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.embedded-pilot-add').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
-            const data: any = {};
-            data.targets = game.collections.get('Actor').filter((a: any) => a.type === 'npc' && !a.isToken);
+            const data: Record<string, unknown> = {};
+            data.targets = game.collections.get('Actor').filter((a: Actor) => a.type === 'npc' && !a.isToken);
             data.actor = sheet.document.uuid;
             await new OD6SAddEmbeddedCrew(data).render({force: true});
         }));
 
-    el.querySelectorAll('.embedded-pilot-remove').forEach((elem: any) =>
-        elem.addEventListener('click', async (_ev: any) => {
-            // Remove skills/specs from the base actor
-            let removeSkills = (sheet.document as any).skills.map((i: any) => i._id);
-            removeSkills = removeSkills.concat((sheet.document as any).specializations.map((i: any) => i._id));
+    el.querySelectorAll<HTMLElement>('.embedded-pilot-remove').forEach((elem) =>
+        elem.addEventListener('click', async () => {
+            // Remove skills/specs from the base actor.
+            // `skills`/`specializations` are sheet-prepared item buckets, not on the Actor type.
+            const doc = sheet.document as Actor & {skills: Item[]; specializations: Item[]};
+            let removeSkills = doc.skills.map((i: Item) => i._id);
+            removeSkills = removeSkills.concat(doc.specializations.map((i: Item) => i._id));
             if (removeSkills.length > 0) {
                 await sheet.document.deleteEmbeddedDocuments('Item', removeSkills);
             }
 
             //zero out attributes
-            const update: any = {};
-            update.system = {};
+            const update: Record<string, unknown> = {};
             for (const a in sheet.document.system.attributes) {
                 update[`system.attributes.${a}.base`] = 0;
                 update[`system.embedded_pilot.actor`] = "";
@@ -40,28 +45,29 @@ export function registerVehicleListeners(html: any, sheet: any): void {
         }));
 
     // Force-exit from vehicle
-    el.querySelectorAll('.vehicle-exit').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.vehicle-exit').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             await sheet.document.setFlag('od6s', 'crew', '');
         }));
 
     // Open a crewmember's character sheet
-    el.querySelectorAll('.crew-member').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            const actor = await od6sutilities.getActorFromUuid(ev.currentTarget.dataset.uuid);
+    el.querySelectorAll<HTMLElement>('.crew-member').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const actor = await od6sutilities.getActorFromUuid(ct.dataset.uuid!);
             if (actor!.testUserPermission(game.user, "OWNER")) actor!.sheet.render(true)
         }));
 
     // Add/remove crew to vehicles
-    el.querySelectorAll('.crew-add').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.crew-add').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
-            const data: any = {};
+            const data: Record<string, unknown> = {};
             data.crew = [];
             if (typeof (game.scenes.active) === 'undefined') return;
             let tokens: TokenDocument[] = game.scenes.active.tokens.filter(
-                (t: any) => typeof (t.actor) !== "undefined" && t.actor !== '' && t.actor !== null,
+                (t: TokenDocument) => t.actor != null,
             );
 
             if (tokens.length === 0) {
@@ -70,24 +76,24 @@ export function registerVehicleListeners(html: any, sheet: any): void {
             }
 
             // Filter out tokens who are a vehicle
-            tokens = tokens.filter((t: any) => t.actor.type !== "vehicle" && t.actor.type !== "starship");
+            tokens = tokens.filter((t: TokenDocument) => t.actor!.type !== "vehicle" && t.actor.type !== "starship");
 
             if (game.user.isGM) {
                 // Filter out tokens who are already crew members in a vehicle
-                tokens = tokens.filter((t: any) => !t.actor.isCrewMember());
+                tokens = tokens.filter((t: TokenDocument) => !t.actor!.isCrewMember());
             } else {
                 // If a player, filter out hostile/neutral tokens
-                tokens = tokens.filter((t: any) => t.disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY);
+                tokens = tokens.filter((t: TokenDocument) => t.disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY);
 
                 // Filter out already-crewed tokens
-                const crewed: any[] = [];
+                const crewed: TokenDocument[] = [];
                 for (let i = 0; i < tokens.length; i++) {
                     if (await OD6S.socket.executeAsGM("checkCrewStatus", tokens[i].actor.uuid)) {
                         crewed.push(tokens[i]);
                     }
                 }
 
-                tokens = tokens.filter((e: any) => !crewed.includes(e));
+                tokens = tokens.filter((e: TokenDocument) => !crewed.includes(e));
             }
 
             if (tokens.length === 0) {
@@ -101,24 +107,26 @@ export function registerVehicleListeners(html: any, sheet: any): void {
             new OD6SAddCrew(data).render(true);
         }));
 
-    el.querySelectorAll('.crew-delete').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
+    el.querySelectorAll<HTMLElement>('.crew-delete').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
-            if (!game.user.isGM && sheet.document.uuid === ev.currentTarget.dataset.crewid) {
-                return await OD6S.socket.executeAsGM('unlinkCrew', ev.currentTarget.dataset.crewid, ev.currentTarget.dataset.vehicleid);
-            } else if (game.user.isGM && sheet.document.uuid === ev.currentTarget.dataset.crewid) {
-                const vehicle = await od6sutilities.getActorFromUuid(ev.currentTarget.dataset.vehicleid)
+            const ct = ev.currentTarget as HTMLElement;
+            if (!game.user.isGM && sheet.document.uuid === ct.dataset.crewid) {
+                return await OD6S.socket.executeAsGM('unlinkCrew', ct.dataset.crewid, ct.dataset.vehicleid);
+            } else if (game.user.isGM && sheet.document.uuid === ct.dataset.crewid) {
+                const vehicle = await od6sutilities.getActorFromUuid(ct.dataset.vehicleid!)
                 await vehicle!.sheet.unlinkCrew(sheet.document.uuid);
             } else {
-                return await sheet.unlinkCrew(ev.currentTarget.dataset.crewid);
+                return await sheet.unlinkCrew(ct.dataset.crewid);
             }
         }));
 
     // Vehicle shield allocation
-    el.querySelectorAll('.arc').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            const arc = ev.currentTarget.dataset.arc;
-            const direction = ev.currentTarget.dataset.direction;
+    el.querySelectorAll<HTMLElement>('.arc').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const arc = ct.dataset.arc!;
+            const direction = ct.dataset.direction;
             const value = sheet.document.system.shields.value;
             let allocated = sheet.document.system.shields.allocated;
             let newValue = sheet.document.system.shields.arcs[arc].value;
@@ -139,26 +147,28 @@ export function registerVehicleListeners(html: any, sheet: any): void {
             }
 
             if (doUpdate) {
-                const update: any = {};
-                update._id = sheet.document.id;
-                update.id = sheet.document.id;
-                update.system = {};
-                update.system.shields = {};
-                update.system.shields.arcs = {};
-                update.system.shields.arcs[arc] = {};
-                update.system.shields.allocated = allocated;
-                update.system.shields.arcs[arc].value = newValue;
+                const update = {
+                    _id: sheet.document.id,
+                    id: sheet.document.id,
+                    system: {
+                        shields: {
+                            allocated,
+                            arcs: {[arc]: {value: newValue}},
+                        },
+                    },
+                };
 
                 await sheet.document.update(update, {diff: true});
             }
         }));
 
     // Vehicle shield allocation by crew member
-    el.querySelectorAll('.c-arc').forEach((elem: any) =>
-        elem.addEventListener('click', async (ev: any) => {
-            const actor = await od6sutilities.getActorFromUuid(ev.currentTarget.dataset.uuid);
-            const arc = ev.currentTarget.dataset.arc;
-            const direction = ev.currentTarget.dataset.direction;
+    el.querySelectorAll<HTMLElement>('.c-arc').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const actor = await od6sutilities.getActorFromUuid(ct.dataset.uuid!);
+            const arc = ct.dataset.arc!;
+            const direction = ct.dataset.direction;
             const value = sheet.document.system.vehicle.shields.value;
             let allocated = sheet.document.system.vehicle.shields.allocated;
             let newValue = sheet.document.system.vehicle.shields.arcs[arc].value;
@@ -179,18 +189,19 @@ export function registerVehicleListeners(html: any, sheet: any): void {
             }
 
             if (doUpdate) {
-                const update: any = {};
-                update.system = {};
-                update.system.shields = {};
-                update.system.shields.arcs = {};
-                update.system.shields.arcs[arc] = {};
-                update.system.shields.allocated = allocated;
-                update.system.shields.arcs[arc].value = newValue;
+                const update: Record<string, unknown> = {
+                    system: {
+                        shields: {
+                            allocated,
+                            arcs: {[arc]: {value: newValue}},
+                        },
+                    },
+                };
                 if (game.user.isGM) {
                     await actor!.update(update, {diff: true});
                 } else {
-                    update.uuid = ev.currentTarget.dataset.uuid;
-                    (sheet.document as any).modifyShields(update)
+                    update.uuid = ct.dataset.uuid;
+                    sheet.document.modifyShields(update)
                 }
             }
         }));

--- a/src/module/actor/specialize-dialog.ts
+++ b/src/module/actor/specialize-dialog.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/character-creation.ts
+++ b/src/module/apps/character-creation.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import {
@@ -9,7 +11,6 @@ import {
 } from "./character-creation-helpers";
 import {debug} from "../system/logger";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
 

--- a/src/module/apps/choose-target.ts
+++ b/src/module/apps/choose-target.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-active-attributes.ts
+++ b/src/module/apps/config-active-attributes.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-attributes-sorting.ts
+++ b/src/module/apps/config-attributes-sorting.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-automation.ts
+++ b/src/module/apps/config-automation.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-characterpoints.ts
+++ b/src/module/apps/config-characterpoints.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-custom-fields.ts
+++ b/src/module/apps/config-custom-fields.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-deadliness.ts
+++ b/src/module/apps/config-deadliness.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-difficulty.ts
+++ b/src/module/apps/config-difficulty.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-initiative.ts
+++ b/src/module/apps/config-initiative.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-labels.ts
+++ b/src/module/apps/config-labels.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-miscrules.ts
+++ b/src/module/apps/config-miscrules.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-reveal.ts
+++ b/src/module/apps/config-reveal.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/config-rules.ts
+++ b/src/module/apps/config-rules.ts
@@ -22,8 +22,6 @@
  * See settings-v2.html.
  */
 
-declare const foundry: any;
-
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
 export default class od6sRulesConfiguration extends HandlebarsApplicationMixin(ApplicationV2) {
@@ -61,8 +59,8 @@ export default class od6sRulesConfiguration extends HandlebarsApplicationMixin(A
 
     async _prepareContext(_options?: object): Promise<object> {
         const settings = Array.from(game.settings.settings)
-            .filter((s: any) => s[1].od6sRules)
-            .map((i: any) => i[1]);
+            .filter((s) => s[1].od6sRules)
+            .map((i) => i[1]);
 
         for (const s of settings) {
             s.inputType = s.type === Boolean ? "checkbox" : "text";
@@ -77,7 +75,7 @@ export default class od6sRulesConfiguration extends HandlebarsApplicationMixin(A
         this: od6sRulesConfiguration,
         _event: Event,
         _form: HTMLFormElement,
-        formData: any,
+        formData: { object: Record<string, unknown> },
     ): Promise<void> {
         const data = formData.object;
         for (const setting in data) {

--- a/src/module/apps/config-wild-die.ts
+++ b/src/module/apps/config-wild-die.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/edit-damage.ts
+++ b/src/module/apps/edit-damage.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/edit-difficulty.ts
+++ b/src/module/apps/edit-difficulty.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/explosive-dialog.ts
+++ b/src/module/apps/explosive-dialog.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import ExplosivesTemplate from "./explosives-template";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/handle-wild-die.ts
+++ b/src/module/apps/handle-wild-die.ts
@@ -1,7 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/init-roll-dialog.ts
+++ b/src/module/apps/init-roll-dialog.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/item-info.ts
+++ b/src/module/apps/item-info.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;

--- a/src/module/apps/roll-dialog.ts
+++ b/src/module/apps/roll-dialog.ts
@@ -1,8 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import {od6sroll} from "./roll";
 
-declare const foundry: any;
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/roll-helpers/roll-effects.ts
+++ b/src/module/apps/roll-helpers/roll-effects.ts
@@ -19,8 +19,9 @@ export function getEffectMod(type: string, name: string, actor: Actor): number {
 
         const spec = actor.items.filter((i: Item) => i.type === type && i.name === name)[0];
         if (typeof (spec) !== 'undefined') {
-            if (typeof (sys.customeffects.skills[spec.system.skill]) !== 'undefined') {
-                return sys.customeffects.skills[spec.system.skill];
+            const specSys = spec.system as OD6SSpecializationItemSystem;
+            if (typeof (sys.customeffects.skills[specSys.skill]) !== 'undefined') {
+                return sys.customeffects.skills[specSys.skill];
             }
         }
     }

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -272,37 +272,42 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         const item = rollData.actor.items.get(rollData.itemid);
         if (typeof (item) !== 'undefined') {
             if (item.type === 'specialization') {
-                const skill = rollData.actor.items.find((i: Item) => i.name === item.system.skill);
+                const itemSys = item.system as OD6SSpecializationItemSystem;
+                const skill = rollData.actor.items.find((i: Item) => i.name === itemSys.skill);
                 if (typeof (skill) !== 'undefined' && skill.name !== '') {
-                    if (skill.system.min === true || String(skill.system.min).toLowerCase() === 'true') {
-                        rollMin = od6sutilities.getDiceFromScore(item.system.score +
-                            rollData.actor.system.attributes[item.system.attribute].score).dice * OD6S.pipsPerDice;
+                    const skillSys = skill.system as OD6SSkillItemSystem;
+                    if (skillSys.min === true || String(skillSys.min).toLowerCase() === 'true') {
+                        rollMin = od6sutilities.getDiceFromScore(itemSys.score +
+                            (rollData.actor.system as OD6SCharacterSystem).attributes[itemSys.attribute].score).dice * OD6S.pipsPerDice;
                     }
                 }
                 if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                     await item.update({'system.used.value': true});
                 }
             } else if (item.type === "skill") {
-                if (item.system.min === true || String(item.system.min).toLowerCase() === 'true') {
-                    rollMin = od6sutilities.getDiceFromScore(item.system.score +
-                        rollData.actor.system.attributes[item.system.attribute].score).dice * OD6S.pipsPerDice;
+                const itemSys = item.system as OD6SSkillItemSystem;
+                if (itemSys.min === true || String(itemSys.min).toLowerCase() === 'true') {
+                    rollMin = od6sutilities.getDiceFromScore(itemSys.score +
+                        (rollData.actor.system as OD6SCharacterSystem).attributes[itemSys.attribute].score).dice * OD6S.pipsPerDice;
                 }
                 if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                     await item.update({'system.used.value': true});
                 }
             } else if (item.type === "weapon") {
                 let found = false;
-                const itemData = item.system;
-                if ( itemData.type === 'specialization' && typeof (itemData.stats.specialization) !== 'undefined' &&
+                const itemData = item.system as OD6SWeaponItemSystem;
+                if ( (itemData as unknown as { type: string }).type === 'specialization' && typeof (itemData.stats.specialization) !== 'undefined' &&
                     itemData.stats.specialization !== 'null' && itemData.stats.specialization !== '') {
                     const spec = rollData.actor.items.find((i: Item) => i.name === itemData.stats.specialization);
                     if (typeof (spec) !== 'undefined' && spec.name !== '') {
                         found = true
-                        const skill = rollData.actor.items.find((i: Item) => i.name === spec.system.skill);
+                        const specSys = spec.system as OD6SSpecializationItemSystem;
+                        const skill = rollData.actor.items.find((i: Item) => i.name === specSys.skill);
                         if (typeof (skill) !== 'undefined' && skill.name !== '') {
-                            if (skill.system.min === true || String(skill.system.min).toLowerCase() === 'true') {
-                                rollMin = od6sutilities.getDiceFromScore(spec.system.score +
-                                    rollData.actor.system.attributes[skill.system.attribute].score).dice * OD6S.pipsPerDice;
+                            const skillSys = skill.system as OD6SSkillItemSystem;
+                            if (skillSys.min === true || String(skillSys.min).toLowerCase() === 'true') {
+                                rollMin = od6sutilities.getDiceFromScore(specSys.score +
+                                    (rollData.actor.system as OD6SCharacterSystem).attributes[skillSys.attribute].score).dice * OD6S.pipsPerDice;
                             }
                             if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                                 await spec.update({'system.used.value': true});
@@ -315,9 +320,10 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                     itemData.stats.skill !== 'null' && itemData.stats.skill !== '') {
                     const skill = rollData.actor.items.find((i: Item) => i.name === itemData.stats.skill);
                     if (typeof (skill) !== 'undefined' && skill.name !== '') {
-                        if (skill.system.min === true || String(skill.system.min).toLowerCase() === 'true') {
-                            rollMin = od6sutilities.getDiceFromScore(skill.system.score +
-                                rollData.actor.system.attributes[skill.system.attribute].score).dice * OD6S.pipsPerDice;
+                        const skillSys = skill.system as OD6SSkillItemSystem;
+                        if (skillSys.min === true || String(skillSys.min).toLowerCase() === 'true') {
+                            rollMin = od6sutilities.getDiceFromScore(skillSys.score +
+                                (rollData.actor.system as OD6SCharacterSystem).attributes[skillSys.attribute].score).dice * OD6S.pipsPerDice;
                         }
                         if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                             await skill.update({'system.used.value': true});

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -55,9 +55,9 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
                 item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!.find((i: any) =>i.id === data.itemId);
             }
         }
-        if (item?.system.subtype?.toLowerCase() === 'explosive') {
+        if ((item?.system as OD6SWeaponItemSystem | undefined)?.subtype?.toLowerCase() === 'explosive') {
             isExplosive = true;
-            if (!item.getFlag('od6s','explosiveSet')) {
+            if (!item!.getFlag('od6s','explosiveSet')) {
                 const exdata = {
                     options: OD6S.explosives,
                     item: item!,
@@ -231,13 +231,14 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
         isAttack = true;
         if (typeof (vehicleWeapon) !== 'undefined') {
-            damageScore = vehicleWeapon.system.damage.score;
-            damageType = vehicleWeapon.system.damage.type;
-            if (vehicleWeapon.system.mods.damage !== 0) damageScore += vehicleWeapon.system.mods.damage;
-            if (vehicleWeapon.system.mods.difficulty !== 0) miscMod += vehicleWeapon.system.mods.difficulty;
-            if (vehicleWeapon.system.mods.attack !== 0) bonusmod += vehicleWeapon.system.mods.attack;
-            if (vehicleWeapon.system.scale.score) {
-                attackerScale = vehicleWeapon.system.scale.score;
+            const vwSys = vehicleWeapon.system as OD6SVehicleWeaponItemSystem;
+            damageScore = vwSys.damage.score;
+            damageType = vwSys.damage.type;
+            if (vwSys.mods.damage !== 0) damageScore += vwSys.mods.damage;
+            if (vwSys.mods.difficulty !== 0) miscMod += vwSys.mods.difficulty;
+            if (vwSys.mods.attack !== 0) bonusmod += vwSys.mods.attack;
+            if (vwSys.scale.score) {
+                attackerScale = vwSys.scale.score;
             } else if (data.actor.type === 'vehicle' || data.actor.type === 'starship' || (data.actor.system as OD6SVehicleSystem)?.embedded_pilot) {
                 attackerScale = data.actor.system.scale.score;
             } else {
@@ -341,11 +342,11 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
                     && i.name === game.i18n.localize('OD6S.MELEE_COMBAT'));
                 if (typeof (skill) !== 'undefined') {
                     if (OD6S.flatSkills) {
-                        data.score = data.actor.system.attributes[skill.system.attribute.toLowerCase()].score;
-                        flatPips = skill.system.score;
+                        data.score = (data.actor.system as OD6SCharacterSystem).attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score;
+                        flatPips = (skill.system as OD6SSkillItemSystem).score;
                     } else {
-                        data.score = skill.system.score +
-                            data.actor.system.attributes[skill.system.attribute.toLowerCase()].score;
+                        data.score = (skill.system as OD6SSkillItemSystem).score +
+                            (data.actor.system as OD6SCharacterSystem).attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score;
                     }
                 } else {
                     data.score = data.actor.system.attributes.agi.score;
@@ -357,11 +358,11 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
                     && i.name === game.i18n.localize('OD6S.BRAWL'));
                 if (typeof (skill) !== 'undefined') {
                     if (OD6S.flatSkills) {
-                        data.score = data.actor.system.attributes[skill.system.attribute.toLowerCase()].score;
-                        flatPips = skill.system.score;
+                        data.score = (data.actor.system as OD6SCharacterSystem).attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score;
+                        flatPips = (skill.system as OD6SSkillItemSystem).score;
                     } else {
-                        data.score = skill.system.score +
-                            data.actor.system.attributes[skill.system.attribute.toLowerCase()].score;
+                        data.score = (skill.system as OD6SSkillItemSystem).score +
+                            (data.actor.system as OD6SCharacterSystem).attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score;
                     }
                 } else {
                     const bAttr = game.settings.get('od6s', 'brawl_attribute')
@@ -417,7 +418,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     if ((data.type === 'skill') || (data.type === 'specialization')) {
         isVisible = !game.settings.get('od6s', 'hide-skill-cards');
-        attribute = data.actor.items.filter((i: Item) => i.id === data.itemId)[0].system.attribute.toLowerCase();
+        attribute = (data.actor.items.filter((i: Item) => i.id === data.itemId)[0].system as OD6SSkillItemSystem).attribute.toLowerCase();
         if (typeof (attribute) === 'undefined') {
             attribute = null;
         } else {
@@ -599,10 +600,11 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             const item = data.actor.items.get(data.itemId!);
             if (typeof (item) !== 'undefined') {
                 if (item.type === 'specialization') {
-                    specSkill = item.system.skill;
+                    specSkill = (item.system as OD6SSpecializationItemSystem).skill;
                 } else {
-                    if (data.name === item.system.stats.specialization) {
-                        specSkill = item.system.stats.skill;
+                    const wsys = item.system as OD6SWeaponItemSystem;
+                    if (data.name === wsys.stats.specialization) {
+                        specSkill = wsys.stats.skill;
                     }
                 }
             }
@@ -612,8 +614,9 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if (data.type === 'damage') {
         if (data.itemId) {
             const item = data.actor.items.get(data.itemId);
-            if (item?.system.damaged > 0) {
-                const score = od6sutilities.getScoreFromDice(rollValues.dice, rollValues.pips) - OD6S.weaponDamage[item!.system.damaged].penalty;
+            const wsys = item?.system as OD6SWeaponItemSystem | undefined;
+            if (wsys && wsys.damaged > 0) {
+                const score = od6sutilities.getScoreFromDice(rollValues.dice, rollValues.pips) - OD6S.weaponDamage[wsys.damaged].penalty;
                 rollValues.dice = od6sutilities.getDiceFromScore(score).dice;
                 rollValues.pips = od6sutilities.getDiceFromScore(score).pips;
             }

--- a/src/module/apps/roll.ts
+++ b/src/module/apps/roll.ts
@@ -23,10 +23,11 @@ export class od6sroll {
         if ((actor.type === 'vehicle' || actor.type === 'starship') && (actor.system as OD6SVehicleSystem).embedded_pilot) {
             return item.roll();
         }
-        if (item.system?.subtype.includes("vehicle")) {
-            if (item.system.subtype === 'vehiclerangedweaponattack') {
-                return actor.rollAction(item.system.itemId);
-            } else if (item.system.subtype === 'vehiclesensors') {
+        const sys = item.system as OD6SActionItemSystem;
+        if (sys?.subtype?.includes("vehicle")) {
+            if (sys.subtype === 'vehiclerangedweaponattack') {
+                return actor.rollAction(sys.itemId);
+            } else if (sys.subtype === 'vehiclesensors') {
                 if (game.settings.get('od6s', 'sensors')) {
                     if (item.name.includes(game.i18n.localize('OD6S.SENSORS_PASSIVE'))) {
                         return actor.rollAction('vehiclesensorspassive');
@@ -39,7 +40,7 @@ export class od6sroll {
                     }
                 }
             } else {
-                return actor.rollAction(item.system.subtype);
+                return actor.rollAction(sys.subtype);
             }
         } else {
             return item.roll();

--- a/src/module/config/settings/attributes.ts
+++ b/src/module/config/settings/attributes.ts
@@ -16,7 +16,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.agi.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.agi.active = value)
     })
 
     game.settings.register("od6s", "customize_str_active", {
@@ -27,7 +27,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.str.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.str.active = value)
     })
 
     game.settings.register("od6s", "customize_mec_active", {
@@ -38,7 +38,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.mec.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.mec.active = value)
     })
 
     game.settings.register("od6s", "customize_kno_active", {
@@ -49,7 +49,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.kno.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.kno.active = value)
     })
 
     game.settings.register("od6s", "customize_per_active", {
@@ -60,7 +60,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.per.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.per.active = value)
     })
 
     game.settings.register("od6s", "customize_tec_active", {
@@ -71,7 +71,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.tec.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.tec.active = value)
     })
 
     game.settings.register("od6s", "customize_ca1_active", {
@@ -82,7 +82,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.ca1.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.ca1.active = value)
     })
 
     game.settings.register("od6s", "customize_ca2_active", {
@@ -93,7 +93,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.ca2.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.ca2.active = value)
     })
 
     game.settings.register("od6s", "customize_ca3_active", {
@@ -104,7 +104,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.ca3.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.ca3.active = value)
     })
 
     game.settings.register("od6s", "customize_ca4_active", {
@@ -115,7 +115,7 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.ca4.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.ca4.active = value)
     })
 
     game.settings.register("od6s", "customize_met_active", {
@@ -126,6 +126,6 @@ export function registerAttributeSettings() {
         type: Boolean,
         default: true,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.attributes.met.active = value)
+        onChange: (value: boolean) => (OD6S.attributes.met.active = value)
     })
 }

--- a/src/module/config/settings/automation.ts
+++ b/src/module/config/settings/automation.ts
@@ -10,7 +10,7 @@ export function registerAutomationSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.autoOpposed = value : true)
+        onChange: (value: boolean) => (value ? OD6S.autoOpposed = value : true)
     })
 
     game.settings.register("od6s", "auto_explosive", {
@@ -22,7 +22,7 @@ export function registerAutomationSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.autoPromptPlayerResistance = value : true)
+        onChange: (value: boolean) => (value ? OD6S.autoPromptPlayerResistance = value : true)
     })
 
     game.settings.register("od6s", "auto_prompt_player_resistance", {
@@ -34,7 +34,7 @@ export function registerAutomationSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.autoPromptPlayerResistance = value : true)
+        onChange: (value: boolean) => (value ? OD6S.autoPromptPlayerResistance = value : true)
     })
 
     /*
@@ -92,7 +92,7 @@ export function registerAutomationSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.autoOpposed = value : true)
+        onChange: (value: boolean) => (value ? OD6S.autoOpposed = value : true)
     })
 
     game.settings.register("od6s", "auto_skill_used", {
@@ -104,6 +104,6 @@ export function registerAutomationSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.autoSkillUsed = value : true)
+        onChange: (value: boolean) => (value ? OD6S.autoSkillUsed = value : true)
     })
 }

--- a/src/module/config/settings/character-points.ts
+++ b/src/module/config/settings/character-points.ts
@@ -10,7 +10,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 2,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.skill = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.skill = value : 2)
     })
 
     game.settings.register("od6s", "character_points_attribute_limit", {
@@ -22,7 +22,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 2,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.attribute = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.attribute = value : 2)
     })
 
     game.settings.register("od6s", "character_points_specialization_limit", {
@@ -34,7 +34,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.specialization = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.specialization = value : 2)
     })
 
     game.settings.register("od6s", "character_points_dodge_limit", {
@@ -46,7 +46,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.dodge = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.dodge = value : 2)
     })
 
     game.settings.register("od6s", "character_points_parry_limit", {
@@ -58,7 +58,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.parry = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.parry = value : 2)
     })
 
     game.settings.register("od6s", "character_points_block_limit", {
@@ -70,7 +70,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.block = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.block = value : 2)
     })
 
     game.settings.register("od6s", "character_points_dr_limit", {
@@ -82,7 +82,7 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.dr = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.dr = value : 2)
     })
 
     game.settings.register("od6s", "character_points_init_limit", {
@@ -94,6 +94,6 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.characterPointLimits.init = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.init = value : 2)
     })
 }

--- a/src/module/config/settings/combat.ts
+++ b/src/module/config/settings/combat.ts
@@ -1,7 +1,7 @@
 import OD6S from "../config-od6s";
 import {od6sutilities} from "../../system/utilities";
 
-export async function updateRerollInitiative(value: any) {
+export async function updateRerollInitiative(value: boolean) {
     if (value) {
         OD6S.initiative.reroll_character = game.settings.get('od6s', 'auto_reroll_character');
         OD6S.initiative.reroll_npc = game.settings.get('od6s', 'auto_reroll_npc');
@@ -24,7 +24,7 @@ export function registerCombatSettings() {
         default: 'per',
         requiresReload: true,
         choices: od6sutilities.getActiveAttributesSelect(),
-        onChange: (value: any) => (OD6S.initiative.attribute = value)
+        onChange: (value: string) => (OD6S.initiative.attribute = value)
     })
 
     game.settings.register("od6s", "reroll_initiative", {
@@ -36,7 +36,7 @@ export function registerCombatSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (updateRerollInitiative(value))
+        onChange: (value: boolean) => (updateRerollInitiative(value))
     })
 
     game.settings.register("od6s", "auto_reroll_npc", {
@@ -48,7 +48,7 @@ export function registerCombatSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.initiative.reroll_npc = value : false)
+        onChange: (value: boolean) => (value ? OD6S.initiative.reroll_npc = value : false)
     })
 
     game.settings.register("od6s", "auto_reroll_character", {
@@ -60,7 +60,7 @@ export function registerCombatSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.initiative.reroll_character = value : false)
+        onChange: (value: boolean) => (value ? OD6S.initiative.reroll_character = value : false)
     })
 
     game.settings.register("od6s", "auto_init_dsn", {
@@ -72,7 +72,7 @@ export function registerCombatSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => (value ? OD6S.initiative.dsn = value : false)
+        onChange: (value: boolean) => (value ? OD6S.initiative.dsn = value : false)
     })
 
     game.settings.register("od6s", "brawl_attribute", {
@@ -118,7 +118,7 @@ export function registerCombatSettings() {
         od6sRules: true,
         type: Boolean,
         default: false,
-        onChange: (value: any) => OD6S.defenseLock = value
+        onChange: (value: boolean) => OD6S.defenseLock = value
     })
 
     game.settings.register("od6s", "fate_point_round", {
@@ -130,7 +130,7 @@ export function registerCombatSettings() {
         type: Boolean,
         default: false,
         requiresReload: true,
-        onChange: (value: any) => OD6S.fatePointRound = value
+        onChange: (value: boolean) => OD6S.fatePointRound = value
     })
 
     game.settings.register("od6s", "fate_point_climactic", {
@@ -141,6 +141,6 @@ export function registerCombatSettings() {
         od6sRules: true,
         type: Boolean,
         default: false,
-        onChange: (value: any) => OD6S.fatePointClimactic = value
+        onChange: (value: boolean) => OD6S.fatePointClimactic = value
     })
 }

--- a/src/module/config/settings/display.ts
+++ b/src/module/config/settings/display.ts
@@ -76,7 +76,7 @@ export function registerDisplaySettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.highlightEffects = value
+        onChange: (value: boolean) => OD6S.highlightEffects = value
     })
 
     game.settings.register("od6s", "show_skill_specialization", {
@@ -87,7 +87,7 @@ export function registerDisplaySettings() {
         default: true,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.showSkillSpecialization = value
+        onChange: (value: boolean) => OD6S.showSkillSpecialization = value
     })
 
     game.settings.register("od6s", "show_metaphysics_attributes", {

--- a/src/module/config/settings/rules.ts
+++ b/src/module/config/settings/rules.ts
@@ -15,7 +15,7 @@ export function registerRulesSettings() {
             "2": game.i18n.localize("OD6S.CONFIG_USE_BODY_ONLY")
         },
         requiresReload: true,
-        onChange: (value: any) => (OD6S.woundConfig = value)
+        onChange: (value: number) => (OD6S.woundConfig = value)
     })
 
     game.settings.register("od6s", "stun_damage_increment", {
@@ -27,7 +27,7 @@ export function registerRulesSettings() {
         default: true,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.stunDamageIncrement = value)
+        onChange: (value: boolean) => (OD6S.stunDamageIncrement = value)
     })
 
     game.settings.register("od6s", "highhitdamage", {
@@ -39,7 +39,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.highHitDamage = value)
+        onChange: (value: boolean) => (OD6S.highHitDamage = value)
     })
 
     game.settings.register("od6s", "weapon_armor_damage", {
@@ -51,7 +51,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.highHitDamage = value)
+        onChange: (value: boolean) => (OD6S.highHitDamage = value)
     })
 
     game.settings.register("od6s", "track_stuns", {
@@ -63,7 +63,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => (OD6S.trackStuns = value)
+        onChange: (value: boolean) => (OD6S.trackStuns = value)
     })
 
     /* TODO
@@ -125,7 +125,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.specializationDice = value
+        onChange: (value: boolean) => OD6S.specializationDice = value
     })
 
     game.settings.register("od6s", "strength_damage", {
@@ -179,7 +179,7 @@ export function registerRulesSettings() {
         default: true,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.vehicleDifficulty = value
+        onChange: (value: boolean) => OD6S.vehicleDifficulty = value
     })
 
     game.settings.register("od6s", "stun_dice", {
@@ -190,7 +190,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: false,
         type: Boolean,
-        onChange: (value: any) => OD6S.passengerDamageDice = value
+        onChange: (value: boolean) => OD6S.passengerDamageDice = value
     })
 
     game.settings.register("od6s", "passenger_damage_dice", {
@@ -201,7 +201,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: false,
         type: Boolean,
-        onChange: (value: any) => OD6S.passengerDamageDice = value
+        onChange: (value: boolean) => OD6S.passengerDamageDice = value
     })
 
     game.settings.register("od6s", "dice_for_grenades", {
@@ -213,7 +213,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.grenadeDamageDice = value
+        onChange: (value: boolean) => OD6S.grenadeDamageDice = value
     })
 
     game.settings.register("od6s", "explosive_end_of_round", {
@@ -234,7 +234,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: true,
         type: Boolean,
-        onChange: (value: any) => OD6S.hideExplosiveTemplates = value
+        onChange: (value: boolean) => OD6S.hideExplosiveTemplates = value
     })
 
     game.settings.register("od6s", "explosive_zones", {
@@ -255,7 +255,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: false,
         type: Boolean,
-        onChange: (value: any) => OD6S.mapRange = value
+        onChange: (value: boolean) => OD6S.mapRange = value
     })
 
     game.settings.register("od6s", "melee_difficulty", {
@@ -267,7 +267,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.meleeDifficulty = value
+        onChange: (value: boolean) => OD6S.meleeDifficulty = value
     })
 
     game.settings.register("od6s", "cost", {
@@ -282,7 +282,7 @@ export function registerRulesSettings() {
             "0": game.i18n.localize("OD6S.CONFIG_COST_PRICE"),
             "1": game.i18n.localize("OD6S.CONFIG_COST_COST"),
         },
-        onChange: (value: any) => OD6S.cost = value
+        onChange: (value: string) => OD6S.cost = value
     })
 
     game.settings.register("od6s", "funds_fate", {
@@ -294,7 +294,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.fundsWild = value
+        onChange: (value: boolean) => OD6S.fundsWild = value
     })
 
     game.settings.register("od6s", "random_hit_locations", {
@@ -305,7 +305,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: false,
         type: Boolean,
-        onChange: (value: any) => OD6S.randomHitLocations = value
+        onChange: (value: boolean) => OD6S.randomHitLocations = value
     })
 
     game.settings.register("od6s", "pip_per_dice", {
@@ -316,7 +316,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: 3,
         type: Number,
-        onChange: (value: any) => OD6S.pipsPerDice = value
+        onChange: (value: number) => OD6S.pipsPerDice = value
     })
 
     game.settings.register("od6s", "flat_skills", {
@@ -328,7 +328,7 @@ export function registerRulesSettings() {
         default: false,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.flatSkills = value
+        onChange: (value: boolean) => OD6S.flatSkills = value
     })
 
     game.settings.register("od6s", "skill_used", {
@@ -340,7 +340,7 @@ export function registerRulesSettings() {
         default: true,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.flatSkills = value
+        onChange: (value: boolean) => OD6S.flatSkills = value
     })
 
     game.settings.register("od6s", "spec_link", {
@@ -352,7 +352,7 @@ export function registerRulesSettings() {
         default: true,
         type: Boolean,
         requiresReload: true,
-        onChange: (value: any) => OD6S.flatSkills = value
+        onChange: (value: boolean) => OD6S.flatSkills = value
     })
 
     game.settings.register("od6s", "initial_attributes", {
@@ -363,7 +363,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: OD6S.initialAttributes,
         type: Number,
-        onChange: (value: any) => OD6S.initialAttributes = value
+        onChange: (value: number) => OD6S.initialAttributes = value
     })
 
     game.settings.register("od6s", "initial_skills", {
@@ -375,7 +375,7 @@ export function registerRulesSettings() {
         default: OD6S.initialSkills,
         type: Number,
         requiresReload: true,
-        onChange: (value: any) => OD6S.initialSkills = value
+        onChange: (value: number) => OD6S.initialSkills = value
     })
 
     game.settings.register("od6s", "initial_character_points", {
@@ -386,7 +386,7 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: OD6S.initialCharacterPoints,
         type: Number,
-        onChange: (value: any) => OD6S.initialCharacterPoints = value
+        onChange: (value: number) => OD6S.initialCharacterPoints = value
     })
 
     game.settings.register("od6s", "initial_fate_points", {
@@ -398,7 +398,7 @@ export function registerRulesSettings() {
         default: OD6S.initialFatePoints,
         type: Number,
         requiresReload: true,
-        onChange: (value: any) => OD6S.initialFatePoints = value
+        onChange: (value: number) => OD6S.initialFatePoints = value
     })
 
     game.settings.register("od6s", "initial_move", {
@@ -409,6 +409,6 @@ export function registerRulesSettings() {
         od6sRules: true,
         default: OD6S.initialMove,
         type: Number,
-        onChange: (value: any) => OD6S.initialMove = value
+        onChange: (value: number) => OD6S.initialMove = value
     })
 }

--- a/src/module/config/settings/wild-die.ts
+++ b/src/module/config/settings/wild-die.ts
@@ -27,7 +27,7 @@ export function registerWildDieSettings() {
             "3": game.i18n.localize("OD6S.CONFIG_WILD_DIE_3")
         },
         requiresReload: true,
-        onChange: (value: any) => (OD6S.wildDieOneDefault = value)
+        onChange: (value: number) => (OD6S.wildDieOneDefault = value)
     })
 
     game.settings.register("od6s", "default_wild_die_one_handle", {
@@ -43,7 +43,7 @@ export function registerWildDieSettings() {
             "0": game.i18n.localize("OD6S.CONFIG_WILD_DIE_HANDLE_0"),
             "1": game.i18n.localize("OD6S.CONFIG_WILD_DIE_HANDLE_1")
         },
-        onChange: (value: any) => (OD6S.wildDieOneAuto = value)
+        onChange: (value: number) => (OD6S.wildDieOneAuto = value)
     })
 
     game.settings.register("od6s", "wild_die_one_face", {

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -7,9 +7,15 @@ import {OD6SChooseTarget} from "../apps/choose-target";
 import {OD6SHandleWildDieForm} from "../apps/handle-wild-die";
 
 // Delegated event helper: attaches a listener on a parent that fires when a child matching selector is the target
-function delegateEvent(parent: any, eventType: any, selector: any, handler: any) {
-    parent.addEventListener(eventType, (ev: any) => {
-        const target = ev.target.closest(selector);
+function delegateEvent(
+    parent: HTMLElement,
+    eventType: string,
+    selector: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handler: (ev: any) => void,
+) {
+    parent.addEventListener(eventType, (ev: Event) => {
+        const target = (ev.target as Element | null)?.closest(selector);
         if (target && parent.contains(target)) {
             // Make ev.currentTarget behave like jQuery delegation
             Object.defineProperty(ev, 'currentTarget', { value: target, configurable: true });

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -1,8 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
 import OD6S from "../config/config-od6s";
 
-declare const foundry: any;
 
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
 const ItemSheetV2 = foundry.applications.sheets.ItemSheetV2;

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -120,7 +120,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
             case "weapon":
                 if (item.type === "specialization") {
-                    this.item.system.stats.specialization = item.system.name;
+                    (this.item.system as OD6SWeaponItemSystem).stats.specialization = (item as Item).name;
                     await this.item.update(this.item.system, {diff: true});
                 }
         }
@@ -379,9 +379,9 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         }
 
         const item = await od6sutilities.getItemByName(name);
-        const description = item ? item.system.description : "";
+        const description = item ? (item.system as { description?: string }).description ?? "" : "";
         const newItem = {name, type, description};
-        itemSheet.item.system.items.push(newItem);
+        (itemSheet.item.system as { items: unknown[] }).items.push(newItem);
         await itemSheet.item.update(
             {id: itemSheet.id, system: itemSheet.item.system},
             {diff: true});

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -25,7 +25,7 @@ export class OD6SItem extends Item {
      */
     prepareData() {
         super.prepareData();
-        this.system.config = OD6S;
+        (this.system as unknown as Record<string, unknown>).config = OD6S;
     }
 
     prepareBaseData() {
@@ -37,14 +37,19 @@ export class OD6SItem extends Item {
      */
     prepareDerivedData() {
         if (this.type === 'skill' || this.type === 'specialization') {
-            this.system.score = (+this.system.base) + (+this.system.mod);
+            const sys = this.system as OD6SSkillItemSystem;
+            sys.score = (+sys.base) + (+sys.mod);
         }
         if (this.type === 'starship-weapon' || this.type === 'vehicle-weapon') {
-            this.system.stats = {};
-            this.system.stats.attribute = this.system.attribute.value;
-            this.system.stats.skill = this.system.skill.value;
-            this.system.stats.specialization = this.system.specialization.value;
-            this.system.subtype = 'vehiclerangedweaponattack';
+            const sys = this.system as OD6SVehicleWeaponItemSystem & {
+                stats: { attribute: string; skill: string; specialization: string };
+                subtype: string;
+            };
+            sys.stats = {} as typeof sys.stats;
+            sys.stats.attribute = sys.attribute.value;
+            sys.stats.skill = sys.skill.value;
+            sys.stats.specialization = sys.specialization.value;
+            sys.subtype = 'vehiclerangedweaponattack';
         }
     }
 
@@ -71,40 +76,45 @@ export class OD6SItem extends Item {
 
     applyMods() {
         if(this.type.match(/^(skill|specialization)/)) {
-            this.system.score = (+this.system.base) + (+this.system.mod);
+            const sys = this.system as OD6SSkillItemSystem;
+            sys.score = (+sys.base) + (+sys.mod);
         }
     }
 
     getScore() {
         if (this.type.match(/^(skill|specialization)/)) {
             if (this.actor) {
-                if (this.system.isAdvancedSkill) {
-                    return this.system.score;
+                const sys = this.system as OD6SSkillItemSystem;
+                const actorSys = this.actor.system as OD6SCharacterSystem;
+                if (sys.isAdvancedSkill) {
+                    return sys.score;
                 } else {
-                    return this.actor.system.attributes[this.system.attribute.toLowerCase()].score + this.system.score;
+                    return actorSys.attributes[sys.attribute.toLowerCase()].score + sys.score;
                 }
             }
         }
         if (this.type.match(/weapon/)) {
             if (this.actor) {
-                let score = this.actor.system.attributes[this.system.stats.attribute.toLowerCase()].score;
-                const spec = this.actor.items.find(i => i.name === this.system.stats.specialization && i.type === 'specialization');
+                const sys = this.system as OD6SWeaponItemSystem & { fire_control?: { score: number } };
+                const actorSys = this.actor.system as OD6SCharacterSystem;
+                let score = actorSys.attributes[sys.stats.attribute.toLowerCase()].score;
+                const spec = this.actor.items.find(i => i.name === sys.stats.specialization && i.type === 'specialization');
                 if (typeof spec !== 'undefined') {
-                    if (typeof this.system.fire_control !== 'undefined' && this.system.fire_control?.score !== '') {
-                        score = score + this.system.fire_control.score;
+                    if (typeof sys.fire_control !== 'undefined' && (sys.fire_control?.score as unknown) !== '') {
+                        score = score + sys.fire_control.score;
                     }
-                    return score + spec.system.score;
+                    return score + (spec.system as OD6SSpecializationItemSystem).score;
                 } else {
-                    const skill = this.actor.items.find(i => i.name === this.system.stats.skill && i.type === 'skill');
+                    const skill = this.actor.items.find(i => i.name === sys.stats.skill && i.type === 'skill');
                     if (typeof skill !== 'undefined') {
-                        if (typeof this.system.fire_control !== 'undefined' && this.system.fire_control?.score !== '') {
-                            score = score + this.system.fire_control.score;
+                        if (typeof sys.fire_control !== 'undefined' && (sys.fire_control?.score as unknown) !== '') {
+                            score = score + sys.fire_control.score;
                         }
-                        return score + skill.system.score;
+                        return score + (skill.system as OD6SSkillItemSystem).score;
                     }
                 }
-                if (typeof this.system.fire_control?.score !== 'undefined' && this.system.fire_control?.score !== '') {
-                    score = score + this.system.fire_control.score;
+                if (typeof sys.fire_control?.score !== 'undefined' && (sys.fire_control?.score as unknown) !== '') {
+                    score = score + sys.fire_control.score;
                 }
                 return score;
             }
@@ -112,19 +122,20 @@ export class OD6SItem extends Item {
     }
 
     getScoreText() {
-        return od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(this.getScore()))
+        return od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(this.getScore() ?? 0))
     }
 
     getParryText() {
         if (this.type === 'weapon') {
             if (this.actor) {
-                if (this.system.stats.parry_specialization !== '') {
-                    const spec = this.actor.items.find(s => s.name === this.system.stats.parry_specialization && s.type === 'specialization');
+                const sys = this.system as OD6SWeaponItemSystem;
+                if (sys.stats.parry_specialization !== '') {
+                    const spec = this.actor.items.find(s => s.name === sys.stats.parry_specialization && s.type === 'specialization');
                     if (typeof spec !== 'undefined') return spec.getScoreText();
                 }
-                if (this.system.stats.parry_skill !== '') {
+                if (sys.stats.parry_skill !== '') {
                     if(this.actor) {
-                        const skill = this.actor.items.find(s=>s.name === this.system.stats.parry_skill && s.type === 'skill' );
+                        const skill = this.actor.items.find(s=>s.name === sys.stats.parry_skill && s.type === 'skill' );
                         if (typeof skill !== 'undefined') return skill.getScoreText();
                     }
                 }
@@ -220,14 +231,15 @@ export class OD6SItem extends Item {
         switch (item.type) {
             case 'skill':
             case 'specialization': {
+                const sys = itemData as OD6SSkillItemSystem;
                 if (OD6S.flatSkills) {
-                    rollData.score = +(actorData.attributes[itemData.attribute.toLowerCase()].score);
-                    flatPips = (+itemData.score)
+                    rollData.score = +(actorData.attributes[sys.attribute.toLowerCase()].score);
+                    flatPips = (+sys.score)
                 } else {
-                    if (itemData.isAdvancedSkill) {
-                        rollData.score = (+itemData.score);
+                    if (sys.isAdvancedSkill) {
+                        rollData.score = (+sys.score);
                     } else {
-                        rollData.score = (+itemData.score) + actorData.attributes[itemData.attribute.toLowerCase()].score;
+                        rollData.score = (+sys.score) + actorData.attributes[sys.attribute.toLowerCase()].score;
                     }
                 }
                 break;
@@ -235,25 +247,27 @@ export class OD6SItem extends Item {
             case 'starship-weapon':
             case 'vehicle-weapon':
             case 'weapon': {
+                const sys = itemData as OD6SWeaponItemSystem;
                 // Try a specialization first, then a skill, then an attribute
                 let found = false;
 
                 if (parry && game.settings.get('od6s','parry_skills')) {
                     let skill;
-                    if(typeof(this.system.stats.parry_specialization) !== "undefined" && this.system.stats.parry_specialization !== "") {
-                        skill = actor.items.find((skill: Item) => skill.name === this.system.stats.parry_specialization && skill.type === 'specialization');
+                    if(typeof(sys.stats.parry_specialization) !== "undefined" && sys.stats.parry_specialization !== "") {
+                        skill = actor.items.find((skill: Item) => skill.name === sys.stats.parry_specialization && skill.type === 'specialization');
                     }
-                    else if(typeof(this.system.stats.parry_skill) !== "undefined" && this.system.stats.parry_skill !== "") {
-                    	skill = actor.items.find((skill: Item) => skill.name === this.system.stats.parry_skill && skill.type === 'skill');
+                    else if(typeof(sys.stats.parry_skill) !== "undefined" && sys.stats.parry_skill !== "") {
+                    	skill = actor.items.find((skill: Item) => skill.name === sys.stats.parry_skill && skill.type === 'skill');
                      } else {
                     	skill = actor.items.find((skill: Item) => skill.name === game.i18n.localize(OD6S.actions.parry.skill) && skill.type === 'skill');
                     }
                     if (skill) {
+                        const skillSys = skill.system as OD6SSkillItemSystem;
                         if(OD6S.flatSkills) {
-                            rollData.score = (+actorData.attributes[skill.system.attribute.toLowerCase()].score);
-                            flatPips = (+skill.system.score);
+                            rollData.score = (+actorData.attributes[skillSys.attribute.toLowerCase()].score);
+                            flatPips = (+skillSys.score);
                         } else {
-                            rollData.score = (+skill.system.score) + (+actorData.attributes[skill.system.attribute.toLowerCase()].score);
+                            rollData.score = (+skillSys.score) + (+actorData.attributes[skillSys.attribute.toLowerCase()].score);
                         }
                     } else {
                         rollData.score = actorData.attributes[OD6S.actions.parry.base.toLowerCase()].score;
@@ -261,33 +275,35 @@ export class OD6SItem extends Item {
                     found = true;
                 }
 
-                if (!found && itemData.stats.specialization !== null) {
-                    const spec = actor.items.find((spec: Item) => spec.name === itemData.stats.specialization && spec.type === 'specialization');                    if (spec) {
+                if (!found && sys.stats.specialization !== null) {
+                    const spec = actor.items.find((spec: Item) => spec.name === sys.stats.specialization && spec.type === 'specialization');                    if (spec) {
+                        const specSys = spec.system as OD6SSpecializationItemSystem;
                         if(OD6S.flatSkills) {
-                            rollData.score = (+actorData.attributes[spec.system.attribute.toLowerCase()].score);
-                            flatPips = (+spec.system.score);
+                            rollData.score = (+actorData.attributes[specSys.attribute.toLowerCase()].score);
+                            flatPips = (+specSys.score);
                         } else {
-                            rollData.score = (+spec.system.score) + (+actorData.attributes[spec.system.attribute.toLowerCase()].score);
+                            rollData.score = (+specSys.score) + (+actorData.attributes[specSys.attribute.toLowerCase()].score);
                         }
                         found = true;
                     }
                 }
                 if (!found) {
                     // See if the actor has the associated skill
-                    const skill = actor.items.find((skill: Item) => skill.name === itemData.stats.skill && skill.type === 'skill');
-                    let attr = actorData.attributes[itemData.stats.attribute.toLowerCase()];
+                    const skill = actor.items.find((skill: Item) => skill.name === sys.stats.skill && skill.type === 'skill');
+                    let attr = actorData.attributes[sys.stats.attribute.toLowerCase()];
                     if(typeof(attr?.score) === "undefined" || attr === null) {
                         // See if it maps to the "shortname" of a custom attribute label
                         // @ts-expect-error
-                        attr = actorData.attributes[od6sutilities.lookupAttributeKey(itemData.stats.attribute.toLowerCase())];
+                        attr = actorData.attributes[od6sutilities.lookupAttributeKey(sys.stats.attribute.toLowerCase())];
                         if(typeof(attr?.score) === "undefined" || attr === null) return false;
                     }
                     if (typeof (skill) !== 'undefined' && skill !== null) {
+                        const skillSys = skill.system as OD6SSkillItemSystem;
                         if(OD6S.flatSkills) {
                             rollData.score = (+attr.score);
-                            flatPips = (+skill.system.score);
+                            flatPips = (+skillSys.score);
                         } else {
-                            rollData.score = (+skill.system.score) + (+attr.score);
+                            rollData.score = (+skillSys.score) + (+attr.score);
                         }
                     } else {
                         // Finally, use base attribute
@@ -305,22 +321,23 @@ export class OD6SItem extends Item {
                 break;
             }
             case 'action': {
+                const sys = itemData as OD6SActionItemSystem;
                 let name = '';
-                if ((itemData.subtype === 'rangedattack' || itemData.subtype === 'meleeattack') && itemData.itemId !== '') {
+                if ((sys.subtype === 'rangedattack' || sys.subtype === 'meleeattack') && sys.itemId !== '') {
                     // Roll is linked to an inventory item, roll that instead
-                    const targetItem = actor.items.find((i: Item) => i.id === itemData.itemId);
+                    const targetItem = actor.items.find((i: Item) => i.id === sys.itemId);
                     return targetItem?.roll(parry);
                 }
 
-                if (itemData.subtype === 'dodge' || itemData.subtype === 'parry' || itemData.subtype === 'block') {
+                if (sys.subtype === 'dodge' || sys.subtype === 'parry' || sys.subtype === 'block') {
                     // Get the appropriate skill or attribute
-                    switch (itemData.subtype) {
+                    switch (sys.subtype) {
                         case 'dodge':
                             name = 'OD6S.DODGE';
                             break;
                         case 'parry':
-                            if (actor.items.find((i: Item) => i.id === itemData.itemId)) {
-                                const targetItem = actor.items.find((i: Item) => i.id === itemData.itemId);
+                            if (actor.items.find((i: Item) => i.id === sys.itemId)) {
+                                const targetItem = actor.items.find((i: Item) => i.id === sys.itemId);
                                 return targetItem?.roll(true);
                             } else {
                                 name = OD6S.actions.parry.skill;
@@ -333,14 +350,14 @@ export class OD6SItem extends Item {
                 }
                 name = game.i18n.localize(name);
 
-                if (itemData.subtype === 'attribute') {
-                    rollData.attribute = itemData.itemId;
+                if (sys.subtype === 'attribute') {
+                    rollData.attribute = sys.itemId;
                 } else {
                     let skill;
                     //let name = item.name;
                     name = game.i18n.localize(name);
-                    if (typeof (itemData.itemId) !== 'undefined' && itemData.itemId !== '') {
-                        skill = actor.items.find((i: Item) => i.type === itemData.subtype && i.id === itemData.itemId);
+                    if (typeof (sys.itemId) !== 'undefined' && sys.itemId !== '') {
+                        skill = actor.items.find((i: Item) => i.type === sys.subtype && i.id === sys.itemId);
                     } else {
                         skill = actor.items.find((i: Item) => i.name === name);
                     }
@@ -349,7 +366,7 @@ export class OD6SItem extends Item {
                             rollData.score = (+actorData.attributes[(skill as any).system.attribute.toLowerCase()].score);
                             flatPips = (+(skill as any).system.score);
                         } else {
-                            if(this.system.isAdvancedSkill) {
+                            if((this.system as OD6SSkillItemSystem).isAdvancedSkill) {
                                 rollData.score = (+(skill as any).system.score);
                             } else {
                                 rollData.score = (+(skill as any).system.score) + (+actorData.attributes[(skill as any).system.attribute.toLowerCase()].score);
@@ -368,7 +385,7 @@ export class OD6SItem extends Item {
                             } else {
                                 // Cannot find, use defaults for the type
                                 for (const a in OD6S.actions) {
-                                    if (OD6S.actions[a].type === itemData.subtype) {
+                                    if (OD6S.actions[a].type === (itemData as OD6SActionItemSystem).subtype) {
                                         rollData.score = (+actorData.attributes[OD6S.actions[a].base].score);
                                         break;
                                     }
@@ -383,12 +400,13 @@ export class OD6SItem extends Item {
         }
 
         if(item.type === 'starship-weapon' || item.type === 'vehicle-weapon') {
-            if(item.system?.fire_control.score > 0) {
-                rollData.score = (+rollData.score) + (+item.system.fire_control.score);
+            const sys = item.system as OD6SVehicleWeaponItemSystem;
+            if(sys?.fire_control.score > 0) {
+                rollData.score = (+rollData.score) + (+sys.fire_control.score);
             }
         }
 
-        let subtype = itemData.subtype;
+        let subtype = (itemData as OD6SActionItemSystem).subtype;
         if (parry) {
             subtype = "parry";
         }

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -361,27 +361,27 @@ export class OD6SItem extends Item {
                     } else {
                         skill = actor.items.find((i: Item) => i.name === name);
                     }
-                    if (skill !== null && typeof (skill) !== 'undefined' && typeof ((skill as any).system.score) !== 'undefined') {
+                    const skillSys = skill?.system as OD6SSkillItemSystem | undefined;
+                    if (skill !== null && typeof (skill) !== 'undefined' && typeof (skillSys?.score) !== 'undefined') {
                         if(OD6S.flatSkills) {
-                            rollData.score = (+actorData.attributes[(skill as any).system.attribute.toLowerCase()].score);
-                            flatPips = (+(skill as any).system.score);
+                            rollData.score = (+actorData.attributes[skillSys!.attribute.toLowerCase()].score);
+                            flatPips = (+skillSys!.score);
                         } else {
                             if((this.system as OD6SSkillItemSystem).isAdvancedSkill) {
-                                rollData.score = (+(skill as any).system.score);
+                                rollData.score = (+skillSys!.score);
                             } else {
-                                rollData.score = (+(skill as any).system.score) + (+actorData.attributes[(skill as any).system.attribute.toLowerCase()].score);
+                                rollData.score = (+skillSys!.score) + (+actorData.attributes[skillSys!.attribute.toLowerCase()].score);
                             }
                         }
                     } else {
                         // Search compendia for the skill and use the attribute
-                        // rollData.score = (+actorData.attributes['agi'].score);
-                        skill = await od6sutilities._getItemFromWorld(name) as any;
+                        skill = (await od6sutilities._getItemFromWorld(name)) as Item | undefined;
                         if (skill !== null && typeof (skill) !== 'undefined') {
-                            rollData.score = (+actorData.attributes[(skill as any).system.attribute.toLowerCase()].score);
+                            rollData.score = (+actorData.attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score);
                         } else {
-                            skill = await od6sutilities._getItemFromCompendium(name) as any;
+                            skill = (await od6sutilities._getItemFromCompendium(name)) as Item | undefined;
                             if (skill !== null && typeof (skill) !== 'undefined') {
-                                rollData.score = (+actorData.attributes[(skill as any).system.attribute.toLowerCase()].score);
+                                rollData.score = (+actorData.attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score);
                             } else {
                                 // Cannot find, use defaults for the type
                                 for (const a in OD6S.actions) {

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -1,7 +1,5 @@
 import OD6S from "./config/config-od6s";
 
-declare const foundry: any;
-
 /**
  * Create a Macro from an Item drop.
  * Get an existing item macro if one exists, otherwise create a new one.
@@ -9,7 +7,8 @@ declare const foundry: any;
  * @param {number} slot     The hotbar slot to use
  * @returns {Promise}
  */
-export async function createOD6SMacro(data: any, slot: any) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function createOD6SMacro(data: any, slot: number) {
 
     if (data.type !== "Item" || data.type !== 'availableaction') return;
     if (!data.uuid.includes('Actor.') && !data.uuid.includes('Token.'))return ui.notifications.warn(game.i18n.localize('OD6S.WARN_NOT_OWNED'));
@@ -29,7 +28,7 @@ export async function createOD6SMacro(data: any, slot: any) {
 
     // Create the macro command
     const command = `game.od6s.rollItemMacro("${item._id}");`;
-    let macro = game.macros.find(m => (m.name === item.name) && ((m as any).command === command));
+    let macro = game.macros.find(m => (m.name === item.name) && (m.command === command));
     if (!macro) {
         macro = await Macro.create({
             name: item.name,
@@ -49,12 +48,12 @@ export async function createOD6SMacro(data: any, slot: any) {
  * @param {string} itemId
  * @return {Promise}
  */
-export function rollItemMacro(itemId: any) {
+export function rollItemMacro(itemId: string) {
     const speaker = ChatMessage.getSpeaker();
     let actor;
     if (speaker.token) actor = game.actors.tokens[speaker.token];
     if (!actor) actor = game.actors.get(speaker.actor);
-    const item = actor ? actor.items.find((i: any) => i.id === itemId) : null;
+    const item = actor ? actor.items.find((i: Item) => i.id === itemId) : null;
     if (!item) return ui.notifications.warn(game.i18n.localize('OD6S.WARN_NO_ITEM_ID') + " " + itemId);
 
     // Trigger the item roll
@@ -66,13 +65,13 @@ export function rollItemMacro(itemId: any) {
  * @param {string} name
  * @return {Promise}
  */
-export function rollItemNameMacro(name: any) {
+export function rollItemNameMacro(name: string) {
     name = game.i18n.localize(name);
     const speaker = ChatMessage.getSpeaker();
     let actor;
     if (speaker.token) actor = game.actors.tokens[speaker.token];
     if (!actor) actor = game.actors.get(speaker.actor);
-    const item = actor ? actor.items.find((i: any) => i.name === name) : null;
+    const item = actor ? actor.items.find((i: Item) => i.name === name) : null;
     if (!item) return ui.notifications.warn(game.i18n.localize('OD6S.WARN_NO_ITEM_NAME') + " " + name);
 
     // Trigger the item roll
@@ -84,7 +83,7 @@ export function rollItemNameMacro(name: any) {
  * @param attribute
  * @returns {string}
  */
-export function getAttributeName(attribute: any) {
+export function getAttributeName(attribute: string) {
     attribute = attribute.toLowerCase();
     if (typeof (OD6S.attributes[attribute]) === "undefined") {
         const warnString = game.i18n.localize('OD6S.ERROR_ATTRIBUTE_KEY') + ": " + attribute;
@@ -99,7 +98,7 @@ export function getAttributeName(attribute: any) {
  * @param attribute
  * @returns {string}
  */
-export function getAttributeShortName(attribute: any) {
+export function getAttributeShortName(attribute: string) {
     attribute = attribute.toLowerCase();
     return OD6S.attributes[attribute].shortName;
 }
@@ -118,11 +117,19 @@ export async function simpleRoll() {
     await runSimpleRoll(result);
 }
 
-async function runSimpleRoll(result: any): Promise<void> {
+interface SimpleRollResult {
+    dice: number;
+    pips: number;
+    wilddie?: boolean;
+    damageroll?: boolean;
+    damagetype?: string;
+}
+
+async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
     let wild = false;
     let rollString = "";
-    let rollMode: any = 0;
-    let dice: any = result.dice;
+    let rollMode = 0;
+    let dice = result.dice;
     const pips = result.pips;
     const damageRoll = !!result.damageroll;
     const damageType = result.damagetype;
@@ -145,11 +152,11 @@ async function runSimpleRoll(result: any): Promise<void> {
     let label = game.i18n.localize("OD6S.ROLLING");
     if (damageRoll) {
         label += " " + game.i18n.localize("OD6S.DAMAGE") + "("
-            + game.i18n.localize(OD6S.damageTypes[damageType]) + ")";
+            + game.i18n.localize(OD6S.damageTypes[damageType!]) + ")";
     }
     const roll = await new Roll(rollString).evaluate();
 
-    let flags: any = {
+    let flags: Record<string, unknown> = {
         type: "simple",
         wild: false,
         wildHandled: false,
@@ -168,7 +175,7 @@ async function runSimpleRoll(result: any): Promise<void> {
     }
 
     if (game.settings.get("od6s", "use_wild_die")) {
-        const WildDie = roll.terms.find((d: any) => game.i18n.localize("OD6S.WILD_DIE_FLAVOR").includes(d.flavor));
+        const WildDie = roll.terms.find((d: { flavor: string }) => game.i18n.localize("OD6S.WILD_DIE_FLAVOR").includes(d.flavor));
         if (WildDie!.total === 1) {
             flags.wild = true;
             if (OD6S.wildDieOneDefault > 0 && OD6S.wildDieOneAuto === 0) flags.wildHandled = true;
@@ -197,7 +204,7 @@ async function runSimpleRoll(result: any): Promise<void> {
         replacementRoll.terms[0].results[highest].discarded = true;
         replacementRoll.terms[0].results[highest].active = false;
         replacementRoll.total -= (+replacementRoll.terms[0].results[highest].result);
-        const rollMessageUpdate: any = {
+        const rollMessageUpdate: Record<string, unknown> = {
             system: {},
             content: replacementRoll.total,
             id: rollMessage.id,

--- a/src/module/system/utilities/bind-tabs.ts
+++ b/src/module/system/utilities/bind-tabs.ts
@@ -8,7 +8,9 @@
  * (e.g. "attributes") that may not exist on every sheet template.
  */
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
+
 
 interface AppWithTabGroups {
     tabGroups?: Record<string, string>;

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -211,7 +211,7 @@ export async function detonateExplosive(data: any): Promise<any> {
     msgData.flags.od6s.targets = [];
     msgData.flags.od6s.item = item!.id;
     msgData.flags.od6s.isOpposable = true;
-    msgData.flags.od6s.damageType = item!.system.damage.type;
+    msgData.flags.od6s.damageType = (item!.system as OD6SWeaponItemSystem).damage.type;
     msgData.flags.od6s.stun = data.stun;
     msgData.flags.od6s.attackMessage = data.messageId;
 
@@ -231,9 +231,10 @@ export async function detonateExplosive(data: any): Promise<any> {
     let rollString;
 
     if(game.settings.get('od6s','explosive_zones')) {
+        const wsys = item!.system as OD6SWeaponItemSystem;
         // Separate rolls for each zone; damage score represents whole dice
-        for (const i in item!.system.blast_radius) {
-            const zone = item!.system.blast_radius[i];
+        for (const i in wsys.blast_radius) {
+            const zone = wsys.blast_radius[i as "1" | "2" | "3" | "4"];
             const zoneTargets = targets.filter((target: any) => target.zone === (+i));
             if (zoneTargets.length < 1) continue;
             if (zone.damage < 1) {
@@ -287,16 +288,17 @@ export async function detonateExplosive(data: any): Promise<any> {
         }
     } else {
         msgData.flags.od6s.targets = targets;
+        const wsys = item!.system as OD6SWeaponItemSystem;
         // One roll, with a fraction for zones > 1
-        const dice = (boolCheck(data.stun)) ? getDiceFromScore(item!.system.stun.score, OD6S.pipsPerDice)
-            : getDiceFromScore(item!.system.damage.score, OD6S.pipsPerDice);
+        const dice = (boolCheck(data.stun)) ? getDiceFromScore(wsys.stun.score, OD6S.pipsPerDice)
+            : getDiceFromScore(wsys.damage.score, OD6S.pipsPerDice);
         if (boolCheck(data.stun)) {
-            if (item!.system.stun.score === 0 || item!.system.stun.score === '') {
+            if (wsys.stun.score === 0 || (wsys.stun.score as unknown) === '') {
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_EXPLOSIVE_CONFIGURED_FOR_ZONES'));
                 return;
             }
         } else {
-            if (item!.system.damage.score === 0 || item!.system.damage.score === '') {
+            if (wsys.damage.score === 0 || (wsys.damage.score as unknown) === '') {
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_EXPLOSIVE_CONFIGURED_FOR_ZONES'));
                 return;
             }

--- a/src/module/system/utilities/items.ts
+++ b/src/module/system/utilities/items.ts
@@ -116,7 +116,7 @@ export function getItemsFromWorldByType(itemType: OD6SItemType): unknown[] {
                 _id: game.items.contents[i]._id,
                 name: game.items.contents[i].name,
                 type: game.items.contents[i].type,
-                description: game.items.contents[i].system.description
+                description: (game.items.contents[i].system as { description?: string }).description ?? ''
             }
             searchResult.push(item);
         }

--- a/src/module/system/utilities/items.ts
+++ b/src/module/system/utilities/items.ts
@@ -1,12 +1,15 @@
 /**
  * Merge two arrays by element property
  */
-export function mergeByProperty(target: any, source: any, prop: any): void {
-    source.forEach((sourceElement: any) => {
-        const targetElement = target.find((targetElement: any) => {
-            return sourceElement[prop] === targetElement[prop];
-        })
-        targetElement ? Object.assign(targetElement, sourceElement) : target.push(sourceElement);
+export function mergeByProperty<T extends Record<string, unknown>>(
+    target: T[],
+    source: T[],
+    prop: keyof T,
+): void {
+    source.forEach((sourceElement) => {
+        const targetElement = target.find((te) => sourceElement[prop] === te[prop]);
+        if (targetElement) Object.assign(targetElement, sourceElement);
+        else target.push(sourceElement);
     })
 }
 
@@ -25,19 +28,17 @@ export async function getSkillsFromTemplate(items: Item[]): Promise<Item[]> {
  * Search for and get an item from compendia by id
  */
 export async function _getItemFromCompendiumId(id: string): Promise<Item | null> {
-    let itemList: any = '';
-    let packs: any;
-    game.packs.keys();
+    let packs: CompendiumPack[];
     if (game.settings.get('od6s', 'hide_compendia')) {
-        packs = await game.packs.filter(p => p.metadata.packageName !== 'od6s')
+        packs = game.packs.filter((p) => p.metadata.packageName !== 'od6s');
     } else {
-        packs = await game.packs;
+        packs = game.packs.contents;
     }
     for (const p of packs) {
-        await (p as any).getIndex().then((index: any) => itemList = index);
-        const searchResult = (itemList as any).find((t: any) => t._id === id);
+        const index = await p.getIndex();
+        const searchResult = index.find((t) => t._id === id);
         if (searchResult) {
-            return await (p as any).getDocument(searchResult._id);
+            return await p.getDocument(searchResult._id) as Item | null;
         }
     }
     return null;
@@ -47,19 +48,17 @@ export async function _getItemFromCompendiumId(id: string): Promise<Item | null>
  * Search for and get an item from compendia by name
  */
 export async function _getItemFromCompendium(itemName: string): Promise<Item | null> {
-    let itemList: any = '';
-    let packs: any;
-    game.packs.keys();
+    let packs: CompendiumPack[];
     if (game.settings.get('od6s', 'hide_compendia')) {
-        packs = await game.packs.filter(p => p.metadata.packageName !== 'od6s')
+        packs = game.packs.filter((p) => p.metadata.packageName !== 'od6s');
     } else {
-        packs = await game.packs;
+        packs = game.packs.contents;
     }
     for (const p of packs) {
-        await (p as any).getIndex().then((index: any) => itemList = index);
-        const searchResult = (itemList as any).find((t: any) => t.name === itemName);
+        const index = await p.getIndex();
+        const searchResult = index.find((t) => t.name === itemName);
         if (searchResult) {
-            return await (p as any).getDocument(searchResult._id);
+            return await p.getDocument(searchResult._id) as Item | null;
         }
     }
     return null;
@@ -86,19 +85,18 @@ export async function getItemByName(itemName: string): Promise<Item | undefined>
 /**
  * Get all items of a certain type from compendia
  */
-export function getItemsFromCompendiumByType(itemType: OD6SItemType): unknown[] {
-    let searchResult: any[] = [];
-    let packs: any;
-    game.packs.keys();
+export function getItemsFromCompendiumByType(itemType: OD6SItemType): Array<{_id: string; name: string; type: string}> {
+    let searchResult: Array<{_id: string; name: string; type: string}> = [];
+    let packs: CompendiumPack[];
     if (game.settings.get('od6s', 'hide_compendia')) {
-        packs = game.packs.filter(p => p.metadata.packageName !== 'od6s' && p.documentName === 'Item')
+        packs = game.packs.filter((p) => p.metadata.packageName !== 'od6s' && p.documentName === 'Item');
     } else {
-        packs = game.packs.filter(p => p.documentName === 'Item');
+        packs = game.packs.filter((p) => p.documentName === 'Item');
     }
 
     for (const p of packs) {
-        const items = p.index.filter((i: any) => i.type === itemType);
-        searchResult = (searchResult as any).concat(items);
+        const items = p.index.filter((i) => i.type === itemType);
+        searchResult = searchResult.concat(items);
     }
 
     searchResult.sort((a, b) => a.name.localeCompare(b.name));
@@ -108,17 +106,16 @@ export function getItemsFromCompendiumByType(itemType: OD6SItemType): unknown[] 
 /**
  * Get all items of a certain type from the world
  */
-export function getItemsFromWorldByType(itemType: OD6SItemType): unknown[] {
-    const searchResult = [];
-    for (let i = 0; i < game.items.contents.length; i++) {
-        if (game.items.contents[i].type === itemType) {
-            const item = {
-                _id: game.items.contents[i]._id,
-                name: game.items.contents[i].name,
-                type: game.items.contents[i].type,
-                description: (game.items.contents[i].system as { description?: string }).description ?? ''
-            }
-            searchResult.push(item);
+export function getItemsFromWorldByType(itemType: OD6SItemType): Array<{_id: string; name: string; type: string; description: string}> {
+    const searchResult: Array<{_id: string; name: string; type: string; description: string}> = [];
+    for (const it of game.items.contents) {
+        if (it.type === itemType) {
+            searchResult.push({
+                _id: it._id,
+                name: it.name,
+                type: it.type,
+                description: (it.system as { description?: string }).description ?? '',
+            });
         }
     }
     return searchResult;
@@ -127,12 +124,12 @@ export function getItemsFromWorldByType(itemType: OD6SItemType): unknown[] {
 /**
  * Get all items from both compendium and world by type, preferring world to compendia
  */
-export function getAllItemsByType(itemType: OD6SItemType): unknown[] {
+export function getAllItemsByType(itemType: OD6SItemType): Array<{_id: string; name: string; type: string}> {
     const cItems = getItemsFromCompendiumByType(itemType);
     const wItems = getItemsFromWorldByType(itemType);
-    const allItems = cItems.map((x) => x);
+    const allItems: Array<{_id: string; name: string; type: string}> = cItems.map((x) => x);
     // Prefer world items over compendium items
-    mergeByProperty(allItems, wItems, 'name');
-    allItems.sort((a, b) => (a as any).name.localeCompare((b as any).name));
+    mergeByProperty(allItems as Array<Record<string, unknown>>, wItems as Array<Record<string, unknown>>, 'name');
+    allItems.sort((a, b) => a.name.localeCompare(b.name));
     return allItems;
 }

--- a/src/module/system/utilities/skills.ts
+++ b/src/module/system/utilities/skills.ts
@@ -10,17 +10,17 @@ export function getScoreFromSkill(actor: Actor, spec: string, skill: string, att
     if (typeof (spec) !== "undefined" && spec !== '') {
         const foundSpec = actor.items.find((s: Item) => s.name === spec && s.type === 'specialization');
         if (foundSpec) {
-            score = foundSpec.system.score;
+            score = (foundSpec.system as OD6SSpecializationItemSystem).score;
             found = true;
         }
     }
     if (!found && typeof (skill) !== "undefined" && skill !== '') {
         const foundSkill = actor.items.find((s: Item) => s.name === skill && s.type === 'skill');
         if (foundSkill) {
-            score = foundSkill.system.score;
+            score = (foundSkill.system as OD6SSkillItemSystem).score;
         }
     }
-    score += actor.system.attributes[attribute.toLowerCase()].score;
+    score += (actor.system as OD6SCharacterSystem).attributes[attribute.toLowerCase()].score;
     return score;
 }
 

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -20,20 +20,23 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
     foundRange.medium = '';
     foundRange.long = '';
 
+    // Range values are declared NumberField in schema, but legacy data can carry
+    // string values like "AGI+2" — treat as Record<string, any> at the access site.
+    const itemRange = (item.system as OD6SWeaponItemSystem).range as unknown as Record<string, any>;
     const range: any = {};
-    range.short = item.system.range.short;
-    range.medium = item.system.range.medium;
-    range.long = item.system.range.long;
+    range.short = itemRange.short;
+    range.medium = itemRange.medium;
+    range.long = itemRange.long;
 
     let baseDice;
 
-    if (regex.test(item.system.range.short) ||
-        regex.test(item.system.range.medium) ||
-        regex.test(item.system.range.long)) {
+    if (regex.test(itemRange.short) ||
+        regex.test(itemRange.medium) ||
+        regex.test(itemRange.long)) {
         // There is a non-numeric value, extract it and find the attribute
-        for (const range in item.system.range) {
+        for (const range in itemRange) {
             for (const attr in OD6S.attributes) {
-                if (item.system.range[range].toLowerCase().includes(attr)) {
+                if (itemRange[range].toLowerCase().includes(attr)) {
                     foundRange[range] = attr;
                     break;
                 }
@@ -111,9 +114,10 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
 }
 
 export function getMeleeDamage(actor: Actor, weapon: Item): number {
-    if (weapon.system.damage.str) {
-        return (+(actor.system as OD6SCharacterSystem).strengthdamage.score) + (+weapon.system.damage.score);
+    const wsys = weapon.system as OD6SWeaponItemSystem;
+    if (wsys.damage.str) {
+        return (+(actor.system as OD6SCharacterSystem).strengthdamage.score) + (+wsys.damage.score);
     } else {
-        return (+weapon.system.damage.score);
+        return (+wsys.damage.score);
     }
 }

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -549,6 +549,21 @@ declare class Macro extends FoundryDocument {
     static create(data: any): Promise<Macro>;
 }
 
+/** Compendium pack (subset of CompendiumCollection used by OD6S code). */
+interface CompendiumPack {
+    metadata: {
+        packageName: string;
+        name: string;
+        label: string;
+        type: string;
+    };
+    documentName: string;
+    index: Collection<{ _id: string; name: string; type: string }>;
+    getIndex(): Promise<Collection<{ _id: string; name: string; type: string }>>;
+    getDocument(id: string): Promise<FoundryDocument | null>;
+    _formatFolderSelectOptions(): Array<{value: string; label: string}>;
+}
+
 /** Folder document */
 declare class Folder extends FoundryDocument {
     type: string;
@@ -845,7 +860,7 @@ interface Game {
     od6s: any;
     system: GameSystem;
     version: string;
-    packs: Collection<any>;
+    packs: Collection<CompendiumPack>;
     folders: Collection<Folder>;
     collections: GameCollections;
     documentTypes: Record<string, string[]>;

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -545,6 +545,7 @@ declare class User extends FoundryDocument {
 
 /** Macro document */
 declare class Macro extends FoundryDocument {
+    command: string;
     static create(data: any): Promise<Macro>;
 }
 

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -114,6 +114,268 @@ interface OD6SVehicleSystem {
     use_wild_die: boolean;
 }
 
+// ---- Item system data shapes ----
+
+/** Common to every item subtype: tags/labels/description from `baseSchema`. */
+interface OD6SItemBase {
+    description: string;
+    labels: Record<string, unknown>;
+    tags: string[];
+    label?: string;
+}
+
+/** Mixed in by gear/weapons/armor/cybernetic/etc — `equipmentSchema`. */
+interface OD6SEquipment {
+    cost: number;
+    price: string;
+    availability: string;
+    quantity: number;
+}
+
+/** Mixed in by gear/weapons/armor/cybernetic/etc — `equipSchema`. */
+interface OD6SEquip {
+    equipped: {
+        value: boolean;
+        type: string;
+        label: string;
+        consumable: boolean;
+    };
+}
+
+/** Mixed in by skill/specialization — `skillFieldsSchema`. */
+interface OD6SSkillFields {
+    attribute: string;
+    min: boolean;
+    base: number;
+    mod: number;
+    score: number;
+    time_taken: string;
+    isAdvancedSkill: boolean;
+    used: { value: boolean };
+}
+
+/** Mixed in by advantage/disadvantage/cybernetic — `advantageFieldsSchema`. */
+interface OD6SAdvantageFields {
+    attribute: string;
+    skill: string;
+    value: string;
+}
+
+/** Mixed in by vehicle-weapon/starship-weapon — `vehicleWeaponsFieldsSchema`. */
+interface OD6SVehicleWeaponsFields {
+    scale: { type: string; score: number };
+    damaged: number;
+    ammo: { type: string; value: number };
+    arc: { type: string; value: string };
+    crew: { type: string; value: number };
+    attribute: { type: string; value: string };
+    skill: { type: string; value: string };
+    specialization: { type: string; value: string };
+    fire_control: { type: string; score: number };
+    range: { short: number; medium: number; long: number };
+    damage: { type: string; score: number };
+    linked: { type: string; value: number };
+    difficulty: number;
+    mods: { difficulty: number; attack: number; damage: number };
+}
+
+/** Common across vehicle/starship actors and the `vehicle` item — `vehicleCommonSchema`. */
+interface OD6SVehicleCommon {
+    vehicle_type: { value: string; type: string; label: string };
+    initiative: { type: string; label: string; formula: string; mod: number; score: number };
+    damage: { value: string; type: string; label: string };
+    scale: { score: number; type: string; label: string };
+    maneuverability: { score: number; type: string; label: string };
+    toughness: { score: number; type: string; label: string };
+    armor: { score: number; type: string; label: string };
+    move: { value: number; type: string; label: string };
+    cargo_capacity: { value: number; type: string; label: string };
+    cost: { value: number; type: string; label: string };
+    price: { value: string; type: string; label: string };
+    crew: { value: number; type: string; label: string };
+    crewmembers: Array<{ uuid: string; name?: string }>;
+    passengers: { value: number; type: string; label: string };
+    skill: { value: string; type: string; label: string };
+    specialization: { value: string; type: string; label: string };
+    attribute: { value: string; type: string; label: string };
+    dodge: { score: number; mod: number; type: string; label: string };
+    sensors: {
+        value: boolean;
+        type: string;
+        label: string;
+        skill: string;
+        mod: number;
+        types: Record<string, { score: number; range: number; label: string; type: string }>;
+    };
+    shields: {
+        value: number;
+        allocated: number;
+        type: string;
+        label: string;
+        skill: string;
+        arcs: Record<string, { label: string; value: number; type: string }>;
+    };
+    ranged: { type: string; label: string; short_label: string; score: number };
+    ranged_damage: { type: string; label: string; short_label: string; score: number };
+    ram: { type: string; label: string; short_label: string; score: number };
+    ram_damage: { type: string; label: string; short_label: string; score: number };
+    length: { value: number; type: string; label: string };
+    tonnage: { value: number; type: string; label: string };
+    embedded_pilot: { value: boolean; type: string; label: string; actor: Record<string, unknown> };
+    sheetmode: { type: string; label: string; short_label: string; value: string };
+    roll_mod: number;
+}
+
+interface OD6SSkillItemSystem extends OD6SItemBase, OD6SSkillFields {}
+
+interface OD6SSpecializationItemSystem extends OD6SItemBase, OD6SSkillFields {
+    skill: string;
+}
+
+interface OD6SAdvantageItemSystem extends OD6SItemBase, OD6SAdvantageFields {}
+
+interface OD6SDisadvantageItemSystem extends OD6SItemBase, OD6SAdvantageFields {}
+
+interface OD6SSpecialAbilityItemSystem extends OD6SItemBase {}
+
+interface OD6SArmorItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
+    pr: number;
+    er: number;
+}
+
+interface OD6SWeaponItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
+    scale: { score: number; type: string; label: string };
+    subtype: string;
+    stats: {
+        attribute: string;
+        skill: string;
+        specialization: string;
+        parry_skill: string;
+        parry_specialization: string;
+    };
+    range: { short: number; medium: number; long: number };
+    damage: { type: string; score: number; muscle: boolean; str: boolean };
+    blast_radius: Record<
+        "1" | "2" | "3" | "4",
+        { range: number; damage: number; stun_range: number; stun_damage: number }
+    >;
+    damaged: number;
+    ammo: number;
+    ammo_price: string;
+    ammo_cost: number;
+    rof: number;
+    stun: { stun_only: boolean; score: number; type: string };
+    difficulty: string;
+    mods: { difficulty: number; attack: number; damage: number };
+}
+
+interface OD6SGearItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
+    quantity: number;
+    consumable: boolean;
+}
+
+interface OD6SCyberneticItemSystem
+    extends OD6SItemBase,
+        OD6SAdvantageFields,
+        OD6SEquipment,
+        OD6SEquip {
+    location: string;
+    slots: number;
+}
+
+interface OD6SManifestationItemSystem extends OD6SItemBase {
+    attack: boolean;
+    activate: boolean;
+    active: boolean;
+    roll: boolean;
+    skills: Record<
+        "channel" | "sense" | "transform",
+        { value: boolean; difficulty: string; rolled: boolean }
+    >;
+}
+
+interface OD6SCharacterTemplateItemSystem extends OD6SItemBase {
+    species: string;
+    attributes: Record<"agi" | "str" | "kno" | "mec" | "per" | "tec" | "met", number>;
+    fp: number;
+    cp: number;
+    funds: number;
+    credits: number;
+    move: number;
+    me: boolean;
+    items: Array<Record<string, unknown>>;
+}
+
+interface OD6SActionItemSystem extends OD6SItemBase {
+    rollable: boolean;
+    type: string;
+    subtype: string;
+    itemId: string;
+}
+
+interface OD6SVehicleItemSystem extends OD6SVehicleCommon {
+    cover: { value: string; type: string; label: string };
+    altitude: { value: number; type: string; label: string };
+}
+
+interface OD6SVehicleWeaponItemSystem
+    extends OD6SItemBase,
+        OD6SEquipment,
+        OD6SEquip,
+        OD6SVehicleWeaponsFields {}
+
+interface OD6SVehicleGearItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
+    quantity: number;
+    consumable: boolean;
+}
+
+interface OD6SStarshipWeaponItemSystem
+    extends OD6SItemBase,
+        OD6SEquipment,
+        OD6SEquip,
+        OD6SVehicleWeaponsFields {
+    "area-units": { type: string; value: number; label: string };
+    mass: { type: string; value: number; label: string };
+    energy: { type: string; value: number; label: string };
+}
+
+interface OD6SStarshipGearItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
+    quantity: number;
+    consumable: boolean;
+}
+
+interface OD6SSpeciesTemplateItemSystem extends OD6SItemBase {
+    attributes: Record<"agi" | "str" | "kno" | "mec" | "per" | "tec" | "met", { min: number; max: number }>;
+    items: Array<Record<string, unknown>>;
+}
+
+interface OD6SItemGroupSystem extends OD6SItemBase {
+    actor_types: string[];
+    items: Array<Record<string, unknown>>;
+}
+
+/** Discriminated union of all 18 OD6S item subtype system shapes. */
+type OD6SItemSystem =
+    | OD6SSkillItemSystem
+    | OD6SSpecializationItemSystem
+    | OD6SAdvantageItemSystem
+    | OD6SDisadvantageItemSystem
+    | OD6SSpecialAbilityItemSystem
+    | OD6SArmorItemSystem
+    | OD6SWeaponItemSystem
+    | OD6SGearItemSystem
+    | OD6SCyberneticItemSystem
+    | OD6SManifestationItemSystem
+    | OD6SCharacterTemplateItemSystem
+    | OD6SActionItemSystem
+    | OD6SVehicleItemSystem
+    | OD6SVehicleWeaponItemSystem
+    | OD6SVehicleGearItemSystem
+    | OD6SStarshipWeaponItemSystem
+    | OD6SStarshipGearItemSystem
+    | OD6SSpeciesTemplateItemSystem
+    | OD6SItemGroupSystem;
+
 // ---- Discriminated type literals ----
 
 /** All actor subtypes registered in `od6s.ts`. */
@@ -235,6 +497,13 @@ interface Actor {
 interface Item {
     /** Narrowed to OD6S item subtypes for type-switch narrowing. */
     type: OD6SItemType;
+
+    /**
+     * Typed union of OD6S item subtype system shapes. Use `item.type` to
+     * narrow before accessing type-specific fields, or cast to the relevant
+     * `OD6S<Type>ItemSystem` at access sites.
+     */
+    system: OD6SItemSystem;
 
     /** Numeric score (skill / spec / weapon score), depends on subtype. */
     getScore(): number | undefined;


### PR DESCRIPTION
## Summary
- Tighten `Item.system` to a discriminated union; drop redundant `as any` casts in `Item.roll`
- Clear ~370 `no-explicit-any` warnings across config, sheet-listeners, effects, templates, advance, inventory, item-crud, sorting helpers, utilities/items, and CompendiumPack

## Test plan
- [ ] `pnpm run lint` — confirm warning count drop
- [ ] `pnpm run build` — typecheck passes
- [ ] `pnpm run test:smoke` — runtime parity in live Foundry