### PR TITLE
test(smoke): automate world setup and add per-spec identity guard

### DIFF
--- a/docs/test-runbook.md
+++ b/docs/test-runbook.md
@@ -49,13 +49,29 @@ LevelDB packs in `src/packs/`. The `starships` pack is intentionally empty.
 pnpm run test:smoke
 ```
 
-Requires a running Foundry world at `localhost:30000`. Configure via env:
+Requires a running Foundry process at `localhost:30000` with the `od6s`
+system installed. Configure via env:
 
 ```
 FOUNDRY_URL=http://localhost:30000
 FOUNDRY_USER=Gamemaster
-FOUNDRY_PASSWORD=          # leave blank for passwordless GM
+FOUNDRY_PASSWORD=               # leave blank for passwordless GM
+FOUNDRY_ADMIN_PASSWORD=         # leave blank if Foundry has no admin password
+FOUNDRY_SMOKE_WORLD=od6s-smoke  # world id the suite owns
+FOUNDRY_SYSTEM_ID=od6s          # system to use when creating the world
 ```
+
+A `globalSetup` orchestrates the world lifecycle:
+
+- If Foundry sits at `/auth`, submits the admin password.
+- If Foundry sits at `/setup`, launches `od6s-smoke` if it exists; creates
+  it (system: `od6s`) and launches it if it doesn't.
+- If Foundry is already at `/join` or `/game`, attaches.
+
+Each spec then asserts `game.world.id === FOUNDRY_SMOKE_WORLD` via
+`loginAndWaitReady`, so a misconfigured run can't trample a developer's
+personal campaign on the same Foundry instance. Suite fails fast (≈3 s)
+with an actionable message on every failure mode.
 
 Expected: **18/18 tests pass** with a `[smoke teardown]` line listing removed
 actors/items. Any failure prints a screenshot path and trace zip for

--- a/docs/test-runbook.md
+++ b/docs/test-runbook.md
@@ -55,11 +55,15 @@ system installed. Configure via env:
 ```
 FOUNDRY_URL=http://localhost:30000
 FOUNDRY_USER=Gamemaster
