### PR TITLE
fix: drop render-time skill score mutation on vehicle/starship (#29)

### DIFF
--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -169,18 +169,8 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         for (const i of sheetData.items) {
             i.img = i.img || CONST.DEFAULT_TOKEN;
             if (i.type === "skill") {
-                if (!OD6S.flatSkills
-                    && typeof i.system.score !== "undefined"
-                    && typeof i.system.attribute !== "undefined") {
-                    i.system.score = (+i.system.score)
-                        + (+actorData.system.attributes[i.system.attribute.toLowerCase()].score);
-                }
                 skills.push(i);
             } else if (i.type === "specialization") {
-                if (!OD6S.flatSkills) {
-                    i.system.score = (+i.system.score)
-                        + (+actorData.system.attributes[i.system.attribute.toLowerCase()].score);
-                }
                 specializations.push(i);
             } else if (i.type === "vehicle-weapon") {
                 vehicle_weapons.push(i);
@@ -209,18 +199,8 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         for (const i of sheetData.items) {
             i.img = i.img || CONST.DEFAULT_TOKEN;
             if (i.type === "skill") {
-                if (!OD6S.flatSkills
-                    && typeof i.system.score !== "undefined"
-                    && typeof i.system.attribute !== "undefined") {
-                    i.system.score = (+i.system.score)
-                        + (+actorData.system.attributes[i.system.attribute.toLowerCase()].score);
-                }
                 skills.push(i);
             } else if (i.type === "specialization") {
-                if (!OD6S.flatSkills) {
-                    i.system.score = (+i.system.score)
-                        + (+actorData.system.attributes[i.system.attribute.toLowerCase()].score);
-                }
                 specializations.push(i);
             } else if (i.type === "starship-weapon") {
                 starship_weapons.push(i);

--- a/tests/smoke/tier-3-vehicle.spec.ts
+++ b/tests/smoke/tier-3-vehicle.spec.ts
@@ -72,3 +72,55 @@ test("vehicle actor schema initialises and vehicle item embeds without errors", 
     expect(result.schemaOk, "vehicle actor schema fields present").toBe(true);
     expect(result.itemSchemaOk, "vehicle item schema fields present").toBe(true);
 });
+
+test("vehicle/starship sheet re-render does not double-count skill scores (#29)", async ({page}) => {
+    // Regression for #29: _prepareVehicleItems / _prepareStarshipItems used
+    // to mutate i.system.score += attribute.score on every render, so the
+    // canonical score grew without bound across sheet re-renders. Removed in
+    // favour of system.total computed once in prepareDerivedActorData.
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const out: any = {};
+        for (const type of ["vehicle", "starship"] as const) {
+            const stale = window.game.actors.filter((a: any) => a.name === `smoke-${type}-29`)
+                .map((a: any) => a.id);
+            if (stale.length) await window.Actor.deleteDocuments(stale);
+            const actor = await window.Actor.create({
+                name: `smoke-${type}-29`,
+                type,
+                system: {attributes: {agi: {base: 9}}},
+            }, {render: false});
+            const [skill] = await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-pilot",
+                type: "skill",
+                system: {base: 6, attribute: "agi"},
+            }]);
+
+            // Render the sheet a few times; each render runs _prepareVehicle/
+            // StarshipItems against the live DataModel.
+            for (let i = 0; i < 3; i++) {
+                await actor.sheet.render(true);
+                await new Promise((r) => setTimeout(r, 150));
+            }
+            const fresh = window.game.actors.get(actor.id).items.get(skill.id);
+            out[type] = {
+                base: fresh.system.base,
+                score: fresh.system.score,
+                total: fresh.system.total,
+                agi: window.game.actors.get(actor.id).system.attributes.agi.score,
+            };
+            await actor.sheet.close();
+            await actor.delete();
+        }
+        return out;
+    });
+
+    for (const type of ["vehicle", "starship"] as const) {
+        const r = result[type];
+        // Canonical score = base + mod (here mod=0). Must NOT include attribute.
+        expect(r.score, `${type} skill.system.score is canonical (no attribute leaked in)`).toBe(r.base);
+        // Display total = canonical + attribute.score (when flatSkills=false, default).
+        expect(r.total, `${type} skill.system.total includes attribute (display value)`).toBe(r.base + r.agi);
+    }
+});

--- a/tests/smoke/tier-3-vehicle.spec.ts
+++ b/tests/smoke/tier-3-vehicle.spec.ts
@@ -101,7 +101,7 @@ test("vehicle/starship sheet re-render does not double-count skill scores (#29)"
             // StarshipItems against the live DataModel.
             for (let i = 0; i < 3; i++) {
                 await actor.sheet.render(true);
-                await new Promise((r) => setTimeout(r, 150));
+                await new Promise((r) => setTimeout(r, 250));
             }
             const fresh = window.game.actors.get(actor.id).items.get(skill.id);
             out[type] = {


### PR DESCRIPTION
## Summary

Closes #29 — extends PR #26's skill-display-decoupling work to vehicle and starship actors. `_prepareVehicleItems` and `_prepareStarshipItems` were still mutating `i.system.score += attribute.score` on every sheet render. Because `i.system` is the live DataModel (not a copy), every re-render re-applied the addition on top of the already-mutated value — the canonical score grew without bound.

### Fix
Delete the mutation blocks in both methods. The display value lives in `i.system.total`, computed once per data-prep cycle in `actor-helpers/prepare-data.ts:99-105`. That path has no actor-type gate, so vehicle and starship actors already get `system.total` populated correctly — there was nothing to add, only render-time corruption to remove.

Vehicle and starship templates don't iterate `actor.skills` / `actor.specializations` for display, so no template change is needed; the mutations were pure corruption affecting any code that read `i.system.score` after a render (roll dialogs, etc.).

### Regression coverage
New smoke spec in `tier-3-vehicle.spec.ts:76`:
- Creates a vehicle and a starship, each with an embedded skill (`base=6`, `attribute="agi"`, actor `agi.base=9` → `agi.score=9`).
- Renders the sheet **three times** (so the bug compounds visibly).
- Asserts `skill.system.score === base` (canonical, no attribute leaked in) and `skill.system.total === base + agi` (correct display value).

Without the fix this test would see `score = 6 + 9*3 = 33` after three renders. With the fix, `score === 6`.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build:ts` — bundle updated
- [x] `tier-3-vehicle.spec.ts` — 2/2 passing
- [x] Full smoke suite — **30/30 passing**

## Related
- Closes #29
- Follow-up to #26 (PR #13 phase 3) — character actors already use `system.total`