### PR TITLE
fix: attribute-edit dialog submit on stale event.currentTarget (#42)

### DIFF
--- a/src/module/actor/attribute-edit.ts
+++ b/src/module/actor/attribute-edit.ts
@@ -14,6 +14,7 @@ export class od6sattributeedit {
         event.preventDefault();
 
         const attribute = event.currentTarget.dataset.attrname;
+        const label = event.currentTarget.dataset.label;
         // @ts-expect-error this.actor is bound by mixin caller
         const score = this.actor.system.attributes[attribute].base;
 
@@ -22,20 +23,18 @@ export class od6sattributeedit {
             {score});
 
         const result = await foundry.applications.api.DialogV2.input({
-            window: {title: game.i18n.localize("OD6S.EDIT") + " " + event.currentTarget.dataset.label + "!"},
+            window: {title: game.i18n.localize("OD6S.EDIT") + " " + label + "!"},
             content,
             ok: {label: game.i18n.localize("OD6S.EDIT_ATTRIBUTE")},
         });
         if (!result) return;
 
         // @ts-expect-error this.actor is bound by mixin caller
-        await od6sattributeedit.editAttributeAction(result.dice, result.pips, event, this.actor);
+        await od6sattributeedit.editAttributeAction(result.dice, result.pips, attribute, this.actor);
     }
 
-    static async editAttributeAction(dice: any, pips: any, event: any, actor: any) {
-        event.preventDefault();
+    static async editAttributeAction(dice: any, pips: any, attribute: string, actor: any) {
         const newScore = od6sutilities.getScoreFromDice(dice, pips);
-        const attribute = event.currentTarget.dataset.attrname;
 
         const update: any = {};
         update.id = actor.id;

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -383,4 +383,90 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         // base is stored in pips (3 pips = 1 die). dice=7, pips=0 → 7D → 21 pips.
         expect(result.finalBase, "attribute base advanced to dialog value").toBe(21);
     });
+
+    test("attribute-edit dialog submit does not throw on stale event.currentTarget", async ({page}) => {
+        // Regression for #42 residual: editAttributeAction read
+        // event.currentTarget.dataset.attrname after awaiting DialogV2.input,
+        // but currentTarget is null by then → TypeError, update never runs.
+        // Mirrors the advance-dialog regression test above.
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            await actor.update({
+                "system.attributes.agi.base": 6,
+                "system.sheetmode.value": "freeedit",
+            });
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 300));
+
+            const root = actor.sheet.element as HTMLElement;
+            const editBtn = root.querySelector(
+                '.attribute-edit[data-attrname="agi"]',
+            ) as HTMLElement | null;
+            if (!editBtn) {
+                await actor.sheet.close();
+                return {found: false};
+            }
+
+            const errors: string[] = [];
+            const onErr = (e: ErrorEvent) => errors.push(String(e.message ?? e));
+            const onRej = (e: PromiseRejectionEvent) => errors.push(String(e.reason?.message ?? e.reason));
+            window.addEventListener("error", onErr);
+            window.addEventListener("unhandledrejection", onRej);
+
+            editBtn.click();
+            // DialogV2.input renders asynchronously; poll for it.
+            let dice: HTMLInputElement | null = null;
+            let pips: HTMLInputElement | null = null;
+            for (let i = 0; i < 30; i++) {
+                await new Promise((r) => setTimeout(r, 100));
+                dice = document.querySelector('input[name="dice"]') as HTMLInputElement | null;
+                pips = document.querySelector('input[name="pips"]') as HTMLInputElement | null;
+                if (dice && pips) break;
+            }
+
+            let submitted = false;
+            if (dice && pips) {
+                dice.value = "7";
+                pips.value = "0";
+                dice.dispatchEvent(new Event("change", {bubbles: true}));
+                pips.dispatchEvent(new Event("change", {bubbles: true}));
+                const dlgEl = dice.closest(".application") as HTMLElement | null;
+                const okBtn = dlgEl?.querySelector(
+                    'button[data-action="ok"], button[data-action="submit"], button.dialog-button[data-button="ok"], footer button[type="submit"]',
+                ) as HTMLButtonElement | null;
+                if (okBtn) {
+                    okBtn.click();
+                    for (let i = 0; i < 30; i++) {
+                        await new Promise((r) => setTimeout(r, 100));
+                        if (window.game.actors.get(actor.id).system.attributes.agi.base !== 6) break;
+                    }
+                    submitted = true;
+                }
+            }
+
+            window.removeEventListener("error", onErr);
+            window.removeEventListener("unhandledrejection", onRej);
+
+            const finalBase = window.game.actors.get(actor.id).system.attributes.agi.base;
+            await actor.sheet.close();
+
+            const currentTargetErrors = errors.filter(
+                (e) => /currentTarget/i.test(e) && /dataset/i.test(e),
+            );
+            return {found: true, submitted, finalBase, currentTargetErrors};
+        });
+
+        if (!result.found) {
+            test.skip(true, "no .attribute-edit[data-attrname=agi] button on the rendered sheet");
+            return;
+        }
+        expect(result.submitted, "attribute-edit dialog opened and submitted").toBe(true);
+        expect(result.currentTargetErrors,
+            "no TypeError reading dataset off a stale event.currentTarget").toEqual([]);
+        // dice=7, pips=0 → 7D → 21 pips.
+        expect(result.finalBase, "attribute base updated to dialog value").toBe(21);
+    });
 });


### PR DESCRIPTION
## Summary

Closes the residual third symptom of #42 — *\"Changing an attribute will not be saved upon clicking Edit Attribute\"* — that PR #43 left unfixed.

This is the **same bug shape PR #43 fixed for `advanceAction`**, just in the sibling `editAttributeAction` path the PR didn't touch. `_onAttributeEdit` awaits `DialogV2.input(...)`, then `editAttributeAction` reads `event.currentTarget.dataset.attrname` — but `currentTarget` is null by the time the dialog resolves, so it throws `TypeError: Cannot read properties of null (reading 'dataset')` and the `actor.update` never runs. User-visible: attribute edits silently drop.

### Fix
- `src/module/actor/attribute-edit.ts` — capture `attribute` and `label` from `event.currentTarget.dataset` synchronously at click time, pass `attribute` through to `editAttributeAction` instead of re-reading the stale event.

### Regression coverage
- New smoke spec in `tier-3-sheet-persistence.spec.ts` mirroring the `advance-dialog` test: open character sheet in `freeedit`, click `.attribute-edit[data-attrname="agi"]`, fill dice=7/pips=0, click the dialog's OK button, assert no `currentTarget…dataset` TypeError and that `attributes.agi.base` was updated to 21. Verified failing without the source fix and passing with it.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `tier-3-sheet-persistence.spec.ts` — 9/9 passing against live Foundry (was 8/8 before, +1 new)
- [ ] Manual: open character sheet → freeedit mode → click pencil/edit on Agility → set new dice/pips → click Edit Attribute → value persists, no console error

## Related
- Closes #42
- Follow-up to PR #43 (which fixed two of three #42 symptoms)