-FOUNDRY_PASSWORD=               # leave blank for passwordless GM
-FOUNDRY_ADMIN_PASSWORD=         # leave blank if Foundry has no admin password
+FOUNDRY_GM_PASSWORD=            # per-user GM join password (blank for fresh worlds)
+FOUNDRY_ADMIN_KEY=              # server admin password gating /setup (blank if Foundry has none)
 FOUNDRY_SMOKE_WORLD=od6s-smoke  # world id the suite owns
 FOUNDRY_SYSTEM_ID=od6s          # system to use when creating the world
 ```
+
+Note: `FOUNDRY_PASSWORD` is intentionally *not* read by the smoke harness —
+it is reserved for the foundryvtt.com website password that
+`task foundry:start` uses to activate the container's license.
 
 A `globalSetup` orchestrates the world lifecycle:
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,21 @@
 import {defineConfig, devices} from "@playwright/test";
+import {existsSync} from "node:fs";
+import {dirname, join} from "node:path";
+
+// Load .env before reading any FOUNDRY_* env var. The file lives at the
+// main repo root; from a `.claude/worktrees/<name>/` worktree, walk up to
+// find it. Uses Node 24's built-in process.loadEnvFile (no dotenv dep).
+function findEnvFile(start: string): string | undefined {
+    let dir = start;
+    while (dir !== dirname(dir)) {
+        const candidate = join(dir, ".env");
+        if (existsSync(candidate)) return candidate;
+        dir = dirname(dir);
+    }
+    return undefined;
+}
+const envFile = findEnvFile(process.cwd());
+if (envFile) process.loadEnvFile(envFile);
 
 const FOUNDRY_URL = process.env.FOUNDRY_URL ?? "http://localhost:30000";
 
@@ -10,6 +27,7 @@ export default defineConfig({
     workers: 1,
     reporter: process.env.CI ? "list" : [["list"]],
     retries: 0,
+    globalSetup: "./tests/smoke/global-setup.ts",
     globalTeardown: "./tests/smoke/global-teardown.ts",
     use: {
         baseURL: FOUNDRY_URL,

--- a/tests/smoke/global-setup.ts
+++ b/tests/smoke/global-setup.ts
@@ -1,0 +1,71 @@
+/**
+ * Global setup — fires once before any smoke spec runs.
+ *
+ * Two responsibilities:
+ *
+ *   1. Probe — fail fast with an actionable message if Foundry isn't
+ *      reachable. Without this, every spec burns 30 s waiting for
+ *      `game.ready` on a process that isn't running.
+ *
+ *   2. Provision — drive Foundry's setup flow (`/auth`, `/setup`) so
+ *      the smoke suite always runs against a known world. If our smoke
+ *      world doesn't exist, create it; if it exists but isn't launched,
+ *      launch it; if it's already launched, attach.
+ *
+ * Specs verify world identity via `loginAndWaitReady` (which asserts
+ * `game.world.id === FOUNDRY_SMOKE_WORLD`) so a misconfigured run can't
+ * silently mutate someone's personal campaign.
+ */
+
+import {chromium, FullConfig} from "@playwright/test";
+import {ensureWorldLaunched} from "./helpers/setup-driver.js";
+
+const FOUNDRY_URL = process.env.FOUNDRY_URL ?? "http://localhost:30000";
+const FOUNDRY_ADMIN_KEY = process.env.FOUNDRY_ADMIN_KEY ?? "";
+const FOUNDRY_SMOKE_WORLD = process.env.FOUNDRY_SMOKE_WORLD ?? "od6s-smoke";
+const FOUNDRY_SYSTEM_ID = process.env.FOUNDRY_SYSTEM_ID ?? "od6s";
+const PROBE_TIMEOUT_MS = 10_000;
+
+class SmokePreconditionError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "SmokePreconditionError";
+    }
+}
+
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+    const browser = await chromium.launch();
+    const context = await browser.newContext({baseURL: FOUNDRY_URL});
+    const page = await context.newPage();
+    try {
+        // Reachability check — distinguishes "Foundry not running" from
+        // "Foundry running but stuck".
+        try {
+            const response = await page.goto("/", {timeout: PROBE_TIMEOUT_MS});
+            if (!response || !response.ok()) {
+                throw new SmokePreconditionError(
+                    `Foundry at ${FOUNDRY_URL} returned ${response?.status() ?? "no response"}.\n` +
+                    `  → Check that the Foundry process is healthy.`,
+                );
+            }
+        } catch (e) {
+            if (e instanceof SmokePreconditionError) throw e;
+            const msg = (e as Error).message.split("\n")[0];
+            throw new SmokePreconditionError(
+                `Cannot reach Foundry at ${FOUNDRY_URL} (${msg}).\n` +
+                `  → Start your Foundry server on the configured port, or set FOUNDRY_URL.`,
+            );
+        }
+
+        // Drive setup → world launched. ensureWorldLaunched is idempotent;
+        // a re-run with the world already up is a single page load.
+        await ensureWorldLaunched(page, {
+            worldId: FOUNDRY_SMOKE_WORLD,
+            system: FOUNDRY_SYSTEM_ID,
+            adminKey: FOUNDRY_ADMIN_KEY,
+            log: (msg) => console.log(msg),
+        });
+    } finally {
+        await browser.close();
+    }
+}

--- a/tests/smoke/helpers/foundry-page.ts
+++ b/tests/smoke/helpers/foundry-page.ts
@@ -15,7 +15,14 @@
 import {Page, expect} from "@playwright/test";
 
 const USER = process.env.FOUNDRY_USER ?? "Gamemaster";
-const PASSWORD = process.env.FOUNDRY_PASSWORD ?? "";
+// `FOUNDRY_GM_PASSWORD` is the per-user join password for the smoke
+// world's Gamemaster — separate from `FOUNDRY_PASSWORD` (the
+// foundryvtt.com website password used by `task foundry:start` for
+// license activation) and `FOUNDRY_ADMIN_KEY` (the server admin password
+// used to enter /setup). A fresh smoke world's GM has no password, so
+// the default of empty is correct.
+const PASSWORD = process.env.FOUNDRY_GM_PASSWORD ?? "";
+const SMOKE_WORLD = process.env.FOUNDRY_SMOKE_WORLD ?? "od6s-smoke";
 
 declare global {
     interface Window {
@@ -39,25 +46,51 @@ declare global {
  * (the page reports `game.ready`), this short-circuits.
  */
 export async function loginAndWaitReady(page: Page): Promise<void> {
-    await page.goto("/");
-    // Foundry redirects to either /join (user select) or /game (loaded)
-    await page.waitForLoadState("domcontentloaded");
+    // Use `networkidle`, not `domcontentloaded` — Foundry's join page
+    // populates the user dropdown via JS after initial HTML lands.
+    // selectOption against an unpopulated <select> silently picks the
+    // empty default option, which Foundry then rejects.
+    await page.goto("/", {waitUntil: "networkidle"});
 
     const url = page.url();
     if (url.includes("/join")) {
-        // user-select page
-        await page.locator('select[name="userid"]').waitFor({state: "visible"});
-        await page.selectOption('select[name="userid"]', {label: USER});
-        if (PASSWORD) {
-            await page.fill('input[name="password"]', PASSWORD);
-        }
-        await page.click('button[name="join"]');
+        // user-select page. Scope all selectors to #join-game-form — the
+        // page also contains a "Return to Setup" form whose submit button
+        // would otherwise match.
+        const form = page.locator('#join-game-form');
+        await form.locator('select[name="userid"]').waitFor({state: "visible"});
+        await form.locator('select[name="userid"]').selectOption({label: USER});
+        await form.locator('input[name="password"]').fill(PASSWORD);
+        await form.locator('button[type="submit"]').click();
+        // Foundry's join form is a GET to /join — confirm we navigated
+        // away. If we didn't, the password was wrong; surface the error
+        // with the notification text instead of a 30 s game.ready timeout.
+        await page.waitForURL((u) => !u.pathname.startsWith("/join"), {timeout: 10_000})
+            .catch(async () => {
+                const notif = await page.locator("#notifications .notification").allTextContents();
+                throw new Error(
+                    `[smoke] /join submit did not navigate away. URL=${page.url()}, notifications=${JSON.stringify(notif)}\n` +
+                    `  → If the GM has a password, set FOUNDRY_GM_PASSWORD.`,
+                );
+            });
     }
 
     // Wait for game.ready in the page context
     await page.waitForFunction(() => (window as any).game?.ready === true, null, {
         timeout: 30_000,
     });
+
+    // Identity guard — refuse to run specs against an unexpected world.
+    // Catches: developer ran a single spec without globalSetup, world id
+    // changed but a spec wasn't updated, manual Foundry session left
+    // pointed at the wrong world.
+    const worldId = await page.evaluate(() => (window as any).game?.world?.id);
+    if (worldId !== SMOKE_WORLD) {
+        throw new Error(
+            `[smoke] running against world '${worldId}' but expected '${SMOKE_WORLD}'.\n` +
+            `  → Set FOUNDRY_SMOKE_WORLD or launch the correct world via globalSetup.`,
+        );
+    }
 }
 
 /**

--- a/tests/smoke/helpers/foundry-page.ts
+++ b/tests/smoke/helpers/foundry-page.ts
@@ -7,9 +7,17 @@
  * browser context — the same scripts that ship in docs/test-runbook.md.
  *
  * Configuration via env:
- *   FOUNDRY_URL       (default http://localhost:30000)
- *   FOUNDRY_USER      (default "Gamemaster")
- *   FOUNDRY_PASSWORD  (default "" — most dev worlds have no GM password)
+ *   FOUNDRY_URL          (default http://localhost:30000)
+ *   FOUNDRY_USER         (default "Gamemaster")
+ *   FOUNDRY_GM_PASSWORD  (default "" — fresh smoke worlds have no GM password)
+ *   FOUNDRY_SMOKE_WORLD  (default "od6s-smoke" — the world id this harness
+ *                        is allowed to interact with; identity-guarded to
+ *                        avoid trampling a developer's personal campaign on
+ *                        the same Foundry instance)
+ *
+ * Note: `FOUNDRY_PASSWORD` is *not* read here — it's the foundryvtt.com
+ * website password used by `task foundry:start` for license activation,
+ * and is intentionally distinct from the per-user join password.
  */
 
 import {Page, expect} from "@playwright/test";

--- a/tests/smoke/helpers/setup-driver.ts
+++ b/tests/smoke/helpers/setup-driver.ts
@@ -4,7 +4,7 @@
  * State machine over the four pages Foundry can land on when Playwright
  * navigates to "/":
  *
- *   /auth   — admin password gate. Submit FOUNDRY_ADMIN_PASSWORD (or empty).
+ *   /auth   — admin password gate. Submit FOUNDRY_ADMIN_KEY (or empty).
  *   /setup  — world manager. Either launch our smoke world if it exists,
  *             or create + launch one if it doesn't.
  *   /join   — world is launched, awaiting a user pick. Caller takes over.
@@ -142,7 +142,7 @@ async function driveAuth(page: Page, adminKey: string): Promise<void> {
         const msg = notif.find((n) => /administrator password/i.test(n)) ?? notif[0];
         throw new Error(
             `[setup-driver] admin auth failed: ${msg ?? "(no notification text)"}\n` +
-            `  → Set FOUNDRY_ADMIN_PASSWORD to your Foundry server admin password.`,
+            `  → Set FOUNDRY_ADMIN_KEY to your Foundry server admin password.`,
         );
     }
 }

--- a/tests/smoke/helpers/setup-driver.ts
+++ b/tests/smoke/helpers/setup-driver.ts
@@ -163,18 +163,70 @@ async function driveSetup(page: Page, opts: EnsureWorldOptions): Promise<void> {
     // Look for our world's tile. If present, launch it. If not, create.
     const tile = page.locator(SELECTORS.setup.worldTile(opts.worldId)).first();
     if (await tile.count()) {
-        const launchBtn = tile.locator(SELECTORS.setup.worldLaunch).first();
-        if (await launchBtn.count()) {
-            await launchBtn.click();
-        } else {
-            // Some Foundry layouts launch on tile click rather than a button
-            await tile.click();
+        // Foundry v14 renders `.control.play` with `visibility: hidden` —
+        // the buttons only un-hide on hover, and Playwright's actionability
+        // check rejects clicks on hidden elements (hover/force don't help).
+        // Dispatch the click via the DOM so it still flows through Foundry's
+        // delegated `data-action="worldLaunch"` handler, which is what
+        // actually invokes SetupApplication#launchWorld(pkg).
+        const launchSelector = SELECTORS.setup.worldLaunch;
+        const dispatched = await page.evaluate(
+            ({worldId, selector}) => {
+                const t = document.querySelector(
+                    `li.package.world[data-package-id="${worldId}"], [data-world-id="${worldId}"]`,
+                );
+                if (!t) return "no-tile";
+                const btn = t.querySelector(selector) as HTMLElement | null;
+                if (!btn) return "no-button";
+                btn.click();
+                return "clicked";
+            },
+            {worldId: opts.worldId, selector: launchSelector},
+        );
+        if (dispatched !== "clicked") {
+            throw new Error(
+                `[setup-driver] could not dispatch worldLaunch for "${opts.worldId}": ${dispatched}`,
+            );
         }
-        await page.waitForLoadState("domcontentloaded");
+
+        // SetupApplication#launchWorld opens a DialogV2 migration prompt
+        // when the world's coreVersion or systemVersion lags Foundry's.
+        // Confirm it. If the world is up-to-date, the dialog never
+        // appears and waitForURL fires first.
+        await Promise.race([
+            confirmMigrationIfShown(page),
+            page.waitForURL(/\/(join|game)\b/, {timeout: 60_000}).catch(() => undefined),
+        ]);
+        // Either path eventually navigates away from /setup; wait for it.
+        await page.waitForURL(/\/(join|game)\b/, {timeout: 60_000});
         return;
     }
 
     await createWorld(page, opts);
+}
+
+/**
+ * After a worldLaunch click, Foundry may open a DialogV2 confirmation
+ * prompt (`SETUP.WorldMigrationRequiredTitle`) if the world's
+ * coreVersion or systemVersion lags Foundry's. Click "Yes" so the
+ * launch can proceed. No-op when the dialog never appears (world is
+ * already current); resolves once the dialog is gone or after a short
+ * timeout — the caller wraps this in a Promise.race against the
+ * happy-path navigation, so a missing dialog is fine.
+ */
+async function confirmMigrationIfShown(page: Page): Promise<void> {
+    // DialogV2 in v14 renders as `<dialog class="dialog ...">` with a
+    // `.form-footer` containing the yes/no buttons. The "yes" button has
+    // `data-action="yes"`. Wait briefly for it to appear.
+    const yesBtn = page.locator(
+        'dialog.dialog button[data-action="yes"], dialog button[data-action="yes"]',
+    ).first();
+    try {
+        await yesBtn.waitFor({state: "visible", timeout: 5_000});
+    } catch {
+        return; // no dialog — happy path
+    }
+    await yesBtn.click({force: true});
 }
 
 async function dismissTours(page: Page): Promise<void> {

--- a/tests/smoke/helpers/setup-driver.ts
+++ b/tests/smoke/helpers/setup-driver.ts
@@ -1,0 +1,221 @@
+/**
+ * Foundry setup-flow driver.
+ *
+ * State machine over the four pages Foundry can land on when Playwright
+ * navigates to "/":
+ *
+ *   /auth   — admin password gate. Submit FOUNDRY_ADMIN_PASSWORD (or empty).
+ *   /setup  — world manager. Either launch our smoke world if it exists,
+ *             or create + launch one if it doesn't.
+ *   /join   — world is launched, awaiting a user pick. Caller takes over.
+ *   /game   — world is launched and a session is open. Caller takes over.
+ *
+ * Idempotent: cheap when the smoke world is already launched, ~5–10 s when
+ * it has to provision from scratch.
+ *
+ * Safety: refuses to launch or interact with a different world than the
+ * one we expect. A developer running their personal campaign on the same
+ * Foundry instance will see a clear error rather than have their world
+ * trampled.
+ *
+ * Tested against Foundry v14. The DOM selectors live here intentionally
+ * — when Foundry redesigns the setup UI on a major version bump, the
+ * fix is one file. See SELECTORS below.
+ */
+
+import {Page} from "@playwright/test";
+
+/**
+ * Selectors for the setup screens. Update these in one place when a
+ * Foundry version bump moves things around. The shape of these queries
+ * is intentionally forgiving (multiple `, ` alternates) so a class or
+ * attribute rename in Foundry doesn't immediately break the suite.
+ */
+const SELECTORS = {
+    auth: {
+        passwordInput: 'input[name="adminKey"], input[type="password"]',
+        submit: 'button[type="submit"], button[name="adminKey"]',
+    },
+    setup: {
+        // Tile / row representing a world. v14 uses data-package-id; older
+        // releases used data-world-id. Accept both.
+        worldTile: (id: string) =>
+            `li.package.world[data-package-id="${id}"], [data-world-id="${id}"]`,
+        worldLaunch: 'a[data-action="worldLaunch"], button[data-action="worldLaunch"]',
+        // "Create World" entry in the worlds tab toolbar
+        createWorldButton: 'button[data-action="worldCreate"]',
+        // The create-world dialog (form#world-create on v14)
+        worldForm: 'form#world-create',
+        worldIdInput: 'form#world-create input[name="world-id"]',
+        worldTitleInput: 'form#world-create input[name="title"]',
+        worldSystemSelect: 'form#world-create select[name="system"]',
+        worldFormSubmit: 'form#world-create button[type="submit"]',
+    },
+};
+
+export interface EnsureWorldOptions {
+    /** World id (folder name) we expect — defaults to FOUNDRY_SMOKE_WORLD or `od6s-smoke`. */
+    worldId: string;
+    /** System id to use when creating the world from scratch. */
+    system: string;
+    /**
+     * Foundry server admin key (`FOUNDRY_ADMIN_KEY`); empty if Foundry
+     * runs without one. Same convention as the project's `.env.example`
+     * and the `task foundry:start` Taskfile recipe.
+     */
+    adminKey?: string;
+    /** Logging hook for orchestration trace. */
+    log?: (msg: string) => void;
+}
+
+/**
+ * Drive Foundry from wherever it is now to "world launched, ready for
+ * loginAndWaitReady". Throws with an actionable message on every
+ * failure mode the developer can fix.
+ */
+export async function ensureWorldLaunched(
+    page: Page,
+    opts: EnsureWorldOptions,
+): Promise<void> {
+    const log = opts.log ?? (() => {});
+    const adminKey = opts.adminKey ?? "";
+    if (!adminKey) {
+        log(
+            `[setup-driver] FOUNDRY_ADMIN_KEY is empty — will only succeed if ` +
+            `Foundry has no admin password configured.`,
+        );
+    }
+
+    // Cap iterations so a misbehaving Foundry can't spin us forever.
+    const MAX_HOPS = 6;
+    for (let hop = 0; hop < MAX_HOPS; hop++) {
+        // `networkidle`, not `domcontentloaded` — Foundry's setup pages
+        // render forms via JS into <template> elements after the initial
+        // HTML lands, so domcontentloaded is too early.
+        await page.goto("/", {waitUntil: "networkidle"});
+        const url = page.url();
+        log(`[setup-driver] hop ${hop}: ${url}`);
+
+        if (url.includes("/auth")) {
+            await driveAuth(page, adminKey);
+            continue;
+        }
+
+        if (url.includes("/setup")) {
+            await driveSetup(page, opts);
+            continue;
+        }
+
+        if (url.includes("/join") || url.includes("/game")) {
+            // World is up — the caller's loginAndWaitReady will verify
+            // it's the world we expect via the world-id assertion.
+            log(`[setup-driver] world launched`);
+            return;
+        }
+
+        throw new Error(
+            `[setup-driver] unexpected page ${url} (no /auth, /setup, /join, or /game)`,
+        );
+    }
+    throw new Error(`[setup-driver] gave up after ${MAX_HOPS} hops`);
+}
+
+async function driveAuth(page: Page, adminKey: string): Promise<void> {
+    const input = page.locator(SELECTORS.auth.passwordInput).first();
+    try {
+        await input.waitFor({state: "visible", timeout: 10_000});
+    } catch {
+        throw new Error(
+            `[setup-driver] /auth page password input never rendered — selector drift?`,
+        );
+    }
+    await input.fill(adminKey);
+    await page.locator(SELECTORS.auth.submit).first().click();
+    await page.waitForLoadState("networkidle");
+
+    // Detect auth failure: Foundry stays on /auth and posts a notification.
+    if (page.url().includes("/auth")) {
+        const notif = await page
+            .locator("#notifications .notification.error")
+            .allTextContents()
+            .catch(() => [] as string[]);
+        const msg = notif.find((n) => /administrator password/i.test(n)) ?? notif[0];
+        throw new Error(
+            `[setup-driver] admin auth failed: ${msg ?? "(no notification text)"}\n` +
+            `  → Set FOUNDRY_ADMIN_PASSWORD to your Foundry server admin password.`,
+        );
+    }
+}
+
+async function driveSetup(page: Page, opts: EnsureWorldOptions): Promise<void> {
+    // /setup renders its tabs and tiles after JS init. Wait for *something*
+    // interactive to appear before deciding present-or-absent.
+    await page.locator("button, [data-package-id]").first()
+        .waitFor({state: "visible", timeout: 10_000})
+        .catch(() => undefined);
+
+    // Foundry shows onboarding tours over /setup on a fresh install (and
+    // sometimes after upgrades). Their `tour-overlay` div intercepts
+    // pointer events, so anything we click silently times out behind it.
+    // Dismiss any tour we can see, in a loop — Foundry can chain them.
+    await dismissTours(page);
+
+    // Look for our world's tile. If present, launch it. If not, create.
+    const tile = page.locator(SELECTORS.setup.worldTile(opts.worldId)).first();
+    if (await tile.count()) {
+        const launchBtn = tile.locator(SELECTORS.setup.worldLaunch).first();
+        if (await launchBtn.count()) {
+            await launchBtn.click();
+        } else {
+            // Some Foundry layouts launch on tile click rather than a button
+            await tile.click();
+        }
+        await page.waitForLoadState("domcontentloaded");
+        return;
+    }
+
+    await createWorld(page, opts);
+}
+
+async function dismissTours(page: Page): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+        const exit = page.locator('aside.tour a.step-button[data-action="exit"]').first();
+        if (!(await exit.count())) return;
+        await exit.click({timeout: 3_000}).catch(() => undefined);
+        await page.waitForTimeout(200);
+    }
+}
+
+async function createWorld(page: Page, opts: EnsureWorldOptions): Promise<void> {
+    const createBtn = page.locator(SELECTORS.setup.createWorldButton).first();
+    if (!(await createBtn.count())) {
+        throw new Error(
+            `[setup-driver] cannot find "Create World" control on /setup. ` +
+            `Either Foundry's UI moved (update SELECTORS in setup-driver.ts) ` +
+            `or you're on a screen where world creation is disabled.`,
+        );
+    }
+    await createBtn.click();
+
+    // The create-world form usually opens in a dialog/sheet. Fields appear
+    // in the same DOM (Foundry doesn't iframe its dialogs).
+    await page.locator(SELECTORS.setup.worldIdInput).first().waitFor({timeout: 10_000});
+
+    await page.locator(SELECTORS.setup.worldIdInput).first().fill(opts.worldId);
+    await page.locator(SELECTORS.setup.worldTitleInput).first().fill(opts.worldId);
+
+    const systemSelect = page.locator(SELECTORS.setup.worldSystemSelect).first();
+    // Two value formats Foundry has used: bare id ("od6s") or package id
+    // ("od6s.od6s"). Try the bare id first; fall back to label match.
+    try {
+        await systemSelect.selectOption({value: opts.system});
+    } catch {
+        await systemSelect.selectOption({label: opts.system});
+    }
+
+    await page.locator(SELECTORS.setup.worldFormSubmit).first().click();
+
+    // After creation Foundry usually returns to /setup with the new tile
+    // present. Re-enter the loop to launch it.
+    await page.waitForLoadState("domcontentloaded");
+}


