### PR TITLE
fix: sheet edits not persisting in Free Edit mode (#27)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -173,6 +173,49 @@ tasks:
     cmds:
       - pnpm run typecheck
 
+  # ── Tests ────────────────────────────────────────────────────────
+
+  test:
+    desc: Run unit tests (vitest)
+    cmds:
+      - pnpm run test
+
+  test:domain:
+    desc: Run domain tests (vitest domain project)
+    cmds:
+      - pnpm run test:domain
+
+  test:smoke:
+    desc: Run Playwright smoke tests against the running Foundry container (logs to test-results/smoke.log)
+    preconditions:
+      - sh: '{{.CONTAINER_RT}} ps --format ''{{"{{.Names}}"}}'' 2>/dev/null | grep -q ''^{{.CONTAINER_NAME}}$'''
+        msg: "Foundry container is not running. Run 'task foundry:start' first."
+    cmds:
+      - mkdir -p test-results
+      - |
+        # Tee combined stdout+stderr to test-results/smoke.log while still
+        # streaming to the terminal. Preserves Playwright's exit code via
+        # PIPESTATUS so the task fails when tests fail.
+        set -o pipefail
+        pnpm run test:smoke 2>&1 | tee test-results/smoke.log
+      - echo ""
+      - echo "Logs   → test-results/smoke.log"
+      - echo "JSON   → test-results/smoke-report.json"
+      - echo "HTML   → test-results/html/index.html (npx playwright show-report test-results/html)"
+
+  test:smoke:ui:
+    desc: Run Playwright smoke tests in interactive UI mode
+    preconditions:
+      - sh: '{{.CONTAINER_RT}} ps --format ''{{"{{.Names}}"}}'' 2>/dev/null | grep -q ''^{{.CONTAINER_NAME}}$'''
+        msg: "Foundry container is not running. Run 'task foundry:start' first."
+    cmds:
+      - pnpm run test:smoke:ui
+
+  test:smoke:report:
+    desc: Open the most recent Playwright HTML report
+    cmds:
+      - pnpm exec playwright show-report test-results/html
+
   # ── Foundry VTT Test Instance ───────────────────────────────────
 
   foundry:init-config:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,7 +201,7 @@ tasks:
       - echo ""
       - echo "Logs   → test-results/smoke.log"
       - echo "JSON   → test-results/smoke-report.json"
-      - echo "HTML   → test-results/html/index.html (npx playwright show-report test-results/html)"
+      - echo "HTML   → playwright-report/index.html (npx playwright show-report playwright-report)"
 
   test:smoke:ui:
     desc: Run Playwright smoke tests in interactive UI mode
@@ -214,7 +214,7 @@ tasks:
   test:smoke:report:
     desc: Open the most recent Playwright HTML report
     cmds:
-      - pnpm exec playwright show-report test-results/html
+      - pnpm exec playwright show-report playwright-report
 
   # ── Foundry VTT Test Instance ───────────────────────────────────
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,14 @@ export default defineConfig({
     expect: {timeout: 10_000},
     fullyParallel: false,
     workers: 1,
-    reporter: process.env.CI ? "list" : [["list"]],
+    // Reporters: stdout `list` for humans, plus persisted `json` and `html`
+    // reports under test-results/ for post-hoc inspection. The `task test:smoke`
+    // wrapper also tees raw stdout/stderr to test-results/smoke.log.
+    reporter: [
+        ["list"],
+        ["json", {outputFile: "test-results/smoke-report.json"}],
+        ["html", {outputFolder: "test-results/html", open: "never"}],
+    ],
     retries: 0,
     globalSetup: "./tests/smoke/global-setup.ts",
     globalTeardown: "./tests/smoke/global-teardown.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,13 +25,16 @@ export default defineConfig({
     expect: {timeout: 10_000},
     fullyParallel: false,
     workers: 1,
-    // Reporters: stdout `list` for humans, plus persisted `json` and `html`
-    // reports under test-results/ for post-hoc inspection. The `task test:smoke`
-    // wrapper also tees raw stdout/stderr to test-results/smoke.log.
+    // Reporters: stdout `list` for humans, plus persisted `json` (under
+    // test-results/) and `html` (under playwright-report/, separate folder
+    // because the HTML reporter wipes its output dir before regenerating
+    // and would otherwise clobber traces/screenshots in test-results/).
+    // The `task test:smoke` wrapper also tees raw stdout/stderr to
+    // test-results/smoke.log.
     reporter: [
         ["list"],
         ["json", {outputFile: "test-results/smoke-report.json"}],
-        ["html", {outputFolder: "test-results/html", open: "never"}],
+        ["html", {outputFolder: "playwright-report", open: "never"}],
     ],
     retries: 0,
     globalSetup: "./tests/smoke/global-setup.ts",

--- a/scripts/unwrap-sheet-forms.mjs
+++ b/scripts/unwrap-sheet-forms.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * One-shot fix for issue #27 — sheet edits not persisting.
+ *
+ * Foundry v14 DocumentSheetV2 / ItemSheetV2 already render the application
+ * root as a <form> (tag: "form"). Each actor/item sheet template wrapped its
+ * content in another <form>, producing nested <form><form>...</form></form>.
+ * Browsers drop the inner form during HTML parsing, so submitOnChange misses
+ * fields unpredictably (actor name, metaphysics toggle, item name, weapon
+ * range, etc.).
+ *
+ * This script swaps the outer <form ...> wrapper for a <div ...> in:
+ *   - src/templates/actor/common/actor-sheet.html
+ *   - src/templates/item/item-*-sheet.html
+ *
+ * Run once: node scripts/unwrap-sheet-forms.mjs
+ */
+
+import {readFileSync, writeFileSync, readdirSync} from "node:fs";
+import {join, dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const files = [
+    join(root, "src/templates/actor/common/actor-sheet.html"),
+    ...readdirSync(join(root, "src/templates/item"))
+        .filter((n) => /^item-.*-sheet\.html$/.test(n))
+        .map((n) => join(root, "src/templates/item", n)),
+];
+
+const OPEN_RE = /^<form(\s+class="[^"]*")?\s+autocomplete="off">\s*$/;
+
+let changed = 0;
+for (const file of files) {
+    const original = readFileSync(file, "utf8");
+    const lines = original.split("\n");
+    if (!OPEN_RE.test(lines[0])) {
+        console.warn(`skip (unexpected first line): ${file}`);
+        continue;
+    }
+    const classMatch = lines[0].match(/class="([^"]*)"/);
+    lines[0] = classMatch ? `<div class="${classMatch[1]}">` : "<div>";
+
+    let lastFormIdx = -1;
+    for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i].includes("</form>")) { lastFormIdx = i; break; }
+    }
+    if (lastFormIdx === -1) {
+        console.warn(`skip (no </form>): ${file}`);
+        continue;
+    }
+    lines[lastFormIdx] = lines[lastFormIdx].replace("</form>", "</div>");
+
+    const next = lines.join("\n");
+    if (next !== original) {
+        writeFileSync(file, next);
+        changed++;
+        console.log(`updated: ${file.replace(root + "/", "")}`);
+    }
+}
+console.log(`\n${changed} file(s) updated.`);

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -329,18 +329,6 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
                 if (ok) await this._onClearSpeciesTemplate();
             }));
 
