### PR TITLE
fix: wire editImage action on profile-img for V2 sheets (#30)

### DIFF
--- a/src/templates/actor/common/actor-sheet.html
+++ b/src/templates/actor/common/actor-sheet.html
@@ -1,7 +1,7 @@
 <div class="{{cssClass}} flexcol">
     {{!-- Sheet Header --}}
     <header class="sheet-header flex-group-left">
-        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="200" width="200"
+        <img class="profile-img" src="{{actor.img}}" data-action="editImage" data-edit="img" title="{{actor.name}}" height="200" width="200"
              alt="{{localize 'OD6S.ALT_ACTOR_IMAGE'}}"/>
         <div class="header-right">
             <h2 class="charname">

--- a/src/templates/item/item-action-sheet.html
+++ b/src/templates/item/item-action-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
         </div>

--- a/src/templates/item/item-action-sheet.html
+++ b/src/templates/item/item-action-sheet.html
@@ -1,6 +1,7 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"/>
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
+             alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
         </div>

--- a/src/templates/item/item-advantage-sheet.html
+++ b/src/templates/item/item-advantage-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-armor-sheet.html
+++ b/src/templates/item/item-armor-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h2 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h2>

--- a/src/templates/item/item-character-template-sheet.html
+++ b/src/templates/item/item-character-template-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-cybernetic-sheet.html
+++ b/src/templates/item/item-cybernetic-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h2 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h2>

--- a/src/templates/item/item-disadvantage-sheet.html
+++ b/src/templates/item/item-disadvantage-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-gear-sheet.html
+++ b/src/templates/item/item-gear-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <div>

--- a/src/templates/item/item-info.html
+++ b/src/templates/item/item-info.html
@@ -1,7 +1,7 @@
 <form autocomplete="off">
     <br>
     <div class="row">
-        <img class="profile-img" src="{{object.img}}" data-edit="img" title="{{object.name}}"
+        <img class="profile-img" src="{{object.img}}" data-action="editImage" data-edit="img" title="{{object.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}" width="75" height="75"/>&nbsp&nbsp
         <h3><br>{{object.name}}</h3>
     </div>

--- a/src/templates/item/item-item-group-sheet.html
+++ b/src/templates/item/item-item-group-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-manifestation-sheet.html
+++ b/src/templates/item/item-manifestation-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-skill-sheet.html
+++ b/src/templates/item/item-skill-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
         </div>

--- a/src/templates/item/item-skill-sheet.html
+++ b/src/templates/item/item-skill-sheet.html
@@ -1,6 +1,7 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"/>
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
+             alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
         </div>

--- a/src/templates/item/item-specialability-sheet.html
+++ b/src/templates/item/item-specialability-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-specialization-sheet.html
+++ b/src/templates/item/item-specialization-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-species-template-sheet.html
+++ b/src/templates/item/item-species-template-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-starship-gear-sheet.html
+++ b/src/templates/item/item-starship-gear-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <div>

--- a/src/templates/item/item-starship-weapon-sheet.html
+++ b/src/templates/item/item-starship-weapon-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <div>

--- a/src/templates/item/item-vehicle-gear-sheet.html
+++ b/src/templates/item/item-vehicle-gear-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <div>

--- a/src/templates/item/item-vehicle-sheet.html
+++ b/src/templates/item/item-vehicle-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>

--- a/src/templates/item/item-vehicle-weapon-sheet.html
+++ b/src/templates/item/item-vehicle-weapon-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <div>

--- a/src/templates/item/item-weapon-sheet.html
+++ b/src/templates/item/item-weapon-sheet.html
@@ -1,6 +1,6 @@
 <div class="{{cssClass}}">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"
+        <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}"
              alt="{{localize 'OD6S.ALT_ITEM_IMAGE'}}"/>
         <div class="header-fields">
             <div>

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -469,4 +469,31 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         // dice=7, pips=0 → 7D → 21 pips.
         expect(result.finalBase, "attribute base updated to dialog value").toBe(21);
     });
+
+    test("character sheet portrait img has editImage action wired (#30)", async ({page}) => {
+        // Regression for #30: clicking the character portrait did nothing.
+        // ApplicationV2 DocumentSheetV2 dispatches the editImage FilePicker via
+        // data-action="editImage" — the legacy data-edit="img" alone is ignored.
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 250));
+            const img = actor.sheet.element.querySelector(
+                "img.profile-img",
+            ) as HTMLImageElement | null;
+            const hasAction = img?.getAttribute("data-action") === "editImage";
+            const hasEdit = img?.getAttribute("data-edit") === "img";
+            await actor.sheet.close();
+            return {foundImg: !!img, hasAction, hasEdit};
+        });
+
+        expect(result.foundImg, "profile img exists on actor sheet").toBe(true);
+        expect(result.hasAction,
+            "profile img must have data-action=editImage for V2 FilePicker wiring").toBe(true);
+        expect(result.hasEdit,
+            "profile img must have data-edit=img to identify the path attribute").toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary

Closes #30 — *\"Cannot change character portrait\"*. ApplicationV2 `DocumentSheetV2` routes the FilePicker through its `editImage` action, which is keyed off `data-action="editImage"`. Our templates only had the legacy `data-edit="img"` attribute (which only tells the action handler *which* path attribute to update), so clicking the portrait did nothing on every V2 sheet — character sheet plus every item sheet.

### Fix
Add `data-action="editImage"` alongside the existing `data-edit="img"` on every `profile-img` across:
- `src/templates/actor/common/actor-sheet.html` (the user-reported one)
- 20 item sheet templates (same bug, also broken)

Confirmed against `.foundry-src/foundry.mjs:37544` (`actions: { editImage: DocumentSheetV2.#onEditImage }`) and `:37847` (the handler reads `target.dataset.edit` for the path).

### Regression coverage
New smoke spec in `tier-3-sheet-persistence.spec.ts` asserts the character-sheet portrait img has both attributes wired, so a future template rewrite can't silently drop it again.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `tier-3-sheet-persistence.spec.ts` — 10/10 (was 9/9 before, +1 new)
- [ ] Manual: open character sheet → click portrait → FilePicker opens
- [ ] Manual: open any item sheet (e.g., weapon) → click portrait → FilePicker opens

## Related
- Closes #30