### PR TITLE
fix: weapon specialization rollMin + attribute-relative ranges (#16, #17)

### DIFF
--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -296,9 +296,9 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
             } else if (item.type === "weapon") {
                 let found = false;
                 const itemData = item.system as OD6SWeaponItemSystem;
-                if ( (itemData as unknown as { type: string }).type === 'specialization' && typeof (itemData.stats.specialization) !== 'undefined' &&
+                if (typeof (itemData.stats.specialization) !== 'undefined' &&
                     itemData.stats.specialization !== 'null' && itemData.stats.specialization !== '') {
-                    const spec = rollData.actor.items.find((i: Item) => i.name === itemData.stats.specialization);
+                    const spec = rollData.actor.items.find((i: Item) => i.type === 'specialization' && i.name === itemData.stats.specialization);
                     if (typeof (spec) !== 'undefined' && spec.name !== '') {
                         found = true
                         const specSys = spec.system as OD6SSpecializationItemSystem;

--- a/src/module/data/item/weapon.ts
+++ b/src/module/data/item/weapon.ts
@@ -18,7 +18,7 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
     if (source.range && typeof source.range === "object") {
       const range = source.range as Record<string, unknown>;
       for (const key of ["short", "medium", "long"]) {
-        if (typeof range[key] !== "number") range[key] = Number(range[key]) || 0;
+        if (typeof range[key] !== "string") range[key] = String(range[key] ?? "0");
       }
     }
     return super.migrateData(source);
@@ -43,9 +43,9 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
         parry_specialization: new fields.StringField({ initial: "" }),
       }),
       range: new fields.SchemaField({
-        short: new fields.NumberField({ initial: 0 }),
-        medium: new fields.NumberField({ initial: 0 }),
-        long: new fields.NumberField({ initial: 0 }),
+        short: new fields.StringField({ initial: "0" }),
+        medium: new fields.StringField({ initial: "0" }),
+        long: new fields.StringField({ initial: "0" }),
       }),
       damage: new fields.SchemaField({
         type: new fields.StringField({ initial: "" }),

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -20,9 +20,7 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
     foundRange.medium = '';
     foundRange.long = '';
 
-    // Range values are declared NumberField in schema, but legacy data can carry
-    // string values like "AGI+2" — treat as Record<string, any> at the access site.
-    const itemRange = (item.system as OD6SWeaponItemSystem).range as unknown as Record<string, any>;
+    const itemRange = (item.system as OD6SWeaponItemSystem).range;
     const range: any = {};
     range.short = itemRange.short;
     range.medium = itemRange.medium;
@@ -34,7 +32,7 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
         regex.test(itemRange.medium) ||
         regex.test(itemRange.long)) {
         // There is a non-numeric value, extract it and find the attribute
-        for (const range in itemRange) {
+        for (const range of ['short', 'medium', 'long'] as const) {
             for (const attr in OD6S.attributes) {
                 if (itemRange[range].toLowerCase().includes(attr)) {
                     foundRange[range] = attr;

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -26,28 +26,34 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
     range.medium = itemRange.medium;
     range.long = itemRange.long;
 
+    const numericRange = {
+        short: Number(itemRange.short),
+        medium: Number(itemRange.medium),
+        long: Number(itemRange.long),
+    };
+
     let baseDice;
 
     if (regex.test(itemRange.short) ||
         regex.test(itemRange.medium) ||
         regex.test(itemRange.long)) {
         // There is a non-numeric value, extract it and find the attribute
-        for (const range of ['short', 'medium', 'long'] as const) {
+        for (const rangeKey of ['short', 'medium', 'long'] as const) {
             for (const attr in OD6S.attributes) {
-                if (itemRange[range].toLowerCase().includes(attr)) {
-                    foundRange[range] = attr;
+                if (itemRange[rangeKey].toLowerCase().includes(attr)) {
+                    foundRange[rangeKey] = attr;
                     break;
                 }
             }
-            if (foundRange[range] === '') {
+            if (foundRange[rangeKey] === '') {
                 // String is present, but attribute not found.  Flee!
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_INVALID_RANGE_ATTRIBUTE'));
                 return false;
             }
         }
     } else {
-        // No strings in range values
-        return range;
+        // No strings in range values — coerce to numbers so the return type matches.
+        return numericRange;
     }
     if ((new Set([foundRange.short, foundRange.medium, foundRange.long])).size === 1) {
         baseDice = Math.floor(actor.system.attributes[foundRange.short].score / OD6S.pipsPerDice) * OD6S.pipsPerDice;

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -253,7 +253,7 @@ interface OD6SWeaponItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
         parry_skill: string;
         parry_specialization: string;
     };
-    range: { short: number; medium: number; long: number };
+    range: { short: string; medium: string; long: string };
     damage: { type: string; score: number; muscle: boolean; str: boolean };
     blast_radius: Record<
         "1" | "2" | "3" | "4",


### PR DESCRIPTION
## Summary
Two related weapon-roll bugs surfaced during the recent type-tightening passes. Bundled because both alter weapon roll behavior and share the same gameplay smoke matrix.

### #16 — Weapon roll picks up specialization rollMin
The weapon branch in `executeRollAction` had a guard `(itemData as { type: string }).type === 'specialization'`, but the weapon `TypeDataModel` has no top-level `type` field — only nested `damage.type`, `stun.type`, etc. The branch was dead, so weapons configured with `stats.specialization` always fell through to the skill branch and used the *skill's* rollMin instead of the *spec's*.

The branch body already does the right thing — it just had a bogus gate. Removed the `system.type` check and tightened the spec lookup to `i.type === 'specialization'` so a same-named non-spec item can't match.

### #17 — Restore attribute-relative weapon ranges
Personal weapon `range.{short,medium,long}` was declared `NumberField` with a `migrateData` step that coerced strings to `Number(value) || 0`. That killed support for `"AGI+2"` / `"STR-1"` syntax, which the rest of the system still expects:
- `getWeaponRange` extracts the attribute name from each range string and uses it for the STR-relative range computation (`weapons.ts:33-47`)
- `OD6S.WARN_INVALID_RANGE_ATTRIBUTE` localization key fires when extraction fails
- `static_str_range` setting matches `[+|-][0-9]$` offsets
- `templates/item/item-weapon-sheet.html` renders the inputs as `type="text"` (vehicle/starship-weapon templates correctly use `type="number"` against their separate NumberField schemas)

Switched personal weapon range fields to `StringField` (initial `"0"`) and reversed the migration so existing numeric values get re-stringified. Vehicle/starship weapon ranges (`vehicle-weapons-fields.ts`) stay `NumberField` — those are not attribute-relative per the rules. Updated `OD6SWeaponItemSystem.range` typing and dropped the `Record<string, any>` cast in `getWeaponRange`.

Closes #16.
Closes #17.

## ⚠️ Needs gameplay smoke before merge

### #16 changes runtime behavior
This restores a path that has been silently dead. Weapons with a configured specialization on actors that own the matching spec will now roll using the spec's score, not the skill's. Verify:
- [ ] Make a weapon attack where `weapon.system.stats.specialization` is set and the actor owns a specialization item with that name → rollMin reflects spec.score + skill.attribute
- [ ] Same setup but the actor does **not** own the spec → falls through to skill branch (unchanged)
- [ ] Weapon with no `stats.specialization` → skill branch (unchanged)

### #17 changes data shape
Existing weapon items will be re-migrated on world load — numeric ranges become string equivalents (`5` → `"5"`).
- [ ] Open an existing weapon item sheet — range fields render as before
- [ ] Edit a range to `"AGI+2"` and save → persists as string, displays correctly in inventory tabs
- [ ] Make a ranged attack with a numeric-range weapon → `getWeaponRange` returns the numeric range as before
- [ ] Make a ranged attack with `"AGI+2"`-style range → `getWeaponRange` resolves through the attribute lookup, no warning
- [ ] Toggle `static_str_range` setting and verify both modes
- [ ] Confirm vehicle and starship weapon range fields are unaffected

## Other checks
- [x] `pnpm run check` — lint + typecheck + 162 unit + 250 domain tests pass