### PR TITLE
fix: sheet persistence regressions (#34, #42)

### DIFF
--- a/src/module/actor/advance.ts
+++ b/src/module/actor/advance.ts
@@ -66,6 +66,7 @@ export class od6sadvance {
             cpcostcolor: "black",
             freeadvance: freeAdvance,
             type: dataset.type,
+            attrname: dataset.attrname,
             originalscore: originalScore,
             itemid: itemid,
             used: used,
@@ -80,7 +81,6 @@ export class od6sadvance {
                 (dlg, formData) => od6sadvance.advanceAction(
                     dlg.actorSheet.actor,
                     dlg.advanceData,
-                    event,
                     formData.base,
                 ),
             ).render({force: true});
@@ -91,7 +91,6 @@ export class od6sadvance {
                 (dlg, formData) => od6sadvance.advanceAction(
                     dlg.actorSheet.actor,
                     dlg.advanceData,
-                    event,
                     formData.dice,
                     formData.pips,
                 ),
@@ -99,7 +98,7 @@ export class od6sadvance {
         }
     }
 
-    static async advanceAction(actor: Actor, advanceData: any, event: Event, dice?: number, pips?: number) {
+    static async advanceAction(actor: Actor, advanceData: any, dice?: number, pips?: number) {
 
         const actorData = actor.system as OD6SCharacterSystem;
         const actorUpdate: any = {};
@@ -121,16 +120,14 @@ export class od6sadvance {
             }
         }
 
-        const dataset = (event.currentTarget as HTMLElement).dataset;
-
         /* Determine item or attribute */
-        if (dataset.type === "attribute") {
+        if (advanceData.type === "attribute") {
             actorUpdate.system.attributes = {};
-            actorUpdate.system.attributes[dataset.attrname!] = {};
-            actorUpdate.system.attributes[dataset.attrname!].base = advanceData.score;
+            actorUpdate.system.attributes[advanceData.attrname!] = {};
+            actorUpdate.system.attributes[advanceData.attrname!].base = advanceData.score;
         }
 
-        if(dataset.type === "skill") {
+        if(advanceData.type === "skill") {
             const skill = actor.items.get(advanceData.itemid);
 
             if(OD6S.specLink) {
@@ -169,7 +166,7 @@ export class od6sadvance {
             }
         }
 
-        if(dataset.type === "specialization") {
+        if(advanceData.type === "specialization") {
             /* Add/subtract to item score, not displayed/aggregate score */
             let newScore;
             OD6S.flatSkills ? newScore = advanceData.base : newScore = advanceData.score - advanceData.originalscore;

--- a/src/module/data/item/weapon.ts
+++ b/src/module/data/item/weapon.ts
@@ -21,6 +21,19 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
         if (typeof range[key] !== "string") range[key] = String(range[key] ?? "0");
       }
     }
+    // Normalize subtype to the localized form. Helpers (isRanged,
+    // isMuscle, isExplosive) and the weapon-sheet <option> values all
+    // operate on localized strings, but the schema's initial is the
+    // raw i18n key — so a brand-new weapon's stored subtype never
+    // matches any rendered option until the user manually picks one.
+    // localize() is a no-op when called before i18n is ready (returns
+    // the key); we re-run it on every construction so the value
+    // self-heals once i18n is up.
+    if (typeof source.subtype === "string" && source.subtype.startsWith("OD6S.")) {
+      const localized = (game as { i18n?: { localize?: (k: string) => string } } | undefined)
+        ?.i18n?.localize?.(source.subtype);
+      if (localized && localized !== source.subtype) source.subtype = localized;
+    }
     return super.migrateData(source);
   }
 
@@ -34,7 +47,15 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
         type: new fields.StringField({ initial: "Number" }),
         label: new fields.StringField({ initial: "OD6S.SCALE" }),
       }),
-      subtype: new fields.StringField({ initial: "OD6S.RANGED" }),
+      // Helpers (isRanged, isMuscle, isExplosive) and the weapon-sheet
+      // <option value> all operate on the *localized* subtype, so the
+      // initial value must be the localized string, not the raw i18n
+      // key. Falls back to the key if i18n isn't ready yet (early init);
+      // migrateData below normalizes any key-form value on later loads.
+      subtype: new fields.StringField({
+        initial: () => (game as { i18n?: { localize?: (k: string) => string } } | undefined)
+          ?.i18n?.localize?.("OD6S.RANGED") ?? "OD6S.RANGED",
+      }),
       stats: new fields.SchemaField({
         attribute: new fields.StringField({ initial: "AGI" }),
         skill: new fields.StringField({ initial: "" }),

--- a/src/templates/chat/edit-difficulty.html
+++ b/src/templates/chat/edit-difficulty.html
@@ -1,7 +1,7 @@
 <div autocomplete="off">
     <div class="flexrow flex-group-left">
         <label for="base-difficulty">{{localize "OD6S.BASE_DIFFICULTY"}}:</label>
-        <input name="baseDifficulty" type="number" value="{{data.baseDifficulty}}">
+        <input id="base-difficulty" name="baseDifficulty" type="number" value="{{data.baseDifficulty}}">
     </div>
     <input name="messageId" type="hidden" value="{{data.messageId}}">
     <div class="flexrow flex-group-center"

--- a/src/templates/chat/edit-difficulty.html
+++ b/src/templates/chat/edit-difficulty.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div autocomplete="off">
     <div class="flexrow flex-group-left">
         <label for="base-difficulty">{{localize "OD6S.BASE_DIFFICULTY"}}:</label>
         <input name="baseDifficulty" type="number" value="{{data.baseDifficulty}}">
@@ -9,4 +9,4 @@
         <button class="edit-difficulty-submit" type="submit" name="submit" value="submit">{{localize "OD6S.SUBMIT"}}</button>
         <button type="button" name="cancel" data-action="cancel">{{localize "OD6S.CANCEL"}}</button>
     </div>
-</form>
+</div>

--- a/src/templates/item/item-attribute-edit.html
+++ b/src/templates/item/item-attribute-edit.html
@@ -1,4 +1,4 @@
-<form>
+<div>
     <div>
         <div class="grid grid-2col">
             <div class="flex-group-center">
@@ -8,13 +8,13 @@
                 <b>{{localize "OD6S.PIPS"}}</b>
             </div>
             <div class="flex-group-center advancedice" data-dice="{{diceFromScore score}}">
-                <input type="number" id="dice" min=0 max=999 onfocus="this.value=''"
+                <input type="number" id="dice" name="dice" min=0 max=999 onfocus="this.value=''"
                        data-dtype="Number" placeholder="{{diceFromScore score}}" value="{{diceFromScore score}}">
             </div>
             <div class="flex-group-center advancepips" data-pips="{{pipsFromScore score}}">
-                <input type="number" max=2 id="pips" min=0 onfocus="this.value=''"
+                <input type="number" max=2 id="pips" name="pips" min=0 onfocus="this.value=''"
                        data-dtype="Number" placeholder="{{pipsFromScore score}}" value="{{pipsFromScore score}}">
             </div>
         </div>
     </div>
-</form>
+</div>

--- a/src/templates/item/item-weapon-sheet.html
+++ b/src/templates/item/item-weapon-sheet.html
@@ -93,7 +93,7 @@
                 <select name="system.subtype" id="item.system.subtype">
                     
                         {{#each (getWeaponTypes) as |subtype|}}
-                            <option value="{{ localize subtype }}" {{#if (eq localize subtype item.system.subtype)}}selected{{/if}}>
+                            <option value="{{ localize subtype }}" {{#if (eq (localize subtype) item.system.subtype)}}selected{{/if}}>
                                 {{localize subtype}}
                             </option>
                         {{/each}}

--- a/tests/smoke/global-setup.ts
+++ b/tests/smoke/global-setup.ts
@@ -24,6 +24,13 @@ const FOUNDRY_URL = process.env.FOUNDRY_URL ?? "http://localhost:30000";
 const FOUNDRY_ADMIN_KEY = process.env.FOUNDRY_ADMIN_KEY ?? "";
 const FOUNDRY_SMOKE_WORLD = process.env.FOUNDRY_SMOKE_WORLD ?? "od6s-smoke";
 const FOUNDRY_SYSTEM_ID = process.env.FOUNDRY_SYSTEM_ID ?? "od6s";
+const FOUNDRY_USER = process.env.FOUNDRY_USER ?? "Gamemaster";
+const FOUNDRY_GM_PASSWORD = process.env.FOUNDRY_GM_PASSWORD ?? "";
+// Default on. Set to "0" / "false" to refuse to shut down a running
+// non-smoke world (preserves an in-progress personal session).
+const FOUNDRY_SMOKE_AUTOSHUTDOWN = !/^(0|false)$/i.test(
+    process.env.FOUNDRY_SMOKE_AUTOSHUTDOWN ?? "",
+);
 const PROBE_TIMEOUT_MS = 10_000;
 
 class SmokePreconditionError extends Error {
@@ -63,6 +70,9 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
             worldId: FOUNDRY_SMOKE_WORLD,
             system: FOUNDRY_SYSTEM_ID,
             adminKey: FOUNDRY_ADMIN_KEY,
+            gmUser: FOUNDRY_USER,
+            gmPassword: FOUNDRY_GM_PASSWORD,
+            autoShutdown: FOUNDRY_SMOKE_AUTOSHUTDOWN,
             log: (msg) => console.log(msg),
         });
     } finally {

--- a/tests/smoke/helpers/setup-driver.ts
+++ b/tests/smoke/helpers/setup-driver.ts
@@ -64,6 +64,21 @@ export interface EnsureWorldOptions {
      * and the `task foundry:start` Taskfile recipe.
      */
     adminKey?: string;
+    /**
+     * GM user name for joining a running world to inspect its id.
+     * Only used when we need to detect a mismatched world before
+     * shutting it down.
+     */
+    gmUser?: string;
+    /** GM join password (FOUNDRY_GM_PASSWORD). Empty for password-less GM. */
+    gmPassword?: string;
+    /**
+     * If a different world is running, return it to /setup and launch
+     * the expected world instead. Default true. Set to false to fail
+     * loud when the world is mismatched (preserves an in-progress
+     * non-smoke session).
+     */
+    autoShutdown?: boolean;
     /** Logging hook for orchestration trace. */
     log?: (msg: string) => void;
 }
@@ -107,10 +122,33 @@ export async function ensureWorldLaunched(
         }
 
         if (url.includes("/join") || url.includes("/game")) {
-            // World is up — the caller's loginAndWaitReady will verify
-            // it's the world we expect via the world-id assertion.
-            log(`[setup-driver] world launched`);
-            return;
+            // A world is up. Confirm it's *our* world; if not, optionally
+            // shut it down and re-enter the loop so /setup launches the
+            // right one. Without this check the running world would only
+            // be detected per-spec by loginAndWaitReady's identity guard,
+            // by which point globalSetup has already returned success.
+            const runningId = await detectRunningWorldId(page, opts);
+            if (runningId === opts.worldId) {
+                log(`[setup-driver] world '${opts.worldId}' already launched`);
+                return;
+            }
+            if (runningId === null) {
+                // Could not determine the world id (e.g., login failed).
+                // Hand back to the caller — loginAndWaitReady will surface
+                // the underlying error with better context than we can.
+                log(`[setup-driver] world launched but id undetectable; deferring to caller`);
+                return;
+            }
+            const autoShutdown = opts.autoShutdown ?? true;
+            if (!autoShutdown) {
+                throw new Error(
+                    `[setup-driver] world '${runningId}' running but expected '${opts.worldId}'.\n` +
+                    `  → Stop the running world or set FOUNDRY_SMOKE_AUTOSHUTDOWN=1.`,
+                );
+            }
+            log(`[setup-driver] world '${runningId}' running; shutting down to launch '${opts.worldId}'`);
+            await shutdownRunningWorld(page, opts);
+            continue;
         }
 
         throw new Error(
@@ -226,6 +264,17 @@ async function confirmMigrationIfShown(page: Page): Promise<void> {
     } catch {
         return; // no dialog — happy path
     }
+    // The migration prompt has a "Create a backup before migrating?"
+    // checkbox that defaults to checked. The backup step can take
+    // minutes on a populated world and easily blows past our launch
+    // wait. A smoke world has no data worth preserving (we recreate
+    // it on demand), so uncheck it to keep the launch fast.
+    await page.evaluate(() => {
+        const cb = document.querySelector(
+            'dialog input[name="createBackup"]',
+        ) as HTMLInputElement | null;
+        if (cb) cb.checked = false;
+    });
     await yesBtn.click({force: true});
 }
 
@@ -270,4 +319,52 @@ async function createWorld(page: Page, opts: EnsureWorldOptions): Promise<void> 
     // After creation Foundry usually returns to /setup with the new tile
     // present. Re-enter the loop to launch it.
     await page.waitForLoadState("domcontentloaded");
+}
+
+/**
+ * Resolve the id of the world Foundry is currently serving.
+ *
+ * Foundry exposes `game.world.id` on the /join page itself — no login
+ * required. From /game the same global is authoritative. Returns null
+ * if the global isn't populated (caller defers to per-spec
+ * `loginAndWaitReady` for a clearer error).
+ */
+async function detectRunningWorldId(
+    page: Page,
+    _opts: EnsureWorldOptions,
+): Promise<string | null> {
+    try {
+        await page.waitForFunction(() => (window as any).game?.world?.id, null, {timeout: 15_000});
+        return await page.evaluate(() => (window as any).game?.world?.id ?? null);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Return the running world to /setup so the loop can re-launch the
+ * expected one.
+ *
+ * From /join: submit the "Return to Setup" admin form (`#join-game-setup`)
+ * with `FOUNDRY_ADMIN_KEY`. This is the path Foundry's UI uses, and
+ * unlike `game.shutDown()` it doesn't require the browser to hold a
+ * Gamemaster session — only the server admin key.
+ *
+ * From /game: fall back to `game.shutDown()`, which requires the
+ * logged-in user to be a Gamemaster. If they aren't, this throws and
+ * surfaces the underlying Foundry message.
+ */
+async function shutdownRunningWorld(page: Page, opts: EnsureWorldOptions): Promise<void> {
+    const url = page.url();
+    if (url.includes("/join")) {
+        const adminKey = opts.adminKey ?? "";
+        const form = page.locator("#join-game-setup");
+        await form.locator('input[name="adminPassword"]').fill(adminKey);
+        await form.locator('button[type="submit"]').click();
+    } else {
+        await page.evaluate(() => (window as any).game?.shutDown?.());
+    }
+    // The redirect target is /setup on success, /auth if the admin key
+    // was rejected. Either is fine for the hop loop.
+    await page.waitForURL((u) => /\/(setup|auth)\b/.test(u.pathname), {timeout: 30_000});
 }

--- a/tests/smoke/tier-3-edit-difficulty.spec.ts
+++ b/tests/smoke/tier-3-edit-difficulty.spec.ts
@@ -116,7 +116,14 @@ test("edit-difficulty dialog updates message difficulty and success flags", asyn
             input.value = "15";
             input.dispatchEvent(new Event("change", {bubbles: true}));
         }
-        const form = (dlg as any).element?.querySelector("form") as HTMLFormElement | null;
+        // OD6SEditDifficulty sets tag: "form", so dlg.element is the
+        // form itself. The template no longer wraps content in a nested
+        // <form> (removed in #34's fix), so a descendant form lookup
+        // returns null on current builds — fall back to the root.
+        const root = (dlg as any).element as HTMLElement | null;
+        const form = (root?.tagName === "FORM"
+            ? (root as HTMLFormElement)
+            : (root?.querySelector("form") as HTMLFormElement | null));
         if (form) form.requestSubmit();
         await new Promise((r) => setTimeout(r, 800));
         return true;

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -303,7 +303,14 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
 
         const result = await evalInWorld(page, async () => {
             const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
-            await actor.update({"system.attributes.agi.base": 6});
+            // The .advancedialog button is only rendered in advance mode.
+            // Also give the actor character points so the cpcost gate
+            // doesn't reject the submit.
+            await actor.update({
+                "system.attributes.agi.base": 6,
+                "system.sheetmode.value": "advance",
+                "system.characterpoints.value": 50,
+            });
             await actor.sheet.render(true);
             await new Promise((r) => setTimeout(r, 300));
 
@@ -373,6 +380,7 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         expect(result.submitted, "advance dialog opened and submitted").toBe(true);
         expect(result.currentTargetErrors,
             "no TypeError reading dataset off a stale event.currentTarget").toEqual([]);
-        expect(result.finalBase, "attribute base advanced to dialog value").toBe(7);
+        // base is stored in pips (3 pips = 1 die). dice=7, pips=0 → 7D → 21 pips.
+        expect(result.finalBase, "attribute base advanced to dialog value").toBe(21);
     });
 });

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -203,4 +203,176 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
             expect(result.rangePersisted).toBe(42);
         }
     });
+
+    test("item-attribute-edit dialog template has no <form> and named dice/pips inputs", async ({page}) => {
+        // Mirrors the actor-side structural test above, for the item-side
+        // template used by `_editTemplateAttribute` on species/character
+        // templates. Catches a regression where the template carries an
+        // outer <form> (nested inside DialogV2's own form → inner form is
+        // dropped by HTML parsing) or its inputs lack name= (DialogV2.input
+        // returns an empty result and getScoreFromDice produces NaN).
+        await loginAndWaitReady(page);
+
+        const result = await evalInWorld(page, async () => {
+            const html = await window.foundry.applications.handlebars.renderTemplate(
+                "systems/od6s/templates/item/item-attribute-edit.html",
+                {score: 5},
+            );
+            const div = document.createElement("div");
+            div.innerHTML = html;
+            const innerForms = div.querySelectorAll("form");
+            const dice = div.querySelector("#dice") as HTMLInputElement;
+            const pips = div.querySelector("#pips") as HTMLInputElement;
+            return {
+                templateHasInnerForm: innerForms.length > 0,
+                diceName: dice?.name,
+                pipsName: pips?.name,
+            };
+        });
+
+        expect(result.templateHasInnerForm, "item-attribute-edit must not wrap content in <form>")
+            .toBe(false);
+        expect(result.diceName).toBe("dice");
+        expect(result.pipsName).toBe("pips");
+    });
+
+    test("weapon subtype <option> is selected to match stored value", async ({page}) => {
+        // Regression for malformed `(eq localize subtype …)` Handlebars in
+        // item-weapon-sheet.html. With `eq` mis-applied no <option> rendered
+        // selected, so after a re-render the <select> snapped to the first
+        // option, and the next submitOnChange clobbered the saved subtype.
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            for (const i of actor.items.filter((x: any) => x.name?.startsWith("smoke-weapon-subtype"))) {
+                await i.delete();
+            }
+            const [weapon] = await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-weapon-subtype",
+                type: "weapon",
+            }]);
+
+            await weapon.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 250));
+
+            const root = weapon.sheet.element as HTMLElement;
+            const select = root.querySelector('select[name="system.subtype"]') as HTMLSelectElement;
+            const stored = actor.items.get(weapon.id).system.subtype;
+            // Selected option's value must match the stored subtype after
+            // initial render — otherwise the next form submission silently
+            // overwrites system.subtype with the first option's value.
+            const selectedMatchesStored = select?.value === stored;
+
+            // Clobber check: change an unrelated field (damage type) and
+            // verify subtype is unchanged on the document.
+            const damageType = root.querySelector(
+                'select[name="system.damage.type"]',
+            ) as HTMLSelectElement | null;
+            let subtypeAfterDamageChange: string | null = null;
+            if (damageType && damageType.options.length > 0) {
+                const otherOption = [...damageType.options].find((o) => o.value !== damageType.value);
+                if (otherOption) {
+                    damageType.value = otherOption.value;
+                    damageType.dispatchEvent(new Event("change", {bubbles: true}));
+                    await new Promise((r) => setTimeout(r, 500));
+                    subtypeAfterDamageChange = actor.items.get(weapon.id).system.subtype;
+                }
+            }
+
+            await weapon.sheet.close();
+            await weapon.delete();
+            return {stored, selectedMatchesStored, subtypeAfterDamageChange};
+        });
+
+        expect(result.selectedMatchesStored,
+            "weapon subtype <select> must reflect the stored value on render").toBe(true);
+        if (result.subtypeAfterDamageChange !== null) {
+            expect(result.subtypeAfterDamageChange,
+                "changing damage type must not clobber stored subtype").toBe(result.stored);
+        }
+    });
+
+    test("advance dialog submit does not throw on stale event.currentTarget", async ({page}) => {
+        // Regression for #42: advanceAction read event.currentTarget.dataset,
+        // but the dialog's submit fires async after the click event has been
+        // fully dispatched, so currentTarget is null → TypeError.
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            await actor.update({"system.attributes.agi.base": 6});
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 300));
+
+            const root = actor.sheet.element as HTMLElement;
+            const advanceBtn = root.querySelector(
+                '.advancedialog[data-type="attribute"][data-attrname="agi"]',
+            ) as HTMLElement | null;
+            if (!advanceBtn) {
+                await actor.sheet.close();
+                return {found: false};
+            }
+
+            const errors: string[] = [];
+            const onErr = (e: ErrorEvent) => errors.push(String(e.message ?? e));
+            const onRej = (e: PromiseRejectionEvent) => errors.push(String(e.reason?.message ?? e.reason));
+            window.addEventListener("error", onErr);
+            window.addEventListener("unhandledrejection", onRej);
+
+            advanceBtn.click();
+            await new Promise((r) => setTimeout(r, 400));
+
+            const dlg = [...window.foundry.applications.instances.values()].find(
+                (a: any) => (a as any).id === "od6s-advance-dialog",
+            ) as any;
+
+            let submitted = false;
+            if (dlg) {
+                const dlgRoot = dlg.element as HTMLElement;
+                const free = dlgRoot.querySelector(
+                    'input[name="freeadvance"]',
+                ) as HTMLInputElement | null;
+                if (free) {
+                    free.checked = true;
+                    free.dispatchEvent(new Event("change", {bubbles: true}));
+                    await new Promise((r) => setTimeout(r, 250));
+                }
+                const dice = dlgRoot.querySelector('input[name="dice"]') as HTMLInputElement | null;
+                const pips = dlgRoot.querySelector('input[name="pips"]') as HTMLInputElement | null;
+                if (dice) dice.value = "7";
+                if (pips) pips.value = "0";
+                const form = dlgRoot.tagName === "FORM"
+                    ? (dlgRoot as HTMLFormElement)
+                    : dlgRoot.querySelector("form") as HTMLFormElement | null;
+                if (form) {
+                    form.requestSubmit();
+                    await new Promise((r) => setTimeout(r, 700));
+                    submitted = true;
+                }
+            }
+
+            window.removeEventListener("error", onErr);
+            window.removeEventListener("unhandledrejection", onRej);
+
+            const finalBase = window.game.actors.get(actor.id).system.attributes.agi.base;
+            await actor.sheet.close();
+
+            const currentTargetErrors = errors.filter(
+                (e) => /currentTarget/i.test(e) && /dataset/i.test(e),
+            );
+            return {found: true, submitted, finalBase, currentTargetErrors};
+        });
+
+        if (!result.found) {
+            test.skip(true, "no .advancedialog[data-type=attribute] button on the rendered sheet");
+            return;
+        }
+        expect(result.submitted, "advance dialog opened and submitted").toBe(true);
+        expect(result.currentTargetErrors,
+            "no TypeError reading dataset off a stale event.currentTarget").toEqual([]);
+        expect(result.finalBase, "attribute base advanced to dialog value").toBe(7);
+    });
 });


