### PR TITLE
fix: vehicle defense + embedded_pilot truthy checks (#15, #18)

### DIFF
--- a/src/module/apps/roll-helpers/roll-difficulty.ts
+++ b/src/module/apps/roll-helpers/roll-difficulty.ts
@@ -93,14 +93,15 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
                         });
                     }
                 } else {
-                    if (targetData.dodge.score === 0) {
+                    const vehicleDefense = (rollData.target!.actor.system as OD6SVehicleSystem).maneuverability.score;
+                    if (vehicleDefense === 0) {
                         if(OD6S.meleeDifficulty) {
                             return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
                         } else {
                             return OD6S.baseMeleeAttackDifficulty;
                         }
                     } else {
-                        return targetData.dodge.score;
+                        return vehicleDefense;
                     }
                 }
             } else {
@@ -137,10 +138,11 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
                         });
                     }
                 } else {
-                    if (targetData.dodge.score === 0) {
+                    const vehicleDefense = (rollData.target!.actor.system as OD6SVehicleSystem).maneuverability.score;
+                    if (vehicleDefense === 0) {
                         return OD6S.baseBrawlAttackDifficulty;
                     } else {
-                        return targetData.dodge.score;
+                        return vehicleDefense;
                     }
                 }
             } else {

--- a/src/module/apps/roll-helpers/roll-difficulty.ts
+++ b/src/module/apps/roll-helpers/roll-difficulty.ts
@@ -93,9 +93,10 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
                         });
                     }
                 } else {
-                    const vehicleDefense = (rollData.target!.actor.system as OD6SVehicleSystem).maneuverability.score;
+                    const vehSys = rollData.target!.actor.system as OD6SVehicleSystem;
+                    const vehicleDefense = vehSys.maneuverability.score;
                     if (vehicleDefense === 0) {
-                        if(OD6S.meleeDifficulty) {
+                        if (OD6S.meleeDifficulty) {
                             return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
                         } else {
                             return OD6S.baseMeleeAttackDifficulty;
@@ -138,7 +139,8 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
                         });
                     }
                 } else {
-                    const vehicleDefense = (rollData.target!.actor.system as OD6SVehicleSystem).maneuverability.score;
+                    const vehSys = rollData.target!.actor.system as OD6SVehicleSystem;
+                    const vehicleDefense = vehSys.maneuverability.score;
                     if (vehicleDefense === 0) {
                         return OD6S.baseBrawlAttackDifficulty;
                     } else {

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -214,13 +214,13 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if (data.subtype === 'vehiclerangedweaponattack') {
         let vehicleWeapon: Item | undefined;
         if (data.actor.type === 'vehicle') {
-            if ((data.actor.system as OD6SVehicleSystem).embedded_pilot) {
+            if ((data.actor.system as OD6SVehicleSystem).embedded_pilot?.value) {
                 vehicleWeapon = data.actor.items.filter((i: Item) => i._id === data.itemId)[0];
             } else {
                 vehicleWeapon = (data.actor as any).vehicle_weapons.filter((i: Item) => i._id === data.itemId)[0];
             }
         } else if (data.actor.type === 'starship') {
-            if ((data.actor.system as OD6SVehicleSystem).embedded_pilot) {
+            if ((data.actor.system as OD6SVehicleSystem).embedded_pilot?.value) {
                 vehicleWeapon = data.actor.items.filter((i: Item) => i._id === data.itemId)[0];
             } else {
                 vehicleWeapon = (data.actor as any).starship_weapons.filter((i: Item) => i._id === data.itemId)[0];
@@ -239,7 +239,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             if (vwSys.mods.attack !== 0) bonusmod += vwSys.mods.attack;
             if (vwSys.scale.score) {
                 attackerScale = vwSys.scale.score;
-            } else if (data.actor.type === 'vehicle' || data.actor.type === 'starship' || (data.actor.system as OD6SVehicleSystem)?.embedded_pilot) {
+            } else if (data.actor.type === 'vehicle' || data.actor.type === 'starship' || (data.actor.system as OD6SVehicleSystem)?.embedded_pilot?.value) {
                 attackerScale = data.actor.system.scale.score;
             } else {
                 attackerScale = (data.actor.system as OD6SCharacterSystem).vehicle.scale!.score;

--- a/src/module/apps/roll.ts
+++ b/src/module/apps/roll.ts
@@ -20,7 +20,7 @@ export class od6sroll {
         const actor = (this as any).actor as Actor;
         const item = actor.items.find((i: Item) => i.id === (event.currentTarget as HTMLElement).dataset.itemId);
         if (!item) return;
-        if ((actor.type === 'vehicle' || actor.type === 'starship') && (actor.system as OD6SVehicleSystem).embedded_pilot) {
+        if ((actor.type === 'vehicle' || actor.type === 'starship') && (actor.system as OD6SVehicleSystem).embedded_pilot?.value) {
             return item.roll();
         }
         const sys = item.system as OD6SActionItemSystem;


### PR DESCRIPTION
## Summary
Two related vehicle/starship behavior bugs that previous type-tightening sweeps preserved with casts. Bundled because they share the same gameplay smoke matrix (vehicle/starship targeting, embedded vs. non-embedded pilot).

### #15 — `embedded_pilot?.value`
`OD6SVehicleSystem.embedded_pilot` is `{ value: boolean }`, so checking the object directly is always truthy when the field exists, making the non-embedded branch dead code at four call sites:
- `apps/roll.ts:23` — item-roll target selection
- `apps/roll-helpers/roll-setup.ts:217` — vehicle weapon lookup
- `apps/roll-helpers/roll-setup.ts:223` — starship weapon lookup
- `apps/roll-helpers/roll-setup.ts:242` — attacker scale source

All four now read `embedded_pilot?.value`.

### #18 — vehicle defense → `maneuverability.score`
Melee/brawl difficulty against vehicle/starship targets read `dodge.score`. Vehicles use `maneuverability` as the dodge equivalent (see `vehicleCommonSchema` and `OD6SVehicleSystem`); the vehicle schema also has a `dodge` field, so the access didn't crash — it just returned a stale/zero value, and the `=== 0` short-circuit then returned a meaningless number from the else branch.

Fixed in `apps/roll-helpers/roll-difficulty.ts` for both `meleeattack` and `brawlattack` vehicle/starship branches.

Closes #15.
Closes #18.

## Test plan
- [x] `pnpm run check` — lint + typecheck + 162 unit + 250 domain tests pass
- [ ] Smoke: vehicle weapon roll with embedded pilot → reads weapon from actor.items
- [ ] Smoke: vehicle weapon roll without embedded pilot → reads weapon from `vehicle_weapons`
- [ ] Smoke: starship weapon roll, both embedded/non-embedded
- [ ] Smoke: melee attack against a vehicle with non-zero maneuverability → difficulty matches maneuverability score
- [ ] Smoke: brawl attack against a starship → same
- [ ] Smoke: melee/brawl against a vehicle with maneuverability=0 → falls through to baseMeleeAttackDifficulty / difficultyLevel