-        // Sheet-mode dropdown: explicit change handler. The template wraps
-        // the body in its own <form> nested inside the application's root
-        // form (which is itself a <form> via DocumentSheetV2's tag:"form"),
-        // and HTML's nested-form parsing prematurely closes the outer form
-        // — so the auto submitOnChange listener doesn't see the select.
-        // Update the actor directly here.
-        root.querySelectorAll<HTMLSelectElement>('select[name="system.sheetmode.value"]')
-            .forEach((el) => el.addEventListener("change", async (ev) => {
-                const value = (ev.target as HTMLSelectElement).value;
-                await this.document.update({"system.sheetmode.value": value});
-            }));
-
         // Existing listener modules accept html[0]; pass [root] for compatibility.
         registerInventoryListeners(html, this);
         registerCombatActionListeners(html, this);

--- a/src/templates/actor/common/actor-sheet.html
+++ b/src/templates/actor/common/actor-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
+<div class="{{cssClass}} flexcol">
     {{!-- Sheet Header --}}
     <header class="sheet-header flex-group-left">
         <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="200" width="200"
@@ -12,5 +12,5 @@
         </div>
     </header>
     {{> (getBodyTemplate actor.type)}}
-</form>
+</div>
 

--- a/src/templates/actor/common/attribute-edit.html
+++ b/src/templates/actor/common/attribute-edit.html
@@ -1,4 +1,4 @@
-<form>
+<div>
     <div>
         <div class="grid grid-2col">
             <div class="flex-group-center">
