### PR TITLE
fix: declare vehicle item subtype in manifest (#33, #35)

### DIFF
--- a/src/system.json
+++ b/src/system.json
@@ -30,6 +30,7 @@
       "manifestation": {},
       "character-template": {},
       "action": {},
+      "vehicle": {},
       "vehicle-weapon": {},
       "vehicle-gear": {},
       "starship-weapon": {},


### PR DESCRIPTION
## Summary

One-line manifest fix that closes **#33** (item-vehicle sheet won't render) and **#35** (vehicle actor schema init throws `Cannot read properties of undefined (reading 'system')`) — they share a root cause.

Vehicle-item support has been complete in the codebase for a while:
- `src/module/data/item/vehicle.ts` — \`VehicleItemData\` data model
- `src/templates/item/item-vehicle-sheet.html` — sheet template
- `src/module/od6s.ts:111` — registers `vehicle: VehicleItemData` in `CONFIG.Item.dataModels`

But `src/system.json`'s `Item` types declaration was missing the `\"vehicle\"` entry. Without the manifest declaration, Foundry treats `type: \"vehicle\"` items as an unknown subtype: no data model is applied (so `item.system` is `undefined`) and no sheet class is registered (so `item.sheet` is `undefined`). Both user-visible bugs collapse to that.

### Fix
Add `\"vehicle\": {}` between `\"action\"` and `\"vehicle-weapon\"` in the `Item` types map.

### Regression coverage (already in place)
- `tier-2-sheets.spec.ts` — iterates every item type and asserts `i.sheet.render(true)` succeeds. Was failing on `vehicle`, now passes.
- `tier-3-vehicle.spec.ts` — creates a vehicle actor and embeds vehicle items asserting no `unhandledrejection`. Was failing, now passes.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] Full smoke suite — 27/28 pass (only failure is the unrelated #36 weapon-roll `damageScore` bug)
- [x] Container restart picked up the manifest change (`nerdctl restart od6s-foundry`); both target specs flipped from fail → pass
- [ ] Manual: create a vehicle item in the world → sheet opens; create a vehicle actor and drop vehicle/vehicle-weapon/vehicle-gear items on it → no console errors

## Related
- Closes #33
- Closes #35