### PR TITLE
test: drive weapon schema correctly in tier-3-weapon-roll spec (#36)

### DIFF
--- a/tests/smoke/tier-3-weapon-roll.spec.ts
+++ b/tests/smoke/tier-3-weapon-roll.spec.ts
@@ -23,21 +23,25 @@ test("weapon roll opens dialog, submits, creates chat message with damage flags"
         if (actor.system.attributes.agi.base < 1) {
             await actor.update({"system.attributes.agi.base": 10});
         }
-        // Create a smoke weapon if not present
-        const existing = actor.items.find((i: any) => i.type === "weapon" && i.name === "smoke-weapon");
-        if (!existing) {
-            await actor.createEmbeddedDocuments("Item", [{
-                name: "smoke-weapon",
-                type: "weapon",
-                system: {
-                    damage: 12,       // 4D damage (score in pips: 4×3=12)
-                    damage_type: "p", // physical
-                    range: {short: 20, medium: 50, long: 100},
-                    skill: {value: "Firearms"},
-                    attribute: {value: "agi"},
-                },
-            }]);
-        }
+        // Recreate the smoke weapon every run so this test isn't sensitive
+        // to schema drift in stale documents from earlier runs (the original
+        // version of this spec wrote against the wrong schema shape).
+        const stale = actor.items.filter(
+            (i: any) => i.type === "weapon" && i.name === "smoke-weapon",
+        ).map((i: any) => i.id);
+        if (stale.length) await actor.deleteEmbeddedDocuments("Item", stale);
+        await actor.createEmbeddedDocuments("Item", [{
+            name: "smoke-weapon",
+            type: "weapon",
+            system: {
+                // Schema: damage is a SchemaField — score (pips) and type live
+                // under it. 4D = 12 pips at the default 3 pips/die.
+                damage: {score: 12, type: "p"},
+                // range fields are StringField in the schema.
+                range: {short: "20", medium: "50", long: "100"},
+                stats: {skill: "Firearms", attribute: "AGI"},
+            },
+        }]);
     });
 
     const result = await evalInWorld(page, async () => {


### PR DESCRIPTION
## Summary

Closes #36. The reported \"weapon-roll chat message has \`damageScore: 0\`\" was a **smoke-test fixture bug, not a source bug**. The spec was writing weapon fields against an outdated/guessed schema shape, so Foundry's data-model validation silently dropped them and the actual `damage.score` stayed at its schema default of `0`. The chat-flag pipeline (`roll-setup.ts:142` → `roll-execute.ts:234`) was correct all along.

### Wrong shape vs schema (`src/module/data/item/weapon.ts`)

| Test wrote | Schema reality |
| --- | --- |
| `damage: 12` | `damage: SchemaField{ score: NumberField, type: StringField, ... }` |
| `damage_type: \"p\"` | not a top-level field — lives at `damage.type` |
| `range.short: 20` (Number) | `range.short: StringField` |
| `skill: {value: \"Firearms\"}` | `stats.skill: StringField` |
| `attribute: {value: \"agi\"}` | `stats.attribute: StringField` (initial `\"AGI\"`) |

### Fix
Rewrite the smoke fixture in `tier-3-weapon-roll.spec.ts` to match `WeaponData`:

```ts
system: {
    damage: {score: 12, type: \"p\"},
    range: {short: \"20\", medium: \"50\", long: \"100\"},
    stats: {skill: \"Firearms\", attribute: \"AGI\"},
}
```

Also recreate the smoke weapon every run instead of `if (!existing)` — otherwise a stale malformed document from before this fix would poison the result on a developer's machine.

## Test plan
- [x] `tier-3-weapon-roll.spec.ts` — passes (was the only red spec on main)
- [x] Full smoke suite — **29/29 passing**
- [x] No source changes; no rebuild needed

## Related
- Closes #36
- Adjacent: #28 (`getWeaponRange` unit coverage) — independent of this fix