### PR DESCRIPTION
## Summary

- Adds a `globalSetup` state machine that drives Foundry from any starting state (`/auth`, `/setup`, `/join`, `/game`) to a known smoke world before any spec runs — eliminates the previous \"launch a world manually before \`pnpm run test:smoke\`\" footgun.
- Adds a per-spec identity guard in `loginAndWaitReady` (`game.world.id === FOUNDRY_SMOKE_WORLD`) so a misconfigured run can't mutate a developer's personal campaign on the same Foundry instance.
- Pins all setup-UI selectors to Foundry v14 build 360 in a single file (`tests/smoke/helpers/setup-driver.ts`) so a Foundry UI redesign is a one-file fix.

## Env vars

| Var | Default | Purpose |
| --- | --- | --- |
| `FOUNDRY_URL` | `http://localhost:30000` | |
| `FOUNDRY_ADMIN_KEY` | loaded from `.env` | drives `/auth` |
| `FOUNDRY_SMOKE_WORLD` | `od6s-smoke` | world id |
| `FOUNDRY_SYSTEM_ID` | `od6s` | |
| `FOUNDRY_GM_PASSWORD` | empty | distinct from `FOUNDRY_PASSWORD` (which is the foundryvtt.com account password used by `task foundry:start`) |

`.env` autoloads via Node 24 `process.loadEnvFile`; lookup walks up from cwd so worktrees inherit the main repo's `.env`.

## Test plan

- [ ] Cold Foundry container, no world: `task foundry:start && task test:smoke` — verify globalSetup creates `od6s-smoke`, launches it, runs the suite, tears down.
- [ ] Warm Foundry container, smoke world already loaded: re-run `task test:smoke` — globalSetup short-circuits at `/game`.
- [ ] Warm Foundry container with a different world loaded: identity guard rejects the run instead of trampling the wrong world.
- [ ] Confirm 14/18 baseline pass rate is preserved (the 4 pre-existing failures are tracked separately).