@@ -17,4 +17,4 @@
             </div>
         </div>
     </div>
-</form>
+</div>

--- a/src/templates/actor/common/attribute-edit.html
+++ b/src/templates/actor/common/attribute-edit.html
@@ -8,11 +8,11 @@
                 <b>{{localize "OD6S.PIPS"}}</b>
             </div>
             <div class="flex-group-center advancedice" data-dice="{{diceFromScore score}}">
-                <input type="number" id="dice" min=0 max=999 onfocus="this.value=''"
+                <input type="number" id="dice" name="dice" min=0 max=999 onfocus="this.value=''"
                        data-dtype="Number" placeholder="{{diceFromScore score}}" value="{{diceFromScore score}}">
             </div>
             <div class="flex-group-center advancepips" data-pips="{{pipsFromScore score}}">
-                <input type="number" max=2 id="pips" min=0 onfocus="this.value=''"
+                <input type="number" max=2 id="pips" name="pips" min=0 onfocus="this.value=''"
                        data-dtype="Number" placeholder="{{pipsFromScore score}}" value="{{pipsFromScore score}}">
             </div>
         </div>

--- a/src/templates/item/item-action-sheet.html
+++ b/src/templates/item/item-action-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
@@ -33,4 +33,4 @@
         {{!-- Effects Tab --}}
         {{> systems/od6s/templates/item/item-effects.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-advantage-sheet.html
+++ b/src/templates/item/item-advantage-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -37,4 +37,4 @@
         {{> systems/od6s/templates/item/item-labels-tags.html }}
 
     </section>
-</form>
+</div>

--- a/src/templates/item/item-armor-sheet.html
+++ b/src/templates/item/item-armor-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -121,4 +121,4 @@
         {{!--Labels Tab --}}
         {{>systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-character-template-sheet.html
+++ b/src/templates/item/item-character-template-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -156,4 +156,4 @@
         {{> systems/od6s/templates/item/item-labels-tags.html }}
 
     </section>
-</form>
+</div>

--- a/src/templates/item/item-cybernetic-sheet.html
+++ b/src/templates/item/item-cybernetic-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -69,4 +69,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-disadvantage-sheet.html
+++ b/src/templates/item/item-disadvantage-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -35,4 +35,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-gear-sheet.html
+++ b/src/templates/item/item-gear-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -73,4 +73,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-item-group-sheet.html
+++ b/src/templates/item/item-item-group-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -92,4 +92,4 @@
         {{> systems/od6s/templates/item/item-labels-tags.html }}
 
     </section>
-</form>
+</div>

--- a/src/templates/item/item-manifestation-sheet.html
+++ b/src/templates/item/item-manifestation-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -112,4 +112,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-skill-sheet.html
+++ b/src/templates/item/item-skill-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
@@ -83,4 +83,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-specialability-sheet.html
+++ b/src/templates/item/item-specialability-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -35,4 +35,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-specialization-sheet.html
+++ b/src/templates/item/item-specialization-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -86,4 +86,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-species-template-sheet.html
+++ b/src/templates/item/item-species-template-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -121,4 +121,4 @@
         {{> systems/od6s/templates/item/item-labels-tags.html }}
 
     </section>
-</form>
+</div>

--- a/src/templates/item/item-starship-gear-sheet.html
+++ b/src/templates/item/item-starship-gear-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -64,4 +64,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-starship-weapon-sheet.html
+++ b/src/templates/item/item-starship-weapon-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -237,4 +237,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-vehicle-gear-sheet.html
+++ b/src/templates/item/item-vehicle-gear-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -64,4 +64,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-vehicle-sheet.html
+++ b/src/templates/item/item-vehicle-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -28,4 +28,4 @@
         {{!-- Effects Tab --}}
         {{> systems/od6s/templates/item/item-effects.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-vehicle-weapon-sheet.html
+++ b/src/templates/item/item-vehicle-weapon-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -204,4 +204,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/src/templates/item/item-weapon-sheet.html
+++ b/src/templates/item/item-weapon-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}" autocomplete="off">
+<div class="{{cssClass}}">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
@@ -407,4 +407,4 @@
         {{!--Labels Tab --}}
         {{> systems/od6s/templates/item/item-labels-tags.html }}
     </section>
-</form>
+</div>

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -112,10 +112,13 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
     });
 
     test("attribute-edit form serializes dice/pips values", async ({page}) => {
-        // Drives the DialogV2.input() form data path: a <form> wrapping the
-        // template should produce a FormData snapshot containing dice and
-        // pips. Without `name=` attributes the snapshot is empty and the
-        // characteristic update silently no-ops.
+        // Drives the DialogV2.input() form data path. DialogV2 wraps
+        // `options.content` inside its own <form class="dialog-form">,
+        // so the template itself must NOT carry a <form> wrapper —
+        // otherwise the inputs end up nested and parsing rules drop
+        // them. This test mirrors that arrangement: parse the template
+        // into a plain <div>, then put that <div> inside a fresh
+        // <form> (the role DialogV2 plays) and read FormData.
         await loginAndWaitReady(page);
 
         const data = await evalInWorld(page, async () => {
@@ -123,14 +126,26 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
                 "systems/od6s/templates/actor/common/attribute-edit.html",
                 {score: 5},
             );
+            const content = document.createElement("div");
+            content.innerHTML = html;
+            // Asserting the template itself is form-free guards against
+            // a regression that would re-introduce the nested-<form>
+            // pattern this PR exists to remove.
+            const innerForms = content.querySelectorAll("form");
             const form = document.createElement("form");
-            form.innerHTML = html;
+            form.appendChild(content);
             (form.querySelector("#dice") as HTMLInputElement).value = "3";
             (form.querySelector("#pips") as HTMLInputElement).value = "2";
             const fd = new FormData(form);
-            return {dice: fd.get("dice"), pips: fd.get("pips")};
+            return {
+                dice: fd.get("dice"),
+                pips: fd.get("pips"),
+                templateHasInnerForm: innerForms.length > 0,
+            };
         });
 
+        expect(data.templateHasInnerForm, "attribute-edit template must not wrap content in <form>")
+            .toBe(false);
         expect(data.dice).toBe("3");
         expect(data.pips).toBe("2");
     });

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Tier 3 — Sheet field persistence (regression for issue #27).
+ *
+ * Foundry v14 DocumentSheetV2 / ItemSheetV2 already render their root
+ * element as a <form>. Wrapping the template body in another <form> nests
+ * the elements; HTML's nested-form parsing drops the inner form, and
+ * submitOnChange then misses fields unpredictably.
+ *
+ * These tests drive the rendered DOM (not actor.update directly) so the
+ * regression — fields silently failing to persist — is actually
+ * exercised.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+async function ensureCharacter(page: import("@playwright/test").Page): Promise<void> {
+    await evalInWorld(page, async () => {
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+        if (actor) await actor.delete();
+        actor = await window.Actor.create({
+            name: "smoke-persist",
+            type: "character",
+            system: {sheetmode: {value: "freeedit"}},
+        }, {render: false});
+        return actor.id;
+    });
+}
+
+test.describe("Tier 3 — sheet field persistence (#27)", () => {
+    test("actor name input persists via submitOnChange", async ({page}) => {
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 250));
+
+            const input = actor.sheet.element.querySelector('input[name="name"]') as HTMLInputElement;
+            const inForm = input?.closest("form") === actor.sheet.element;
+
+            input.value = "smoke-persist-renamed";
+            input.dispatchEvent(new Event("change", {bubbles: true}));
+            await new Promise((r) => setTimeout(r, 400));
+
+            const persisted = window.game.actors.get(actor.id).name;
+            await actor.sheet.close();
+            return {inForm, persisted};
+        });
+
+        expect(result.inForm, "name input is direct child of sheet form").toBe(true);
+        expect(result.persisted).toBe("smoke-persist-renamed");
+    });
+
+    test("metaphysics toggle persists and adds tab", async ({page}) => {
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            // Reset
+            await actor.update({"system.metaphysicsextranormal.value": false});
+
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 250));
+
+            const cb = actor.sheet.element.querySelector(
+                'input[type="checkbox"][name="system.metaphysicsextranormal.value"]',
+            ) as HTMLInputElement;
+            cb.checked = true;
+            cb.dispatchEvent(new Event("change", {bubbles: true}));
+            await new Promise((r) => setTimeout(r, 500));
+
+            const persisted = window.game.actors.get(actor.id).system.metaphysicsextranormal.value;
+
+            // After re-render, the metaphysics tab nav button should exist
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 250));
+            const tabButton = actor.sheet.element.querySelector(
+                '[data-tab="metaphysics"], a[data-tab="metaphysics"]',
+            );
+
+            await actor.sheet.close();
+            return {persisted, tabPresent: !!tabButton};
+        });
+
+        expect(result.persisted).toBe(true);
+        expect(result.tabPresent, "metaphysics nav tab present after toggle").toBe(true);
+    });
+
+    test("characteristic edit dialog inputs have name attributes", async ({page}) => {
+        // The attribute-edit dialog's <input> elements need name= for
+        // DialogV2.input() to read their values. Without name=, the result
+        // object has no dice/pips and the score recompute silently produces NaN.
+        await loginAndWaitReady(page);
+
+        const result = await evalInWorld(page, async () => {
+            const html = await window.foundry.applications.handlebars.renderTemplate(
+                "systems/od6s/templates/actor/common/attribute-edit.html",
+                {score: 5},
+            );
+            const div = document.createElement("div");
+            div.innerHTML = html;
+            const dice = div.querySelector("#dice") as HTMLInputElement;
+            const pips = div.querySelector("#pips") as HTMLInputElement;
+            return {diceName: dice?.name, pipsName: pips?.name};
+        });
+
+        expect(result.diceName).toBe("dice");
+        expect(result.pipsName).toBe("pips");
+    });
+
+    test("attribute-edit form serializes dice/pips values", async ({page}) => {
+        // Drives the DialogV2.input() form data path: a <form> wrapping the
+        // template should produce a FormData snapshot containing dice and
+        // pips. Without `name=` attributes the snapshot is empty and the
+        // characteristic update silently no-ops.
+        await loginAndWaitReady(page);
+
+        const data = await evalInWorld(page, async () => {
+            const html = await window.foundry.applications.handlebars.renderTemplate(
+                "systems/od6s/templates/actor/common/attribute-edit.html",
+                {score: 5},
+            );
+            const form = document.createElement("form");
+            form.innerHTML = html;
+            (form.querySelector("#dice") as HTMLInputElement).value = "3";
+            (form.querySelector("#pips") as HTMLInputElement).value = "2";
+            const fd = new FormData(form);
+            return {dice: fd.get("dice"), pips: fd.get("pips")};
+        });
+
+        expect(data.dice).toBe("3");
+        expect(data.pips).toBe("2");
+    });
+
+    test("item name input on item sheet persists", async ({page}) => {
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            // Replace any leftover smoke-weapon
+            const stale = actor.items.filter((i: any) => i.name?.startsWith("smoke-weapon"));
+            for (const i of stale) await i.delete();
+            const [weapon] = await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-weapon",
+                type: "weapon",
+            }]);
+
+            await weapon.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 250));
+
+            const root = weapon.sheet.element as HTMLElement;
+            const nameInput = root.querySelector('input[name="name"]') as HTMLInputElement;
+            const inForm = nameInput?.closest("form") === root;
+
+            nameInput.value = "smoke-weapon-renamed";
+            nameInput.dispatchEvent(new Event("change", {bubbles: true}));
+            await new Promise((r) => setTimeout(r, 400));
+
+            const persistedName = actor.items.get(weapon.id).name;
+
+            // Range field
+            const rangeInput = root.querySelector(
+                'input[name="system.range.short"], input[name="system.range.medium"], input[name="system.range.long"]',
+            ) as HTMLInputElement | null;
+            let rangePersisted: number | null = null;
+            if (rangeInput) {
+                rangeInput.value = "42";
+                rangeInput.dispatchEvent(new Event("change", {bubbles: true}));
+                await new Promise((r) => setTimeout(r, 400));
+                const path = rangeInput.name.split(".");
+                let v: any = actor.items.get(weapon.id);
+                for (const k of path) v = v?.[k];
+                rangePersisted = Number(v);
+            }
+
+            await weapon.sheet.close();
+            await weapon.delete();
+            return {inForm, persistedName, rangePersisted};
+        });
+
+        expect(result.inForm, "weapon name input is direct child of item-sheet form").toBe(true);
+        expect(result.persistedName).toBe("smoke-weapon-renamed");
+        if (result.rangePersisted !== null) {
+            expect(result.rangePersisted).toBe(42);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #27.

## Root causes

Two distinct bugs produced the symptoms reported in #27 (Foundry v14, sheet in Free Edit mode):

### 1. Nested `<form>` parsing

\`DocumentSheetV2\` / \`ItemSheetV2\` already render the application root as \`<form>\` (\`tag: "form"\`), but every actor and item template wrapped its content in another \`<form>\`. Browsers can't nest forms — the inner one is dropped during HTML parsing — so \`submitOnChange\` misses fields unpredictably.

Caused: actor name, metaphysics toggle, item name, item range, weapon-skill changes silently failing to persist.

A workaround for the same bug already lived in \`actor-sheet.ts\` for the sheet-mode select, with a comment in the source explicitly flagging the root cause.

### 2. Missing \`name=\` on attribute-edit dialog inputs

\`DialogV2.input()\` reads form data by \`name=\`. The dice/pips inputs in \`attribute-edit.html\` had only \`id=\`, so the dialog returned an empty result and \`getScoreFromDice(undefined, undefined)\` produced \`NaN\` — the characteristic update silently no-op'd.

Caused: \"Edit Attribute\" never persisting characteristic edits.

## What this PR does

- **Codemod \`scripts/unwrap-sheet-forms.mjs\`** swaps the outer \`<form>\` for \`<div>\` in \`actor-sheet.html\` + 19 \`item-*-sheet.html\` templates.
- Adds \`name=\"dice\"\` / \`name=\"pips\"\` to \`attribute-edit.html\`.
- Drops the now-unneeded sheet-mode workaround in \`actor-sheet.ts\`.
- Adds 5 tier-3 smoke tests in \`tier-3-sheet-persistence.spec.ts\` that drive the rendered DOM (not \`actor.update\`) so the regression mode is actually exercised. Includes structural assertions (input is direct child of sheet form; dialog inputs have \`name=\`) so the bugs can't creep back in.
- Adds Playwright JSON + HTML reporter outputs under \`test-results/\`, plus \`task test:smoke\` / \`test:smoke:ui\` / \`test:smoke:report\` Taskfile entries that gate on the Foundry container being up.

## Test plan

- [ ] \`pnpm run typecheck\` — clean ✓ (verified locally)
- [ ] \`pnpm run lint\` — 0 errors, 720 warnings (under threshold) ✓ (verified locally)
- [ ] \`task test:smoke\` once #32 is merged — verify the new persistence specs pass alongside the existing 14/18 baseline.
- [ ] Manual: open a character sheet, switch to Free Edit, change name → save → reload → verify name persists.
- [ ] Manual: toggle Metaphysics → tab appears.
- [ ] Manual: edit a characteristic via \"Edit Attribute\" → value persists.
- [ ] Manual: open a weapon item sheet, change name and range → both persist.

## Related

- Builds on the smoke harness from #32.
- #34 (edit-difficulty dialog persistence) may share the same nested-form root cause and should be re-checked after this lands.