### PR TITLE
fix: wounds dropdown selected attribute reaches wrong context

### DIFF
--- a/src/templates/actor/common/wounds.html
+++ b/src/templates/actor/common/wounds.html
@@ -36,7 +36,15 @@
             <select name="system.wounds.value" id="actor.system.wounds.value" style="width: 70px;">
                 
                     {{#each (getWoundLevels actor.type) as |level key|}}
-                        <option value="{{ key }}" {{#if (eq key actor.system.wounds.value)}}selected{{/if}}>
+                        {{!-- Inside #each, the iteration's current item is `level`,
+                             so `actor` must be reached via the parent context.
+                             key is a string from Object.keys; wounds.value is a
+                             NumberField, so coerce key to a number for the strict
+                             eq. Without this, no option ever gets `selected` and
+                             the browser defaults to the first one (Healthy) on
+                             every render — which looked to users like the change
+                             didn't save. --}}
+                        <option value="{{ key }}" {{#if (eq (add key 0) ../actor.system.wounds.value)}}selected{{/if}}>
                             {{localize (woundsFromValue key ../actor.type)}}
                         </option>
                     {{/each}}

--- a/tests/smoke/tier-3-wounds.spec.ts
+++ b/tests/smoke/tier-3-wounds.spec.ts
@@ -84,3 +84,71 @@ test("wound transitions advance and status toggle works without schema errors", 
     expect(result.afterSevere).toBeGreaterThan(result.afterWounded);
     expect(result.errs, "wound flow errors").toEqual([]);
 });
+
+test("wound dropdown reflects stored value on render and persists round-trip", async ({page}) => {
+    // Regression: actor.system.wounds.value persisted via form change correctly,
+    // but the dropdown's `selected` comparison inside #each was reaching the
+    // wrong context (the iterated deadliness entry, not the actor). The
+    // `selected` attribute never rendered, the browser fell back to the first
+    // option ("Healthy") on every reopen, and users saw "changing wounds
+    // doesn't seem to save".
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const stale = window.game.actors.filter((a: any) => a.name === "smoke-wounds-dropdown")
+            .map((a: any) => a.id);
+        if (stale.length) await window.Actor.deleteDocuments(stale);
+        const actor = await window.Actor.create({
+            name: "smoke-wounds-dropdown", type: "character",
+        }, {render: false});
+        await actor.update({"system.wounds.value": 0});
+
+        // open sheet, change dropdown to first non-zero option, close
+        await actor.sheet.render(true);
+        await new Promise((r) => setTimeout(r, 250));
+        const root1 = actor.sheet.element as HTMLElement;
+        const sel1 = root1.querySelector(
+            'select[name="system.wounds.value"]',
+        ) as HTMLSelectElement | null;
+        if (!sel1) {
+            await actor.sheet.close();
+            await actor.delete();
+            return {skipReason: "wounds dropdown not rendered (woundConfig?)"};
+        }
+        const target = [...sel1.options].find((o) => o.value !== "0");
+        const targetVal = target?.value ?? "";
+        if (target) {
+            sel1.value = target.value;
+            sel1.dispatchEvent(new Event("change", {bubbles: true}));
+            await new Promise((r) => setTimeout(r, 600));
+        }
+        const persistedAfterChange = window.game.actors.get(actor.id).system.wounds.value;
+        await actor.sheet.close();
+
+        // reopen and verify the dropdown reflects the stored value
+        await actor.sheet.render(true);
+        await new Promise((r) => setTimeout(r, 250));
+        const root2 = actor.sheet.element as HTMLElement;
+        const sel2 = root2.querySelector(
+            'select[name="system.wounds.value"]',
+        ) as HTMLSelectElement | null;
+        const reopenedSelectValue = sel2?.value;
+        const persistedAfterReopen = window.game.actors.get(actor.id).system.wounds.value;
+
+        await actor.sheet.close();
+        await actor.delete();
+        return {targetVal, persistedAfterChange, reopenedSelectValue, persistedAfterReopen};
+    });
+
+    if (result.skipReason) {
+        test.skip(true, result.skipReason);
+        return;
+    }
+    expect(String(result.persistedAfterChange),
+        "stored wounds.value updates on dropdown change").toBe(result.targetVal);
+    expect(String(result.persistedAfterReopen),
+        "stored wounds.value survives reopen").toBe(result.targetVal);
+    expect(result.reopenedSelectValue,
+        "dropdown reflects the stored value on reopen (selected attribute fires)")
+        .toBe(result.targetVal);
+});

--- a/tests/smoke/tier-3-wounds.spec.ts
+++ b/tests/smoke/tier-3-wounds.spec.ts
@@ -116,11 +116,19 @@ test("wound dropdown reflects stored value on render and persists round-trip", a
             return {skipReason: "wounds dropdown not rendered (woundConfig?)"};
         }
         const target = [...sel1.options].find((o) => o.value !== "0");
-        const targetVal = target?.value ?? "";
-        if (target) {
-            sel1.value = target.value;
-            sel1.dispatchEvent(new Event("change", {bubbles: true}));
-            await new Promise((r) => setTimeout(r, 600));
+        if (!target) {
+            await actor.sheet.close();
+            await actor.delete();
+            return {skipReason: "no non-zero wound option (deadliness config?)"};
+        }
+        const targetVal = target.value;
+        const targetNum = Number(targetVal);
+        sel1.value = targetVal;
+        sel1.dispatchEvent(new Event("change", {bubbles: true}));
+        // Poll for the persisted value rather than a fixed sleep — survives slow CI.
+        for (let i = 0; i < 30; i++) {
+            await new Promise((r) => setTimeout(r, 50));
+            if (window.game.actors.get(actor.id).system.wounds.value === targetNum) break;
         }
         const persistedAfterChange = window.game.actors.get(actor.id).system.wounds.value;
         await actor.sheet.close();


### PR DESCRIPTION
## Summary

Closes the user-reported \"changing Wounds doesn't seem to save\" regression. The data **was** saving — `actor.system.wounds.value` persisted correctly through the form-change pipeline. But the dropdown's `selected` conditional rendered on **no** option, so the browser defaulted to the first one (Healthy) on every reopen, exactly mimicking a non-persistent change.

### Root cause (two compounding bugs)

`src/templates/actor/common/wounds.html` had:

```handlebars
{{#each (getWoundLevels actor.type) as |level key|}}
    <option value=\"{{ key }}\" {{#if (eq key actor.system.wounds.value)}}selected{{/if}}>
```

1. **Wrong context.** Inside `{{#each}}`, the iteration's current item is `level` (a deadliness config object). `actor` doesn't exist on it, so `actor.system.wounds.value` resolves to empty. Needs `../actor.system.wounds.value`.
2. **Type mismatch.** `Object.keys` yields string keys (`\"1\"`, `\"2\"`, ...). `system.wounds.value` is a `NumberField`. Foundry's `eq` helper is strict `===`, so `(eq \"1\" 1)` is false even with the right context. Need to coerce with the existing `(add key 0)` helper.

Either bug alone breaks the `selected` attribute. With both, the bug has been silent since the schema migration.

### Fix
```handlebars
<option value=\"{{ key }}\" {{#if (eq (add key 0) ../actor.system.wounds.value)}}selected{{/if}}>
```

### Verification (probe results)

| | before fix | after fix |
| --- | --- | --- |
| `actor.system.wounds.value` after dropdown change | `1` ✓ | `1` ✓ |
| `actor.system.wounds.value` after close+reopen | `1` ✓ | `1` ✓ |
| `<select>.value` after reopen | `\"0\"` ❌ | `\"1\"` ✓ |
| Rendered HTML | `<option value=\"1\">` (no selected) | `<option value=\"1\" selected>` |

### Regression coverage
New spec in `tier-3-wounds.spec.ts:88`: open sheet, change dropdown to a non-zero option, close, reopen, assert the rendered `<select>`'s value matches `actor.system.wounds.value`. Skip-soft if the dropdown isn't rendered (woundConfig 1/2 paths), so the test stays valid across `bodypoints` settings.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `tier-3-wounds.spec.ts` — 2/2 passing
- [x] Full smoke suite — **31/31 passing**

## Related
- User-reported on the 2.2.0 readiness check; not previously filed as a separate issue.