### PR TITLE
fix: auto-explosive end-to-end + v14 hardening (#19)

### DIFF
--- a/scss/global/_window.scss
+++ b/scss/global/_window.scss
@@ -96,3 +96,19 @@
   display: none;
   overflow: hidden;
 }
+
+// ── Settings config dialogs ──────────────────────────────────────────────
+// All od6s ApplicationV2 settings forms (Rules Options, Automation, etc.)
+// use position.height: "auto", which lets content grow past the viewport
+// with no internal scroll. Cap at 90vh and make the inner form scroll.
+.od6s.settings-config {
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+
+  > .window-content {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+}

--- a/src/module/apps/config-active-attributes.ts
+++ b/src/module/apps/config-active-attributes.ts
@@ -87,7 +87,7 @@ export default class od6sActiveAttributesConfiguration extends HandlebarsApplica
 
     static async #onCloseForm(this: od6sActiveAttributesConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-attributes-sorting.ts
+++ b/src/module/apps/config-attributes-sorting.ts
@@ -158,7 +158,7 @@ export default class od6sAttributesSortingConfiguration extends HandlebarsApplic
         }
         await game.settings.set("od6s", "attributes_sorting", attrSort);
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-automation.ts
+++ b/src/module/apps/config-automation.ts
@@ -66,7 +66,7 @@ export default class od6sAutomationConfiguration extends HandlebarsApplicationMi
 
     static async #onCloseForm(this: od6sAutomationConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-characterpoints.ts
+++ b/src/module/apps/config-characterpoints.ts
@@ -66,7 +66,7 @@ export default class od6sCharacterPointConfiguration extends HandlebarsApplicati
 
     static async #onCloseForm(this: od6sCharacterPointConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-custom-fields.ts
+++ b/src/module/apps/config-custom-fields.ts
@@ -87,7 +87,7 @@ export default class od6sCustomFieldsConfiguration extends HandlebarsApplication
 
     static async #onCloseForm(this: od6sCustomFieldsConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-deadliness.ts
+++ b/src/module/apps/config-deadliness.ts
@@ -66,7 +66,7 @@ export default class od6sDeadlinessConfiguration extends HandlebarsApplicationMi
 
     static async #onCloseForm(this: od6sDeadlinessConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-difficulty.ts
+++ b/src/module/apps/config-difficulty.ts
@@ -66,7 +66,7 @@ export default class od6sDifficultyConfiguration extends HandlebarsApplicationMi
 
     static async #onCloseForm(this: od6sDifficultyConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-initiative.ts
+++ b/src/module/apps/config-initiative.ts
@@ -83,7 +83,7 @@ export default class od6sInitiativeConfiguration extends HandlebarsApplicationMi
 
     static async #onCloseForm(this: od6sInitiativeConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-labels.ts
+++ b/src/module/apps/config-labels.ts
@@ -66,7 +66,7 @@ export default class od6sCustomLabelsConfiguration extends HandlebarsApplication
 
     static async #onCloseForm(this: od6sCustomLabelsConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-miscrules.ts
+++ b/src/module/apps/config-miscrules.ts
@@ -66,7 +66,7 @@ export default class od6sMiscRulesConfiguration extends HandlebarsApplicationMix
 
     static async #onCloseForm(this: od6sMiscRulesConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-reveal.ts