### PR DESCRIPTION
## Summary

Cluster fix for the form/change-event persistence bugs reported in #34 and #42, with three additional issues uncovered while running the new smoke specs against a live Foundry instance.

### Code fixes

- **#34** — `edit-difficulty.html` still wrapped its content in `<form>`, but `OD6SEditDifficulty` already sets `tag: "form"`. Browser nested-form parsing dropped the inner form, so `baseDifficulty` never reached `FormData`. Swap the wrapper for a `<div>`.
- **#42 (Type select)** — `item-weapon-sheet.html:96` had `{{#if (eq localize subtype item.system.subtype)}}`. `eq` only takes 2 args, so no `<option>` ever rendered `selected`. After a re-render the `<select>` snapped to the first option, and the next form submission overwrote the saved subtype. Fixed to `(eq (localize subtype) item.system.subtype)`. This also explains the "Damage Type will not be retained" symptom, since the stale form was clobbering adjacent fields on submit.
- **#42 (Advance: `event.currentTarget is null`)** — `advanceAction` was reading `event.currentTarget.dataset` to recover `type` / `attrname`, but the dialog's submit fires async after the original click event has been fully dispatched, by which point `currentTarget` is null. Capture `attrname` into `advanceData` at click time and read `advanceData.type` / `advanceData.attrname` in `advanceAction`.
- **#42 (template attribute edit)** — `item-attribute-edit.html` still had the pre-#37 pattern: outer `<form>` wrapper plus inputs missing `name="dice"` / `name="pips"`. Used by the item-side `_editTemplateAttribute` path on species/character templates. Apply the same fix #37 made to the actor-side template.
- **Weapon subtype schema/initial mismatch (uncovered while testing)** — `WeaponData.subtype` initial was the i18n key `"OD6S.RANGED"`, but every consumer (`isRanged` / `isMuscle` / `isExplosive` helpers, the weapon sheet's `<option value>`) operates on the localized string. A brand-new weapon's stored subtype matched no rendered option — same user-visible symptom as the malformed `eq` bug. Fix: functional `initial` that localizes when i18n is ready, plus a `migrateData` normaliser for any persisted key-form values.

### Smoke regression coverage

Three new specs in `tier-3-sheet-persistence.spec.ts` to lock in the fixes that previously had no coverage (the existing edit-difficulty spec already covered #34):

1. **item-attribute-edit template** — structural assertion mirroring the actor-side test: no inner `<form>`, dice/pips inputs have `name=`.
2. **weapon subtype select** — selected option matches stored value on render; changing damage type doesn't clobber subtype.
3. **advance dialog** — click `.advancedialog` → submit → assert no `currentTarget` / `dataset` TypeError and base persists.

### Smoke harness fixes (uncovered while testing)

- **`setup-driver` auto-recovery** — when Foundry was at `/join` or `/game`, the driver short-circuited on "world is up" and deferred the identity check to per-spec `loginAndWaitReady`, which would just throw. Now it reads `game.world.id` (available on `/join` without login) and, if mismatched, submits the admin "Return to Setup" form on `/join` so the loop can launch the expected world. Gated by `FOUNDRY_SMOKE_AUTOSHUTDOWN` (default on); set to `0` to preserve an in-progress non-smoke session.
- **`confirmMigrationIfShown`** — now unchecks "Create a backup before migrating?" before clicking Begin Migration. Foundry's backup step easily exceeds the 60s launch wait; smoke worlds are recreated on demand.
- **`tier-3-edit-difficulty` test logic** — `dlg.element.querySelector("form")` now returns null because the nested `<form>` was removed (and the `tag: "form"` application root IS the form). Fall back to using the root directly.

## What I did *not* find a clear root cause for in #42

- "Changing an attribute on a character will not be saved upon clicking Edit Attribute" — that flow uses `actor/common/attribute-edit.html`, which is already fixed and covered by passing smoke tests. May be a downstream symptom of the Advance regression or a v14 quirk we haven't reproduced.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors, 719 warnings (under threshold)
- [x] `tier-3-sheet-persistence.spec.ts` — 8/8 passing against live Foundry
- [x] `tier-3-edit-difficulty.spec.ts` — passing in isolation
- [x] Full smoke suite — 22 passing; the 4 failures (`tier-2-sheets`, `tier-3-vehicle`, `tier-3-weapon-roll`, plus `tier-3-edit-difficulty` when run after upstream specs leave state) are documented pre-existing bugs (#33, #35, #36) that this PR does not claim to fix.
- [ ] Manual: open weapon item sheet, change Type → reload → Type persists; change Type then Damage Type → both persist
- [ ] Manual: in Advance mode, advance an attribute → no `currentTarget` TypeError, value persists
- [ ] Manual: edit-difficulty dialog on a chat card → new value persists in `flags.od6s.baseDifficulty`
- [ ] Manual: open a species/character template item, edit a template attribute → value persists

## Related

- Closes #34
- Addresses two of three symptoms in #42 (Type/Damage Type retention, Advance TypeError); the third (character-sheet attribute edit) needs reproduction
- Builds on PR #37