### PR TITLE
test: tighten weapon range/skill form persistence coverage (#38)

### DIFF
--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -150,7 +150,7 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         expect(data.pips).toBe("2");
     });
 
-    test("item name input on item sheet persists", async ({page}) => {
+    test("weapon item-sheet persists name, range.short, and stats.skill via form change (#38)", async ({page}) => {
         await loginAndWaitReady(page);
         await ensureCharacter(page);
 

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -177,31 +177,42 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
 
             const persistedName = actor.items.get(weapon.id).name;
 
-            // Range field
+            // Range field — system.range.short is a StringField in the schema.
             const rangeInput = root.querySelector(
-                'input[name="system.range.short"], input[name="system.range.medium"], input[name="system.range.long"]',
+                'input[name="system.range.short"]',
             ) as HTMLInputElement | null;
-            let rangePersisted: number | null = null;
+            let rangePersisted: string | null = null;
             if (rangeInput) {
                 rangeInput.value = "42";
                 rangeInput.dispatchEvent(new Event("change", {bubbles: true}));
                 await new Promise((r) => setTimeout(r, 400));
-                const path = rangeInput.name.split(".");
-                let v: any = actor.items.get(weapon.id);
-                for (const k of path) v = v?.[k];
-                rangePersisted = Number(v);
+                rangePersisted = String(actor.items.get(weapon.id).system.range.short);
+            }
+
+            // Skill field — system.stats.skill is a StringField in the schema.
+            const skillInput = root.querySelector(
+                'input[name="system.stats.skill"]',
+            ) as HTMLInputElement | null;
+            let skillPersisted: string | null = null;
+            if (skillInput) {
+                skillInput.value = "Firearms";
+                skillInput.dispatchEvent(new Event("change", {bubbles: true}));
+                await new Promise((r) => setTimeout(r, 400));
+                skillPersisted = String(actor.items.get(weapon.id).system.stats.skill);
             }
 
             await weapon.sheet.close();
             await weapon.delete();
-            return {inForm, persistedName, rangePersisted};
+            return {inForm, persistedName, rangePersisted, skillPersisted};
         });
 
         expect(result.inForm, "weapon name input is direct child of item-sheet form").toBe(true);
         expect(result.persistedName).toBe("smoke-weapon-renamed");
-        if (result.rangePersisted !== null) {
-            expect(result.rangePersisted).toBe(42);
-        }
+        // #38 regression: range and skill must persist via the form-change
+        // submit path, not just direct item.update. Failing soft (null) means
+        // the input never rendered, which is itself a regression.
+        expect(result.rangePersisted, "system.range.short input rendered and persisted (#38)").toBe("42");
+        expect(result.skillPersisted, "system.stats.skill input rendered and persisted (#38)").toBe("Firearms");
     });
 
     test("item-attribute-edit dialog template has no <form> and named dice/pips inputs", async ({page}) => {


### PR DESCRIPTION
## Summary

Closes #38. The reported symptom — \"weapon item-sheet form-change events don't persist `system.range.short` / `system.stats.skill`\" — **no longer reproduces against current main**. A direct probe (create weapon, render sheet, mutate input value, dispatch a bubbling `change` event, wait, read back) now sees `\"42\"` and `\"Firearms\"` persist correctly through the form-driven submitOnChange path.

The ambient fix likely landed via #43 + #44 (form/change-event wiring work). No weapon-specific source change has been needed since the bug was filed.

### What this PR does
Promotes the regression test the issue itself recommended in its *Test plan when fixing* section:

- The existing `tier-3-sheet-persistence.spec.ts:153` already mutated `system.range.short` but only soft-asserted (`if (rangePersisted !== null) expect(...)`), which would silently no-op if the input failed to render.
- This PR makes the range assertion hard (`toBe(\"42\")`) and adds a parallel hard assertion for `system.stats.skill` (the second field called out in #38).

If either input ever stops persisting via form-change again, this test fails fast.

### Notes on the schema
Both fields are `StringField` in `WeaponData` (not `NumberField` as #38 originally suspected). The values asserted here are strings.

## Test plan
- [x] `tier-3-sheet-persistence.spec.ts` — 10/10 passing locally with the strengthened assertions
- [x] No source code change

## Related
- Closes #38
- Likely silently fixed by #43 / #44 (form/change-event wiring)