+++ b/src/module/apps/config-reveal.ts
@@ -66,7 +66,7 @@ export default class od6sRevealConfiguration extends HandlebarsApplicationMixin(
 
     static async #onCloseForm(this: od6sRevealConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-rules.ts
+++ b/src/module/apps/config-rules.ts
@@ -87,7 +87,7 @@ export default class od6sRulesConfiguration extends HandlebarsApplicationMixin(A
 
     static async #onCloseForm(this: od6sRulesConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/config-wild-die.ts
+++ b/src/module/apps/config-wild-die.ts
@@ -68,7 +68,7 @@ export default class od6sWildDieConfiguration extends HandlebarsApplicationMixin
 
     static async #onCloseForm(this: od6sWildDieConfiguration): Promise<void> {
         if (this.requiresWorldReload) {
-            await SettingsConfig.reloadConfirm({world: true});
+            await foundry.applications.settings.SettingsConfig.reloadConfirm({world: true});
         }
         await this.close();
     }

--- a/src/module/apps/explosive-dialog.ts
+++ b/src/module/apps/explosive-dialog.ts
@@ -103,11 +103,10 @@ export default class ExplosiveDialog extends HandlebarsApplicationMixin(Applicat
 
         if (this.data.stage === 1 && this.data.type === "OD6S.EXPLOSIVE_THROWN") {
             const region = regions[0];
-            const distance = Math.floor((canvas as any).grid.measureDistance(
+            const distance = Math.floor((canvas as any).grid.measurePath([
                 {x: this.token.center.x, y: this.token.center.y},
                 {x: region.shapes[0].x, y: region.shapes[0].y},
-                {gridSpaces: false},
-            ));
+            ]).distance);
 
             await this.data.item.update({
                 flags: {

--- a/src/module/apps/explosives-template.ts
+++ b/src/module/apps/explosives-template.ts
@@ -145,8 +145,9 @@ export default class ExplosivesTemplate {
         this.#moveTime = now;
 
         const center = event.data.getLocalPosition(canvas.stage);
-        const interval = canvas.grid.type === CONST.GRID_TYPES.GRIDLESS ? 0 : 2;
-        const snapped = canvas.grid.getSnappedPosition(center.x, center.y, interval);
+        const snapped = canvas.grid.type === CONST.GRID_TYPES.GRIDLESS
+            ? { x: center.x, y: center.y }
+            : canvas.grid.getSnappedPoint({ x: center.x, y: center.y }, { mode: CONST.GRID_SNAPPING_MODES.CENTER, resolution: 1 });
 
         this.previewX = snapped.x;
         this.previewY = snapped.y;
@@ -155,10 +156,10 @@ export default class ExplosivesTemplate {
         this.#drawCircle(this.previewX, this.previewY);
 
         // Draw range line
-        const distance = Math.floor(canvas.grid.measureDistance(
+        const distance = Math.floor(canvas.grid.measurePath([
             { x: this.originX, y: this.originY },
-            { x: this.previewX, y: this.previewY }
-        ));
+            { x: this.previewX, y: this.previewY },
+        ]).distance);
 
         this.#rangeLine.clear();
         this.#rangeLine.lineStyle(4, 0xffd900, 1);
@@ -193,8 +194,9 @@ export default class ExplosivesTemplate {
 
         await this.#finishPlacement();
 
-        const interval = canvas.grid.type === CONST.GRID_TYPES.GRIDLESS ? 0 : 2;
-        const snapped = canvas.grid.getSnappedPosition(this.previewX, this.previewY, interval);
+        const snapped = canvas.grid.type === CONST.GRID_TYPES.GRIDLESS
+            ? { x: this.previewX, y: this.previewY }
+            : canvas.grid.getSnappedPoint({ x: this.previewX, y: this.previewY }, { mode: CONST.GRID_SNAPPING_MODES.CENTER, resolution: 1 });
 
         const radiusPixels = this.radius * canvas.dimensions.distancePixels;
 

--- a/src/module/apps/roll-helpers/roll-effects.ts
+++ b/src/module/apps/roll-helpers/roll-effects.ts
@@ -50,5 +50,7 @@ export async function cancelAction(rollData: RollData): Promise<void> {
         }
         await item?.unsetFlag('od6s', 'explosiveSet');
         await item?.unsetFlag('od6s', 'explosiveTemplate');
+        await item?.unsetFlag('od6s', 'explosiveOrigin');
+        await item?.unsetFlag('od6s', 'explosiveRange');
     }
 }

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -527,6 +527,12 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         if (region && !game.settings.get('od6s', 'explosive_end_of_round')) {
             await region.update({ visibility: 2 });
         }
+        if (game.settings.get('od6s', 'auto_explosive')) {
+            await item?.unsetFlag('od6s', 'explosiveSet');
+            await item?.unsetFlag('od6s', 'explosiveTemplate');
+            await item?.unsetFlag('od6s', 'explosiveOrigin');
+            await item?.unsetFlag('od6s', 'explosiveRange');
+        }
     }
 
     if (rollData.subtype === 'dodge' || rollData.subtype === 'parry' || rollData.subtype === 'block') {

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -525,7 +525,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
             }
         }
         if (region && !game.settings.get('od6s', 'explosive_end_of_round')) {
-            await region.update({hidden: false});
+            await region.update({ visibility: 2 });
         }
     }
 

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -508,13 +508,11 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
             }
         }
         if (game.settings.get('od6s', 'auto_explosive') && region) {
-            // @ts-expect-error
-            await region.setFlag('od6s', 'originalOwner', game.user.owner);
+            await region.setFlag('od6s', 'originalOwner', game.user.id);
             await region.setFlag('od6s', 'templateId', rollMessage._id);
 
             if (!flags.success) {
-                // @ts-expect-error
-                await od6sutilities.scatterExplosive(rollData.range, origin, templateId);
+                await od6sutilities.scatterExplosive(rollData.range, origin, regionId);
                 await od6sutilities.wait(100);
                 const newTargets = await od6sutilities.getExplosiveTargets(rollData.actor, rollData.itemid);
                 if (Object.keys(newTargets).length === 0) {
@@ -526,9 +524,8 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                 await od6sutilities.wait(100);
             }
         }
-        if(!game.settings.get('od6s','explosive_end_of_round')) {
-            // @ts-expect-error
-            await template.document.update({hidden: false});
+        if (region && !game.settings.get('od6s', 'explosive_end_of_round')) {
+            await region.update({hidden: false});
         }
     }
 

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -4,7 +4,7 @@
 import {od6sutilities} from "../../system/utilities";
 import ExplosiveDialog from "../explosive-dialog";
 import OD6S from "../../config/config-od6s";
-import {getEffectMod} from "./roll-effects";
+import {cancelAction, getEffectMod} from "./roll-effects";
 import type {Modifier} from "./difficulty-math";
 import type {IncomingRollData, RollData, DiceValue} from "./roll-data";
 
@@ -409,6 +409,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     if (data.score < OD6S.pipsPerDice && !(OD6S.flatSkills && (data.type === 'skill' || data.type === 'specialization'))) {
         ui.notifications.warn(game.i18n.localize("OD6S.SCORE_TOO_LOW"));
+        if (isExplosive) await cancelAction({ ...data, isExplosive, itemid: data.itemId } as unknown as RollData);
         return false;
     }
 
@@ -484,7 +485,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
                     if (isExplosive) {
                         distance = item?.getFlag('od6s', 'explosiveRange');
                     } else {
-                        distance = Math.floor(canvas.grid.measureDistance(actorToken as Token, targets[0], {gridSpaces: true}));
+                        distance = Math.floor(canvas.grid.measurePath([(actorToken as Token).center, targets[0].center]).distance);
                     }
                     const rangeConfig = data.range as { short: number; medium: number; long: number };
                     if (distance < 3) {

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -46,7 +46,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     const contact = false;
     let canStun = false;
     let onlyStun = false;
-    const actorToken = data.actor.isToken ? data.actor.token : data.actor.getActiveTokens()[0];
+    const actorToken = data.actor.isToken ? data.actor.token.object : data.actor.getActiveTokens()[0];
 
     if (typeof(data.itemId) !== 'undefined' && data.itemId !== '') {
         let item = data.actor.items.get(data.itemId);

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -11,7 +11,7 @@ export async function scatterExplosive(range: any, origin: any, regionId: any): 
     const region = canvas.scene.getEmbeddedDocument('Region', regionId);
     const shape = region.shapes[0];
     const target = {x: shape.x, y: shape.y};
-    const sourceRay = new Ray(origin, target);
+    const sourceRay = new foundry.canvas.geometry.Ray(origin, target);
 
     // Save original position for un-scatter on hit
     await region.setFlag('od6s', 'originalX', shape.x);
@@ -65,7 +65,7 @@ export async function scatterExplosive(range: any, origin: any, regionId: any): 
 
     const newAngle = sourceRay.angle + angle;
 
-    const destRay = Ray.fromAngle(shape.x, shape.y, newAngle, distance);
+    const destRay = foundry.canvas.geometry.Ray.fromAngle(shape.x, shape.y, newAngle, distance);
 
     // Check if it would collide with a wall and stop it there
     const checkCollision = CONFIG.Canvas.polygonBackends.move.testCollision(
@@ -74,9 +74,9 @@ export async function scatterExplosive(range: any, origin: any, regionId: any): 
 
     let newPos;
     if (checkCollision !== null) {
-        const distanceToCollision = (canvas.grid.measureDistance(destRay.A, checkCollision)
+        const distanceToCollision = (canvas.grid.measurePath([destRay.A, checkCollision]).distance
             * canvas.dimensions.distancePixels) - 5;
-        const collisionRay = Ray.fromAngle(shape.x, shape.y, newAngle, distanceToCollision);
+        const collisionRay = foundry.canvas.geometry.Ray.fromAngle(shape.x, shape.y, newAngle, distanceToCollision);
         newPos = { x: collisionRay.B.x, y: collisionRay.B.y };
     } else {
         newPos = { x: Math.floor(destRay.B.x), y: Math.floor(destRay.B.y) };
@@ -117,7 +117,7 @@ export async function getExplosiveTargets(actor: any, itemId: any): Promise<any[
     for (const target of hitTokens) {
         const thisTarget: any = {};
         thisTarget.id = target.id;
-        thisTarget.range = canvas.grid.measureDistance(center, target.center);
+        thisTarget.range = canvas.grid.measurePath([center, target.center]).distance;
         thisTarget.zone = getBlastRadius(item, thisTarget.range);
         thisTarget.name = target.name;
         targets.push(thisTarget);

--- a/src/templates/settings/settings-v2.html
+++ b/src/templates/settings/settings-v2.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div>
     {{#each settings as |setting s|}}
         <div class="form-group">
             <label for="{{setting.key}}">{{localize setting.name}}</label>
@@ -29,4 +29,4 @@
     <div class="submit">
         <button type="submit" name="close" data-action="closeForm">{{localize "Submit"}}</button>
     </div>
-</form>
+</div>

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -71,6 +71,19 @@ declare class Module {
 // ---- Foundry Namespace ----
 
 declare namespace foundry {
+    namespace canvas {
+        namespace geometry {
+            class Ray {
+                constructor(A: { x: number; y: number }, B: { x: number; y: number });
+                A: { x: number; y: number };
+                B: { x: number; y: number };
+                angle: number;
+                distance: number;
+                static fromAngle(x: number, y: number, radians: number, distance: number): Ray;
+            }
+        }
+    }
+
     namespace utils {
         function mergeObject<T extends object>(original: T, other: any, options?: MergeObjectOptions): T;
         function deepClone<T>(original: T): T;
@@ -102,6 +115,12 @@ declare namespace foundry {
                 static confirm(options: any): Promise<boolean>;
                 static prompt(options: any): Promise<any>;
                 static wait(options: any): Promise<any>;
+            }
+        }
+
+        namespace settings {
+            class SettingsConfig {
+                static reloadConfirm(options?: { world?: boolean }): Promise<boolean>;
             }
         }
 


### PR DESCRIPTION
## Summary

Originally a 4-line fix for three suppressed `@ts-expect-error` references in the auto-explosive failure path. Smoke-testing on a live Foundry v14 world surfaced a cascade of blockers that prevented the feature from being reachable at all — all bundled into this PR rather than shipping a fix that no user could exercise.

## The original fix (`roll-execute.ts`)

The auto-explosive failure path in `executeRollAction` had three suppressed errors that throw `ReferenceError` at runtime when `od6s/auto_explosive` is enabled and the roll branches to failure.

- `game.user.owner` → `game.user.id` — `User` has no `owner` property; the flag stored is `originalOwner`, so the intent is the user id.
- `templateId` (undeclared) → `regionId` — leftover symbol from before the v14 region migration.
- `template` (undeclared) → `region` — same renaming gap. Also moved under the existing `region` truthiness check, and switched `{hidden: false}` → `{ visibility: 2 }` to match how `explosives.ts` and `chat-log-listeners.ts` reveal regions in v14.

## Blockers surfaced during smoke

To get to a state where the auto-explosive failure path actually executes, these had to be fixed too:

### Settings dialogs (`9887c5a`)
- Rules Options dialog content overflowed viewport with no scroll.
- `settings-v2.html` wrapped its inputs in a nested `<form>` while the V2 application root is itself a form — inputs weren't bound to the outer form, so `submitOnChange` never persisted toggles. Same root cause as #27/PR #37; the codemod that unwrapped 20 sheet templates missed this one.
- `SettingsConfig` global → `foundry.applications.settings.SettingsConfig` (v13+; removed v15) across all 13 config-*.ts close handlers.

### v14 canvas/grid migration (`081de3f`)
- `canvas.grid.getSnappedPosition` → `getSnappedPoint` (2 sites). Threw on every mouse move during placement preview.
- `canvas.grid.measureDistance` → `measurePath` (5 sites).
- `Ray` global → `foundry.canvas.geometry.Ray` (3 sites).
- Type stubs extended for `applications.settings.SettingsConfig` and `canvas.geometry.Ray`.

### Explosive lifecycle (`1b3ddaa`)
- `cancelAction` only unset 2 of 4 explosive flags — leftover `Origin`/`Range` pointed at deleted regions, so the next click skipped placement.
- `setupRollData`'s "score < 1D" early return didn't clean up flags set by `explosive_dialog`. Now invokes `cancelAction` when explosive.
- The `auto_explosive` resolution branch never cleared item flags after detonation/scatter, so re-rolling the same grenade silently re-used the prior region. Now clears all 4 flags at the end of the auto branch. Manual mode (auto off) is unchanged — flags persist so the chat-card detonation button still works.

Filed #40 for the related (rules-driven, pre-existing) limitation around throwing two of the **same** stacked grenade item in one round.

## Manual smoke verification

All three branches verified end-to-end against a live world (`auto_explosive: true`). See the test protocol comment below for the exact steps and outputs.

| Branch | Setting state | Assertion | Result |
|---|---|---|---|
| A — success | `auto_explosive: true` | `region.originalOwner === game.user.id`, `region.templateId === message._id` | ✅ |
| B — failure | `auto_explosive: true` | `scatterExplosive` runs, no `ReferenceError: templateId` | ✅ |
| C1 — reveal-immediate | `explosive_end_of_round: false` | `region.visibility === 2` after detonation | ✅ |
| C2 — reveal-deferred | `explosive_end_of_round: true` | `region.visibility === 1` (GM-only, deferred) | ✅ |

Closes #19.