### PR TITLE
refactor: decouple skill display score from system.score (#13)

### DIFF
--- a/scripts/codemod-system-score-to-total.mjs
+++ b/scripts/codemod-system-score-to-total.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * #13 Phase 2 codemod: switch actor-side handlebars templates from
+ * `<thing>.system.score` to `<thing>.system.total` for display contexts.
+ *
+ * Skipped:
+ * - src/templates/item/item-skill-sheet.html
+ * - src/templates/item/item-specialization-sheet.html
+ *   (item edit forms — no actor context, `total` is undefined for unowned items)
+ */
+
+import {readFileSync, writeFileSync} from 'node:fs';
+
+const TARGETS = [
+    'src/templates/actor/common/tabs/attribute-column.html',
+    'src/templates/actor/character/tabs/attributes.html',
+    'src/templates/actor/character/tabs/metaphysics.html',
+    'src/templates/metaphysicsRoll.html',
+    'src/templates/actor/character/create-skill-column.html',
+    'src/templates/actor/character/create-character-skills.html',
+];
+
+let totalReplacements = 0;
+for (const file of TARGETS) {
+    const before = readFileSync(file, 'utf8');
+    const after = before.replace(/\.system\.score\b/g, '.system.total');
+    const count = (before.match(/\.system\.score\b/g) ?? []).length;
+    if (count > 0) {
+        writeFileSync(file, after);
+        console.log(`${file}: ${count} replacement(s)`);
+        totalReplacements += count;
+    }
+}
+console.log(`\nTotal: ${totalReplacements}`);

--- a/scss/global/_window.scss
+++ b/scss/global/_window.scss
@@ -97,11 +97,13 @@
   overflow: hidden;
 }
 
-// ── Settings config dialogs ──────────────────────────────────────────────
-// All od6s ApplicationV2 settings forms (Rules Options, Automation, etc.)
-// use position.height: "auto", which lets content grow past the viewport
-// with no internal scroll. Cap at 90vh and make the inner form scroll.
-.od6s.settings-config {
+// ── Viewport-capped scroll for od6s ApplicationV2 windows ────────────────
+// Settings dialogs (Rules Options, Automation, etc.) and item/actor sheets
+// all use position.height: "auto", which lets content grow past the
+// viewport with no internal scroll. Cap at 90vh and make .window-content
+// the scroll container.
+.od6s.settings-config,
+.od6s.sheet {
   max-height: 90vh;
   display: flex;
   flex-direction: column;

--- a/src/module/actor/actor-helpers/prepare-data.ts
+++ b/src/module/actor/actor-helpers/prepare-data.ts
@@ -1,5 +1,6 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
+import {computeSkillDisplayScore} from "./skill-score";
 
 export function prepareBaseActorData(actor: any): void {
     // Set all mod values to zero
@@ -86,14 +87,23 @@ export async function prepareDerivedActorData(actor: any): Promise<void> {
         i.findActiveEffects();
         i.applyMods();
 
-        if(i.type === 'skill' || i.type === 'specialization') {
-            if (i.system.isAdvancedSkill) {
-                i.system.total = i.system.score;
-                i.system.text = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(i.system.score));
-            } else {
-                i.system.total = i.system.score + actor.system.attributes[i.system.attribute].score;
-                i.system.totalText = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(i.system.total));
-            }
+        if (i.type === 'skill' || i.type === 'specialization') {
+            // `system.score` is the canonical own-progression value (base + mod),
+            // already reset by `i.applyMods()` above. `system.total` is the display
+            // value that includes the linked attribute (and respects flatSkills /
+            // advanced-skill rules). Templates and roll-dialog data-score reads
+            // should consume `system.total`; roll-formula consumers add the
+            // attribute themselves and therefore stay on `system.score`.
+            const attrKey = typeof i.system.attribute === 'string' ? i.system.attribute : undefined;
+            const attribute = attrKey ? actor.system.attributes?.[attrKey] : undefined;
+            i.system.total = computeSkillDisplayScore({
+                base: i.system.base,
+                mod: i.system.mod,
+                isAdvancedSkill: i.type === 'skill' && i.system.isAdvancedSkill,
+                attributeScore: attribute?.score,
+                flatSkills: OD6S.flatSkills,
+            });
+            i.system.totalText = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(i.system.total));
         }
     }
 

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -14,7 +14,6 @@ import {registerEffectListeners} from "./sheet-listeners/effects";
 import {registerDragListeners} from "./sheet-listeners/drag";
 
 // Helper modules
-import {computeSkillDisplayScore} from "./actor-helpers/skill-score";
 import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
 import {deleteItem, addItem, onItemCreate} from "./sheet-helpers/item-crud";
 import {
@@ -124,33 +123,8 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
             if (i.type === "gear") {
                 gear.push(i);
             } else if (i.type === "skill") {
-                // Compute the display score *idempotently* from base/mod/attribute.
-                // Reading + writing `i.system.score` here used to compound across
-                // re-renders because prepareDerivedData() only resets score on
-                // actor re-prepare, not on every sheet render.
-                if (typeof i.system.attribute !== "undefined") {
-                    i.system.score = computeSkillDisplayScore({
-                        base: i.system.base,
-                        mod: i.system.mod,
-                        isAdvancedSkill: i.system.isAdvancedSkill,
-                        attributeScore:
-                            actorData.system.attributes?.[i.system.attribute.toLowerCase()]?.score,
-                        flatSkills: OD6S.flatSkills,
-                    });
-                }
                 skills.push(i);
             } else if (i.type === "specialization") {
-                // Specializations always roll on the linked attribute; no
-                // advanced-skill exemption applies.
-                if (typeof i.system.attribute !== "undefined") {
-                    i.system.score = computeSkillDisplayScore({
-                        base: i.system.base,
-                        mod: i.system.mod,
-                        attributeScore:
-                            actorData.system.attributes?.[i.system.attribute.toLowerCase()]?.score,
-                        flatSkills: OD6S.flatSkills,
-                    });
-                }
                 specializations.push(i);
             } else if (i.type === "weapon") {
                 weapons.push(i);

--- a/src/module/data/item/fields/skill-fields.ts
+++ b/src/module/data/item/fields/skill-fields.ts
@@ -1,5 +1,23 @@
 const fields = foundry.data.fields;
 
+/**
+ * Skill / specialization shared progression fields.
+ *
+ * Score-field convention (consumers must follow):
+ *   - `base + mod`     → own progression in pips. Persisted; reset by
+ *                        `applyMods()`.
+ *   - `score`          → derived `base + mod`. Roll-formula consumers read
+ *                        this and add the linked attribute themselves.
+ *   - `system.total`   → derived display value (`base + mod + attribute`,
+ *                        respecting flatSkills + advanced-skill rules).
+ *                        Populated by `prepareDerivedActorData()` via
+ *                        `computeSkillDisplayScore()`. Templates and
+ *                        roll-dialog `data-score` reads consume `total`,
+ *                        not `score`.
+ *
+ * `total` is not declared here — it's a runtime-only derivation written by
+ * the actor's prepare pass, not a persisted schema field.
+ */
 export function skillFieldsSchema() {
   return {
     attribute: new fields.StringField({ initial: "" }),

--- a/src/module/data/item/fields/skill-fields.ts
+++ b/src/module/data/item/fields/skill-fields.ts
@@ -4,10 +4,13 @@ const fields = foundry.data.fields;
  * Skill / specialization shared progression fields.
  *
  * Score-field convention (consumers must follow):
- *   - `base + mod`     → own progression in pips. Persisted; reset by
- *                        `applyMods()`.
- *   - `score`          → derived `base + mod`. Roll-formula consumers read
- *                        this and add the linked attribute themselves.
+ *   - `base`, `mod`    → persisted progression inputs in pips. `base` carries
+ *                        any persisted advances; `mod` stores temporary
+ *                        adjustments. Both are written to the document.
+ *   - `score`          → derived `base + mod`, recomputed by `applyMods()`.
+ *                        Not an independent input — never edit directly.
+ *                        Roll-formula consumers read this and add the linked
+ *                        attribute themselves.
  *   - `system.total`   → derived display value (`base + mod + attribute`,
  *                        respecting flatSkills + advanced-skill rules).
  *                        Populated by `prepareDerivedActorData()` via

--- a/src/templates/actor/character/create-character-skills.html
+++ b/src/templates/actor/character/create-character-skills.html
@@ -49,12 +49,12 @@
                                                 <div class="flex-group-center"
                                                      data-item-id="{{skill._id}}"
                                                      data-type="skill"
-                                                     data-score="{{skill.system.score}}"
+                                                     data-score="{{skill.system.total}}"
                                                      data-base="{{skill.system.base}}"
                                                      data-label="{{skill.name}}">
                                                     {{#unless (flatSkills)}}
-                                                        <b>{{diceFromScore skill.system.score}}</b>D+<b>{{pipsFromScore
-                                                            skill.system.score}}</b>
+                                                        <b>{{diceFromScore skill.system.total}}</b>D+<b>{{pipsFromScore
+                                                            skill.system.total}}</b>
                                                     {{else}}
                                                         {{ skill.system.base }}
                                                     {{/unless}}</div>
@@ -64,7 +64,7 @@
                                                          title="{{localize "OD6S.INCREASE_SKILL"}}"
                                                          data-item-id="{{skill._id}}"
                                                          data-type="skill"
-                                                         data-score="{{skill.system.score}}"
+                                                         data-score="{{skill.system.total}}"
                                                          data-base="{{skill.system.base}}"
                                                          data-label="{{skill.name}}">
                                                         <a><i class="fas fa-plus-square"></i></a></div>
@@ -72,7 +72,7 @@
                                                          title="{{localize "OD6S.DECREASE_SKILL"}}"
                                                          data-item-id="{{skill._id}}"
                                                          data-type="skill"
-                                                         data-score="{{skill.system.score}}"
+                                                         data-score="{{skill.system.total}}"
                                                          data-base="{{skill.system.base}}"
                                                          data-label="{{skill.name}}">
                                                         <a><i class="fas fa-minus-square"></i></a></div>

--- a/src/templates/actor/character/create-skill-column.html
+++ b/src/templates/actor/character/create-skill-column.html
@@ -27,12 +27,12 @@
                             <div class="flex-group-center"
                                  data-item-id="{{skill._id}}"
                                  data-type="skill"
-                                 data-score="{{skill.system.score}}"
+                                 data-score="{{skill.system.total}}"
                                  data-base="{{skill.system.base}}"
                                  data-label="{{skill.name}}">
                                 {{#unless (flatSkills)}}
-                                    <b>{{diceFromScore skill.system.score}}</b>D+<b>{{pipsFromScore
-                                        skill.system.score}}</b>
+                                    <b>{{diceFromScore skill.system.total}}</b>D+<b>{{pipsFromScore
+                                        skill.system.total}}</b>
                                 {{else}}
                                     {{ skill.system.base }}
                                 {{/unless}}</div>
@@ -42,7 +42,7 @@
                                      title="{{localize "OD6S.INCREASE_SKILL"}}"
                                      data-item-id="{{skill._id}}"
                                      data-type="skill"
-                                     data-score="{{skill.system.score}}"
+                                     data-score="{{skill.system.total}}"
                                      data-base="{{skill.system.base}}"
                                      data-label="{{skill.name}}">
                                     <a><i class="fas fa-plus-square"></i></a></div>
@@ -50,7 +50,7 @@
                                      title="{{localize "OD6S.DECREASE_SKILL"}}"
                                      data-item-id="{{skill._id}}"
                                      data-type="skill"
-                                     data-score="{{skill.system.score}}"
+                                     data-score="{{skill.system.total}}"
                                      data-base="{{skill.system.base}}"
                                      data-label="{{skill.name}}">
                                     <a><i class="fas fa-minus-square"></i></a></div>
@@ -83,12 +83,12 @@
                                     <div class="flex-group-center"
                                          data-item-id="{{spec._id}}"
                                          data-type="spec"
-                                         data-score="{{spec.system.score}}"
+                                         data-score="{{spec.system.total}}"
                                          data-base="{{spec.system.base}}"
                                          data-label="{{spec.name}}">
                                         {{#unless (flatspecs)}}
-                                            <b>{{diceFromScore spec.system.score}}</b>D+<b>{{pipsFromScore
-                                                spec.system.score}}</b>
+                                            <b>{{diceFromScore spec.system.total}}</b>D+<b>{{pipsFromScore
+                                                spec.system.total}}</b>
                                         {{else}}
                                             {{ spec }}
                                         {{/unless}}</div>
@@ -99,7 +99,7 @@
                                              title="{{localize "OD6S.INCREASE_SPECIALIZATION"}}"
                                              data-item-id="{{spec._id}}"
                                              data-type="spec"
-                                             data-score="{{spec.system.score}}"
+                                             data-score="{{spec.system.total}}"
                                              data-base="{{spec.system.base}}"
                                              data-label="{{spec.name}}">
                                             <a><i class="fas fa-plus-square"></i></a></div>
@@ -107,7 +107,7 @@
                                              title="{{localize "OD6S.DECREASE_SPECIALIZATION"}}"
                                              data-item-id="{{spec._id}}"
                                              data-type="spec"
-                                             data-score="{{spec.system.score}}"
+                                             data-score="{{spec.system.total}}"
                                              data-base="{{spec.system.base}}"
                                              data-label="{{spec.name}}">
                                             <a><i class="fas fa-minus-square"></i></a></div>

--- a/src/templates/actor/character/tabs/attributes.html
+++ b/src/templates/actor/character/tabs/attributes.html
@@ -64,7 +64,7 @@
                                                 (eq ../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                              data-item-id="{{skill._id}}"
                                              data-type="skill"
-                                             data-score="{{skill.system.score}}"
+                                             data-score="{{skill.system.total}}"
                                              data-base="{{skill.system.base}}"
                                              data-label="{{skill.name}}">
                                             {{skill.name}}
@@ -74,12 +74,12 @@
                                             {{getModColor skill.system.mod}}"
                                              data-item-id="{{skill._id}}"
                                              data-type="skill"
-                                             data-score="{{skill.system.score}}"
+                                             data-score="{{skill.system.total}}"
                                              data-base="{{skill.system.base}}"
                                              data-label="{{skill.name}}">
                                             {{#unless (flatSkills)}}
-                                                <b>{{diceFromScore skill.system.score}}</b>D+<b>{{pipsFromScore
-                                                    skill.system.score}}</b>
+                                                <b>{{diceFromScore skill.system.total}}</b>D+<b>{{pipsFromScore
+                                                    skill.system.total}}</b>
                                             {{else}}
                                                 {{ skill.system.base }}
                                             {{/unless}}</div>
@@ -90,7 +90,7 @@
                                                    title="{{localize "OD6S.ADVANCE_SKILL"}}"
                                                    data-item-id="{{skill._id}}"
                                                    data-type="skill"
-                                                   data-score="{{skill.system.score}}"
+                                                   data-score="{{skill.system.total}}"
                                                    data-base="{{skill.system.base}}"
                                                    data-label="{{skill.name}}"
                                                    data-freeadvance="false">
@@ -100,7 +100,7 @@
                                             <div class="item item-controls flexrow flex-group-center"
                                                  data-item-id="{{skill._id}}"
                                                  data-type="skill"
-                                                 data-score="{{skill.system.score}}"
+                                                 data-score="{{skill.system.total}}"
                                                  data-base="{{skill.system.base}}"
                                                  data-label="{{skill.name}}"
                                                  data-freeadvance="true">

--- a/src/templates/actor/character/tabs/metaphysics.html
+++ b/src/templates/actor/character/tabs/metaphysics.html
@@ -55,7 +55,7 @@
                                             (eq ../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                          data-item-id="{{skill._id}}"
                                          data-type="skill"
-                                         data-score="{{skill.system.score}}"
+                                         data-score="{{skill.system.total}}"
                                          data-label="{{skill.name}}">
                                         {{skill.name}}:
                                     </div>
@@ -63,10 +63,10 @@
                                             (eq ../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                          data-item-id="{{skill._id}}"
                                          data-type="skill"
-                                         data-score="{{skill.system.score}}"
+                                         data-score="{{skill.system.total}}"
                                          data-label="{{skill.name}}">
-                                        <b>{{diceFromScore skill.system.score}}</b>D+<b>{{pipsFromScore
-                                            skill.system.score}}</b>
+                                        <b>{{diceFromScore skill.system.total}}</b>D+<b>{{pipsFromScore
+                                            skill.system.total}}</b>
                                     </div>
                                     {{#if (eq ../actor.system.sheetmode.value "advance")}}
                                         <div class="item item-controls flexrow flex-group-center"
@@ -75,7 +75,7 @@
                                                title="{{localize "OD6S.ADVANCE_SKILL"}}"
                                                data-item-id="{{skill._id}}"
                                                data-type="skill"
-                                               data-score="{{skill.system.score}}"
+                                               data-score="{{skill.system.total}}"
                                                data-label="{{skill.name}}"
                                                data-freeadvance="false">
                                                 <i class="fas fa-plus-square"></i></a>
@@ -84,7 +84,7 @@
                                         <div class="item item-controls flexrow flex-group-center"
                                              data-item-id="{{skill._id}}"
                                              data-type="skill"
-                                             data-score="{{skill.system.score}}"
+                                             data-score="{{skill.system.total}}"
                                              data-label="{{skill.name}}"
                                              data-freeadvance="true">
                                             <a class="item-control item-edit" title="Edit Skill"><i

--- a/src/templates/actor/common/tabs/attribute-column.html
+++ b/src/templates/actor/common/tabs/attribute-column.html
@@ -69,7 +69,7 @@
                                     (eq ../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                  data-item-id="{{skill._id}}"
                                  data-type="skill"
-                                 data-score="{{skill.system.score}}"
+                                 data-score="{{skill.system.total}}"
                                  data-base="{{skill.system.base}}"
                                  data-label="{{skill.name}}">
                                 {{skill.name}}
@@ -80,12 +80,12 @@
                                 {{getModColor skill.system.mod}}"
                                  data-item-id="{{skill._id}}"
                                  data-type="skill"
-                                 data-score="{{skill.system.score}}"
+                                 data-score="{{skill.system.total}}"
                                  data-base="{{skill.system.base}}"
                                  data-label="{{skill.name}}">
                                 {{#unless (flatSkills)}}
-                                    <b>{{diceFromScore skill.system.score}}</b>D+<b>{{pipsFromScore
-                                        skill.system.score}}</b>
+                                    <b>{{diceFromScore skill.system.total}}</b>D+<b>{{pipsFromScore
+                                        skill.system.total}}</b>
                                 {{else}}
                                     {{ skill.system.base }}
                                 {{/unless}}</div>
@@ -96,7 +96,7 @@
                                        title="{{localize "OD6S.ADVANCE_SKILL"}}"
                                        data-item-id="{{skill._id}}"
                                        data-type="skill"
-                                       data-score="{{skill.system.score}}"
+                                       data-score="{{skill.system.total}}"
                                        data-base="{{skill.system.base}}"
                                        data-label="{{skill.name}}"
                                        data-freeadvance="false">
@@ -111,7 +111,7 @@
                                 <div class="item item-controls flexrow flex-group-center"
                                      data-item-id="{{skill._id}}"
                                      data-type="skill"
-                                     data-score="{{skill.system.score}}"
+                                     data-score="{{skill.system.total}}"
                                      data-base="{{skill.system.base}}"
                                      data-label="{{skill.name}}"
                                      data-freeadvance="true">
@@ -149,7 +149,7 @@
                                                 (eq ../../actor.system.sheetmode.value "normal")}} rolldialog{{/if}}"
                                              data-item-id="{{spec._id}}"
                                              data-type="specialization"
-                                             data-score="{{spec.system.score}}"
+                                             data-score="{{spec.system.total}}"
                                              data-label="{{spec.name}}">
                                             <i>{{spec.name}}</i>
                                         </div>
@@ -159,11 +159,11 @@
                                             {{getModColor spec.system.mod}}"
                                              data-item-id="{{spec._id}}"
                                              data-type="specialization"
-                                             data-score="{{spec.system.score}}"
+                                             data-score="{{spec.system.total}}"
                                              data-label="{{spec.name}}">
                                             {{#unless (flatSkills)}}
-                                                <b>{{diceFromScore spec.system.score}}</b>D+<b>{{pipsFromScore
-                                                    spec.system.score}}</b>
+                                                <b>{{diceFromScore spec.system.total}}</b>D+<b>{{pipsFromScore
+                                                    spec.system.total}}</b>
                                             {{else}}
                                                 {{ spec.system.base }}
                                             {{/unless}}</div>
@@ -174,7 +174,7 @@
                                                    title="{{localize "OD6S.ADVANCE_SKILL"}}"
                                                    data-item-id="{{spec._id}}"
                                                    data-type="specialization"
-                                                   data-score="{{spec.system.score}}"
+                                                   data-score="{{spec.system.total}}"
                                                    data-base="{{spec.system.base}}"
                                                    data-label="{{spec.name}}"
                                                    data-freeadvance="false">
@@ -184,7 +184,7 @@
                                             <div class="item item-controls flexrow flex-group-center"
                                                  data-item-id="{{spec._id}}"
                                                  data-type="specialization"
-                                                 data-score="{{spec.system.score}}"
+                                                 data-score="{{spec.system.total}}"
                                                  data-base="{{spec.system.base}}"
                                                  data-label="{{spec.name}}"
                                                  data-freeadvance="true">

--- a/src/templates/metaphysicsRoll.html
+++ b/src/templates/metaphysicsRoll.html
@@ -10,15 +10,15 @@
             </div>
         {{/if}}
         <div class="flexrow flex-group-left">
-            <div class="dice flexrow flex-group-left" data-dice="{{diceFromScore skill.system.score}}">
+            <div class="dice flexrow flex-group-left" data-dice="{{diceFromScore skill.system.total}}">
                 <label for="dice">{{localize 'OD6S.DICE'}}</label>
                 <input type="number" data-dtype="Number"
-                       max="99" id="dice" name="dice" value="{{diceFromScore skill.system.score}}">
+                       max="99" id="dice" name="dice" value="{{diceFromScore skill.system.total}}">
             </div>
-            <div class="pips flexrow flex-group-left" data-pips="{{pipsFromScore skill.system.score}}">
+            <div class="pips flexrow flex-group-left" data-pips="{{pipsFromScore skill.system.total}}">
                 <label for="pips">{{localize 'OD6S.PIPS'}}</label>
                 <input type="number" data-dtype="Number"
-                       max="99" id="pips" name="pips" value="{{pipsFromScore skill.system.score}}">
+                       max="99" id="pips" name="pips" value="{{pipsFromScore skill.system.total}}">
             </div>
         </div>
         <div class="flexrow flex-group-left">


### PR DESCRIPTION
## Summary
Resolves the long-standing conflict between sheet-render mutation of `i.system.score` and roll-side consumers that treat `system.score` as `base + mod` and add the linked attribute themselves. After this PR:

- `system.score` is **always** `base + mod` (own progression).
- `system.total` is the **display value** (`base + mod + attribute`, respecting flat-skills + advanced-skill rules), populated by `prepareDerivedActorData()`.
- `_prepareCharacterItems` no longer mutates `system.score`.

Closes #13.

## Phased commits
- `8d9a57f` — **Phase 1**: route `prepare-data.ts` through `computeSkillDisplayScore()` (handles flatSkills + advanced skill correctly; spec gets non-advanced treatment).
- `b37ddf4` — **Phase 2**: codemod 43 actor-side template refs from `system.score` → `system.total`. Item edit sheets unchanged. Codemod script committed at `scripts/codemod-system-score-to-total.mjs`.
- `376d27d` — **Phase 3**: drop the `i.system.score = ...` mutation in `_prepareCharacterItems` for both skill and spec branches.
- `08ec7d2` — **Phase 5**: docstring on `skill-fields.ts` describing the score/total convention.

Phase 4 (roll-path audit) was code-change-free — every consumer already treats `system.score` as `base + mod` and adds the attribute itself. Verified at:
- `src/module/item/item.ts:84` `getScore()` and weapon→skill chain
- `src/module/apps/roll-helpers/roll-setup.ts` (skill, spec, melee/brawl, weapon)
- `src/module/apps/roll-helpers/roll-execute.ts` rollMin sites
- `src/module/system/utilities/skills.ts` `getScoreFromSkill`

## ⚠️ Needs gameplay smoke before merge
This decouples display from roll-formula values, so verifying both is essential. The full matrix from the issue:

- [ ] **Sheet modes**: Normal / Advance / Free-Edit
- [ ] **Roll triggers**: melee, brawl, ranged, direct skill click
- [ ] **Skill kinds**: standard skill, advanced skill (`(A) ...`), specialization
- [ ] **Settings toggles**: `flat_skills` on, `flat_skills` off
- [ ] **Regression check**: render the sheet, then roll the same skill from the dialog without an intervening actor update — produced score should match the displayed dice (the bug this PR closes)
- [ ] **Metaphysics tab**: `metaphysicsRoll.html` dialog populates dice/pips correctly
- [ ] **Character creation**: `create-skill-column` and `create-character-skills` views show the right dice
- [ ] **Item sheet**: opening a skill or specialization item directly shows the raw `base + mod` (unchanged behavior)

## Migration / compatibility note
Third-party modules or Babele packs reading `system.score` for display will continue to get a valid `base + mod` value — they just won't get the combined dice. Field path for the combined display value is now `system.total`.

## Other checks
- [x] `pnpm run check` — lint + typecheck + 162 unit + 250 domain tests pass
- [x] No new domain test failures from removing the mutation