### PR TITLE
style: clean up roll/advance/specialize dialog markup

### DIFF
--- a/scss/components/_dialogs.scss
+++ b/scss/components/_dialogs.scss
@@ -1,0 +1,120 @@
+@use '../utils' as *;
+
+// ── Roll / advance / specialize dialogs ─────────────────────────────────
+// Scoped to .od6s.dialog so we don't accidentally restyle Foundry's
+// generic DialogV2 confirms used by the rest of the system.
+.od6s.dialog {
+
+  // Section divider — replaces the bare <div class="center"><b>X</b></div>
+  // pattern. Gives Penalties / Modifiers a real visual weight matched to
+  // the sheet's gold scribe lines.
+  .dialog-section {
+    margin: 12px 0 6px;
+    padding: 0;
+    font-family: $font-display;
+    font-size: 0.78em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: $c-accent;
+    text-align: center;
+    position: relative;
+
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      width: calc(50% - 4em);
+      height: 1px;
+      background: $grad-rule;
+    }
+    &::before { left: 0; }
+    &::after  { right: 0; }
+  }
+
+  // "D" suffix after each penalty / dice input — was a bare <b>D</b>,
+  // now a small muted glyph that doesn't compete with the number.
+  .dice-suffix {
+    margin-left: 4px;
+    color: $c-accent;
+    font-family: $font-display;
+    font-size: 0.85em;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+  }
+
+  // Character-points cost readout. Was inline `style="color:black"`,
+  // invisible against the dark dialog background. Map cpcostcolor's two
+  // existing string values to text colors that work on the panel.
+  .cpcost {
+    font-family: $font-numeric;
+    font-weight: 700;
+  }
+  .cpcost-black { color: $c-text-primary; }
+  .cpcost-red   { color: $c-bad; }
+
+  // Roll / submit button — match the gold accent treatment used on the
+  // .create-character button so dialog actions feel like the same family.
+  .dialog-submit {
+    background: $grad-banner;
+    border: 1px solid $c-accent-border;
+    color: $c-accent-bright;
+    border-radius: 2px;
+    padding: 6px 22px;
+    font-family: $font-display;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 700;
+    font-size: 0.95em;
+    box-shadow: $c-shadow-inset, 0 2px 8px rgba(0, 0, 0, 0.5);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.6);
+    cursor: pointer;
+    transition: filter 0.15s ease, transform 0.05s ease, box-shadow 0.15s ease;
+
+    &:hover {
+      filter: brightness(1.18);
+      box-shadow:
+        $c-shadow-inset,
+        0 2px 10px rgba(0, 0, 0, 0.55),
+        $c-glow-soft;
+    }
+
+    &:active { transform: translateY(1px); }
+  }
+
+  // Tighten the row rhythm so the dialog feels less stretched out.
+  .roll-dialog {
+    > .flexrow {
+      margin: 4px 0;
+      align-items: center;
+      gap: 8px;
+    }
+
+    // Two-column layout for penalty / modifier rows. Was broken because
+    // 3 of 4 .column elements had a `column>` typo and never picked up
+    // the flex:50% rule.
+    .row {
+      display: flex;
+      gap: 10px;
+      margin: 2px 0;
+
+      > .column { flex: 1 1 50%; min-width: 0; }
+    }
+
+    // Ensure labels in label/input pairs stay left-aligned and the input
+    // doesn't collapse against the right edge.
+    label {
+      flex: 0 0 auto;
+      margin-right: 6px;
+      color: $c-text-muted;
+    }
+
+    // Numeric inputs in the dialog are short — no need for them to
+    // grow to the full row width.
+    input[type="number"] {
+      width: 4em;
+      text-align: right;
+    }
+  }
+}

--- a/scss/od6s.scss
+++ b/scss/od6s.scss
@@ -17,3 +17,4 @@
 @use 'components/items';
 @use 'components/attributes';
 @use 'components/chat';
+@use 'components/dialogs';

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1071,7 +1071,7 @@
   "OD6S.USE": "Use",
   "OD6S.USE_A_CHARACTER_POINT": "Use a Character Point",
   "OD6S.USE_BONUS_DICE": "Bonus Dice:",
-  "OD6S.USE_BONUS_PIPS": "Bonus Pips:+",
+  "OD6S.USE_BONUS_PIPS": "Bonus Pips:",
   "OD6S.USE_CHARACTER_POINTS": "Use Character Points?",
   "OD6S.USE_FATE_POINT": "Use a Fate Point?",
   "OD6S.USE_STRENGTH_DAMAGE": "Use Strength Damage Bonus",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -793,7 +793,7 @@
   "OD6S.TYPE": "Tipo",
   "OD6S.USE_A_CHARACTER_POINT": "Usar punto de personaje",
   "OD6S.USE_BONUS_DICE": "Dados Extras:",
-  "OD6S.USE_BONUS_PIPS": "Pips:+",
+  "OD6S.USE_BONUS_PIPS": "Pips:",
   "OD6S.USE_CHARACTER_POINTS": "¿Usar puntos de personaje?",
   "OD6S.USE_FATE_POINT": "¿Usar Fate Point?",
   "OD6S.USE_WILD_DIE": "¿Usar Wild Die?",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -490,7 +490,7 @@
   "OD6S.TYPE": "Type",
   "OD6S.USE_A_CHARACTER_POINT": "Dépense un point de personnage",
   "OD6S.USE_BONUS_DICE": "Dés Bonus:",
-  "OD6S.USE_BONUS_PIPS": "Bonus Pips:+",
+  "OD6S.USE_BONUS_PIPS": "Bonus Pips:",
   "OD6S.USE_CHARACTER_POINTS": "Utiliser un point de personnage ?",
   "OD6S.USE_FATE_POINT": "Utiliser un point de Destin ?",
   "OD6S.USE_WILD_DIE": "Utiliser un dé Joker ?",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -863,7 +863,7 @@
   "OD6S.TYPE": "Тип",
   "OD6S.USE_A_CHARACTER_POINT": "Используйте пункт характера",
   "OD6S.USE_BONUS_DICE": "Бонусные кубики:",
-  "OD6S.USE_BONUS_PIPS": "Бонусные пункты:+",
+  "OD6S.USE_BONUS_PIPS": "Бонусные пункты:",
   "OD6S.USE_CHARACTER_POINTS": "Используйте пункты персонажа?",
   "OD6S.USE_FATE_POINT": "Использовать пункт судьбы?",
   "OD6S.USE_WILD_DIE": "Использовать дикий кубик?",

--- a/src/templates/actor/character/advance.html
+++ b/src/templates/actor/character/advance.html
@@ -70,7 +70,7 @@
                        {{#if metaphysicsteacher}}checked{{/if}}>
             </div>
             <div class="flexrow flex-group-center" data-cpcost="{{cpcost}}">
-                <p style="color:{{ cpcostcolor }};">CP Cost: {{cpcost}}</p>
+                <p class="cpcost cpcost-{{cpcostcolor}}">CP Cost: {{cpcost}}</p>
             </div>
         </div>
     {{/if}}
@@ -82,7 +82,7 @@
                    {{#if freeadvance}}checked{{/if}}>
         </div>
         <div class="flexrow flex-group-center" data-cpcost="{{cpcost}}">
-            <p style="color:{{ cpcostcolor }};">CP Cost: {{cpcost}}</p>
+            <p class="cpcost cpcost-{{cpcostcolor}}">CP Cost: {{cpcost}}</p>
         </div>
     </div>
     <footer class="form-footer">

--- a/src/templates/actor/common/specialize.html
+++ b/src/templates/actor/common/specialize.html
@@ -17,7 +17,7 @@
                            {{#if freeadvance}}checked{{/if}}>
                 </div>
                 <div class="flexrow flex-group-center" data-cpcost="{{cpcost}}">
-                    <p style="color:{{ cpcostcolor }};">CP Cost: {{cpcost}}</p>
+                    <p class="cpcost cpcost-{{cpcostcolor}}">CP Cost: {{cpcost}}</p>
                 </div>
             </div>
         </div>

--- a/src/templates/initRoll.html
+++ b/src/templates/initRoll.html
@@ -3,7 +3,7 @@
     <div class="flexrow flex-group-left usecharacterpoints">
         <div data-characterpoints="{{characterpoints}}">{{ localize 'OD6S.USE_CHARACTER_POINTS'}}</div>
         <div class="flexrow flex-group-center">
-            <div class="boxed" style="color:{{ cpcostcolor }};">{{characterpoints}}</div>
+            <div class="boxed cpcost cpcost-{{cpcostcolor}}">{{characterpoints}}</div>
             <div class="flex-group-center cpup">
                 <i class="fas fa-plus-square"></i>
             </div>
@@ -32,6 +32,6 @@
         </div>
     </div>
     <footer class="form-footer">
-        <button type="submit" data-action="submit">{{localize "OD6S.ROLL"}}</button>
+        <button type="submit" class="dialog-submit" data-action="submit">{{localize "OD6S.ROLL"}}</button>
     </footer>
 </div>

--- a/src/templates/metaphysicsRoll.html
+++ b/src/templates/metaphysicsRoll.html
@@ -33,9 +33,9 @@
                        max="99" id="bonuspips" name="bonuspips" value="{{bonuspips}}">
             </div>
         </div>
-        <div class="center"><b>{{localize "OD6S.PENALTIES"}}</b></div>
+        <h3 class="dialog-section">{{localize "OD6S.PENALTIES"}}</h3>
         <div class="row">
-            <div class="column>">
+            <div class="column">
                 <div class="flexrow flex-group-left" title="{{localize 'OD6S.ACTION_PENALTY'}}">
                     <div class="actionpenalty flexrow flex-group-left">
                         <label for="actionpenalty">{{localize 'OD6S.ACTIONS'}}:</label>
@@ -44,7 +44,7 @@
                          data-actionpenalty="{{../actionpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="actionpenalty" name="actionpenalty"
-                               value="{{../actionpenalty}}"><b>D</b>
+                               value="{{../actionpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
@@ -57,11 +57,11 @@
                          data-woundpenalty="{{../woundpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="woundpenalty" name="woundpenalty"
-                               value="{{../woundpenalty}}"><b>D</b>
+                               value="{{../woundpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
-            <div class="column>">
+            <div class="column">
                 <div class="flexrow flex-group-left" title="{{localize 'OD6S.OTHER_PENALTY'}}">
                     <div class="otherpenalty flexrow flex-group-left">
                         <label for="otherpenalty">{{localize 'OD6S.OTHER'}}:</label>
@@ -70,7 +70,7 @@
                          data-otherpenalty="{{../otherpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="otherpenalty" name="otherpenalty"
-                               value="{{../otherpenalty}}"><b>D</b>
+                               value="{{../otherpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
@@ -102,6 +102,6 @@
         <hr>
     {{/each}}
     <footer class="form-footer">
-        <button type="submit" data-action="submit">{{localize "OD6S.ROLL"}}</button>
+        <button type="submit" class="dialog-submit" data-action="submit">{{localize "OD6S.ROLL"}}</button>
     </footer>
 </div>

--- a/src/templates/roll.html
+++ b/src/templates/roll.html
@@ -25,7 +25,7 @@
         <div class="flexrow flex-group-left usecharacterpoints">
             <div data-characterpoints="{{characterpoints}}">{{ localize 'OD6S.USE_CHARACTER_POINTS'}}</div>
             <div class="flexrow flex-group-center">
-                <div class="boxed" style="color:{{ cpcostcolor }};">{{characterpoints}}</div>
+                <div class="boxed cpcost cpcost-{{cpcostcolor}}">{{characterpoints}}</div>
                 <div class="flex-group-center cpup">
                     <i class="fas fa-plus-square"></i>
                 </div>
@@ -162,9 +162,9 @@
         {{/if}}
     {{/if}}
     {{#if (showPenalties type) }}
-        <div class="center"><b>{{localize "OD6S.PENALTIES"}}</b></div>
+        <h3 class="dialog-section">{{localize "OD6S.PENALTIES"}}</h3>
         <div class="row">
-            <div class="column>">
+            <div class="column">
                 <div class="flexrow flex-group-left" title="{{localize 'OD6S.ACTION_PENALTY'}}">
                     <div class="actionpenalty flexrow flex-group-left">
                         <label for="actionpenalty">{{localize 'OD6S.ACTIONS'}}:</label>
@@ -173,7 +173,7 @@
                          data-actionpenalty="{{actionpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="actionpenalty" name="actionpenalty"
-                               value="{{actionpenalty}}"><b>D</b>
+                               value="{{actionpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
@@ -186,13 +186,13 @@
                          data-woundpenalty="{{woundpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="woundpenalty" name="woundpenalty"
-                               value="{{woundpenalty}}"><b>D</b>
+                               value="{{woundpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
         </div>
         <div class="row">
-            <div class="column>">
+            <div class="column">
                 <div class="flexrow flex-group-left" title="{{localize 'OD6S.STUNNED_PENALTY'}}">
                     <div class="stunnedpenalty flexrow flex-group-left">
                         <label for="stunnedpenalty">{{localize 'OD6S.WOUNDS_STUNNED'}}:</label>
@@ -201,11 +201,11 @@
                          data-otherpenalty="{{stunnedpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="stunnedpenalty" name="stunnedpenalty"
-                               value="{{stunnedpenalty}}"><b>D</b>
+                               value="{{stunnedpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
-            <div class="column>">
+            <div class="column">
                 <div class="flexrow flex-group-left" title="{{localize 'OD6S.OTHER_PENALTY'}}">
                     <div class="otherpenalty flexrow flex-group-left">
                         <label for="otherpenalty">{{localize 'OD6S.OTHER'}}:</label>
@@ -214,7 +214,7 @@
                          data-otherpenalty="{{otherpenalty}}">
                         <input type="number" data-dtype="Number"
                                max="99" id="otherpenalty" name="otherpenalty"
-                               value="{{otherpenalty}}"><b>D</b>
+                               value="{{otherpenalty}}"><span class="dice-suffix">D</span>
                     </div>
                 </div>
             </div>
@@ -281,7 +281,7 @@
             </div>
         {{else}}
             {{#if (showModifiers)}}
-                <div class="center"><b>{{localize "OD6S.MODIFIERS"}}</b></div>
+                <h3 class="dialog-section">{{localize "OD6S.MODIFIERS"}}</h3>
                 <div class="flexrow flex-group-left">
                     {{#unless (displayRange subtype)}}
                         <div class="flexrow flex-group-left range" data-range="{{range}}">
@@ -426,7 +426,7 @@
         {{/if}}
     {{/if}}
     {{#if (isSkillOrAttribute type subtype) }}
-        <div class="center"><b>{{localize "OD6S.MODIFIERS"}}</b></div>
+        <h3 class="dialog-section">{{localize "OD6S.MODIFIERS"}}</h3>
         <div class="row">
             <div class="column">
                 <div class="flexrow flex-group-left miscmod modifier">
@@ -439,6 +439,6 @@
         </div>
     {{/if}}
     <footer class="form-footer">
-        <button type="submit" data-action="submit">{{localize "OD6S.ROLL"}}</button>
+        <button type="submit" class="dialog-submit" data-action="submit">{{localize "OD6S.ROLL"}}</button>
     </footer>
 </div>

--- a/tests/smoke/tier-3-roll-dialog-cosmetic.spec.ts
+++ b/tests/smoke/tier-3-roll-dialog-cosmetic.spec.ts
@@ -14,53 +14,59 @@ import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
 test("roll dialog renders with cosmetic fixes", async ({page}) => {
     await loginAndWaitReady(page);
     const result = await evalInWorld(page, async () => {
-        let actor = window.game.actors.find((a: any) => a.name === "smoke-roll-cosmetic");
-        if (actor) await actor.delete();
-        actor = await window.Actor.create({
-            name: "smoke-roll-cosmetic", type: "character",
-            system: {attributes: {agi: {base: 10}}, characterpoints: {value: 5}},
-        }, {render: false});
-        const [skill] = await actor.createEmbeddedDocuments("Item", [{
-            name: "Space Transports", type: "skill",
-            system: {base: 12, attribute: "mec"},
-        }]);
+        let actor: any = null;
+        let dlg: any = null;
+        try {
+            const stale = window.game.actors.find((a: any) => a.name === "smoke-roll-cosmetic");
+            if (stale) await stale.delete();
+            actor = await window.Actor.create({
+                name: "smoke-roll-cosmetic", type: "character",
+                system: {attributes: {agi: {base: 10}}, characterpoints: {value: 5}},
+            }, {render: false});
+            const [skill] = await actor.createEmbeddedDocuments("Item", [{
+                name: "Space Transports", type: "skill",
+                system: {base: 12, attribute: "mec"},
+            }]);
 
-        // Open the roll dialog via skill.roll
-        const apps0 = new Set([...window.foundry.applications.instances.keys()]);
-        await skill.roll();
-        await new Promise(r => setTimeout(r, 700));
-        const dlg = [...window.foundry.applications.instances.values()].find(
-            (a: any) => !apps0.has(a.id) && a.constructor.name.includes("RollDialog"),
-        );
-        if (!dlg) {
-            await actor.delete();
-            return {error: "dialog did not open"};
+            // Open the roll dialog via skill.roll. Poll for the new RollDialog
+            // to appear instead of sleeping a fixed duration.
+            const apps0 = new Set([...window.foundry.applications.instances.keys()]);
+            await skill.roll();
+            for (let i = 0; i < 30; i++) {
+                await new Promise((r) => setTimeout(r, 50));
+                dlg = [...window.foundry.applications.instances.values()].find(
+                    (a: any) => !apps0.has(a.id) && a.constructor.name.includes("RollDialog"),
+                );
+                if (dlg) break;
+            }
+            if (!dlg) return {error: "dialog did not open within 1.5s"};
+            const root = (dlg as any).element as HTMLElement;
+            const html = root.outerHTML;
+
+            const hasColumnTypo = html.includes('class="column>"') || html.includes('class="column&gt;"');
+            const hasOldCenterPattern = !!root.querySelector('div.center > b');
+            const dialogSections = root.querySelectorAll('.dialog-section').length;
+            const diceSuffixes = root.querySelectorAll('.dice-suffix').length;
+            const cpcost = root.querySelector('.cpcost');
+            const cpcostHasInlineColor = cpcost?.getAttribute("style")?.includes("color:") ?? false;
+            const cpcostClass = cpcost?.className;
+            const submit = root.querySelector('button[data-action="submit"]');
+            const submitClass = submit?.className;
+            const bonusPipsLabel = (root.querySelector('label[for="bonuspips"]') as HTMLElement)
+                ?.textContent?.trim();
+
+            return {
+                hasColumnTypo, hasOldCenterPattern,
+                dialogSections, diceSuffixes,
+                cpcostHasInlineColor, cpcostClass,
+                submitClass,
+                bonusPipsLabel,
+            };
+        } finally {
+            try { if (dlg) await dlg.close(); } catch { /* ignore */ }
+            try { if (actor) await actor.delete(); } catch { /* ignore */ }
         }
-        const root = (dlg as any).element as HTMLElement;
-        const html = root.outerHTML;
-
-        const hasColumnTypo = html.includes('class="column>"') || html.includes('class="column&gt;"');
-        const hasOldCenterPattern = !!root.querySelector('div.center > b');
-        const dialogSections = root.querySelectorAll('.dialog-section').length;
-        const diceSuffixes = root.querySelectorAll('.dice-suffix').length;
-        const cpcost = root.querySelector('.cpcost');
-        const cpcostHasInlineColor = cpcost?.getAttribute("style")?.includes("color:") ?? false;
-        const cpcostClass = cpcost?.className;
-        const submit = root.querySelector('button[data-action="submit"]');
-        const submitClass = submit?.className;
-        const bonusPipsLabel = (root.querySelector('label[for="bonuspips"]') as HTMLElement)?.textContent?.trim();
-
-        try { await (dlg as any).close(); } catch {}
-        await actor.delete();
-        return {
-            hasColumnTypo, hasOldCenterPattern,
-            dialogSections, diceSuffixes,
-            cpcostHasInlineColor, cpcostClass,
-            submitClass,
-            bonusPipsLabel,
-        };
     });
-    console.log("[probe-cosmetic]", JSON.stringify(result, null, 2));
     expect(result.error).toBeUndefined();
     expect(result.hasColumnTypo, "no class=\"column>\" typo").toBe(false);
     expect(result.hasOldCenterPattern, "no <div.center><b> pattern").toBe(false);

--- a/tests/smoke/tier-3-roll-dialog-cosmetic.spec.ts
+++ b/tests/smoke/tier-3-roll-dialog-cosmetic.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Tier 3 — Roll dialog cosmetic markup.
+ *
+ * Locks in the structural fixes applied to roll.html / metaphysicsRoll.html /
+ * initRoll.html: no `class="column>"` typo, no bare `<div class="center"><b>`
+ * section headers, dice indicators wrapped in .dice-suffix, cpcost styled
+ * via class instead of inline color, and the submit button carrying the
+ * .dialog-submit class.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("roll dialog renders with cosmetic fixes", async ({page}) => {
+    await loginAndWaitReady(page);
+    const result = await evalInWorld(page, async () => {
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-roll-cosmetic");
+        if (actor) await actor.delete();
+        actor = await window.Actor.create({
+            name: "smoke-roll-cosmetic", type: "character",
+            system: {attributes: {agi: {base: 10}}, characterpoints: {value: 5}},
+        }, {render: false});
+        const [skill] = await actor.createEmbeddedDocuments("Item", [{
+            name: "Space Transports", type: "skill",
+            system: {base: 12, attribute: "mec"},
+        }]);
+
+        // Open the roll dialog via skill.roll
+        const apps0 = new Set([...window.foundry.applications.instances.keys()]);
+        await skill.roll();
+        await new Promise(r => setTimeout(r, 700));
+        const dlg = [...window.foundry.applications.instances.values()].find(
+            (a: any) => !apps0.has(a.id) && a.constructor.name.includes("RollDialog"),
+        );
+        if (!dlg) {
+            await actor.delete();
+            return {error: "dialog did not open"};
+        }
+        const root = (dlg as any).element as HTMLElement;
+        const html = root.outerHTML;
+
+        const hasColumnTypo = html.includes('class="column>"') || html.includes('class="column&gt;"');
+        const hasOldCenterPattern = !!root.querySelector('div.center > b');
+        const dialogSections = root.querySelectorAll('.dialog-section').length;
+        const diceSuffixes = root.querySelectorAll('.dice-suffix').length;
+        const cpcost = root.querySelector('.cpcost');
+        const cpcostHasInlineColor = cpcost?.getAttribute("style")?.includes("color:") ?? false;
+        const cpcostClass = cpcost?.className;
+        const submit = root.querySelector('button[data-action="submit"]');
+        const submitClass = submit?.className;
+        const bonusPipsLabel = (root.querySelector('label[for="bonuspips"]') as HTMLElement)?.textContent?.trim();
+
+        try { await (dlg as any).close(); } catch {}
+        await actor.delete();
+        return {
+            hasColumnTypo, hasOldCenterPattern,
+            dialogSections, diceSuffixes,
+            cpcostHasInlineColor, cpcostClass,
+            submitClass,
+            bonusPipsLabel,
+        };
+    });
+    console.log("[probe-cosmetic]", JSON.stringify(result, null, 2));
+    expect(result.error).toBeUndefined();
+    expect(result.hasColumnTypo, "no class=\"column>\" typo").toBe(false);
+    expect(result.hasOldCenterPattern, "no <div.center><b> pattern").toBe(false);
+    expect(result.dialogSections, "Penalties + Modifiers as .dialog-section").toBeGreaterThanOrEqual(2);
+    expect(result.diceSuffixes, "all 4 penalty Ds wrapped in .dice-suffix").toBeGreaterThanOrEqual(4);
+    expect(result.cpcostHasInlineColor, "no inline color on cpcost").toBe(false);
+    expect(result.cpcostClass, "cpcost has cpcost-{color} class").toContain("cpcost-");
+    expect(result.submitClass, "Roll button has dialog-submit class").toContain("dialog-submit");
+    expect(result.bonusPipsLabel, "Bonus Pips label has no trailing +").not.toMatch(/\+$/);
+});


### PR DESCRIPTION
## Summary

Polish pass on the roll dialog and its advance/specialize siblings. Five real bugs visible in the rendered DOM, plus an i18n nit:

| # | Bug | Fix |
|---|-----|-----|
| 1 | `class=\"column>\"` typo on **3 of 4** `.column` wrappers in `roll.html` + `metaphysicsRoll.html`. Only the Wounds column ever picked up `flex:50%`, leaving the other rows ragged. | sed-fix to `class=\"column\"` |
| 2 | `style=\"color:{{cpcostcolor}}\"` rendered literal `\"black\"` on the character-points readout — invisible on the dark dialog. | Replace with `class=\"cpcost cpcost-{{cpcostcolor}}\"`; CSS maps `cpcost-black → $c-text-primary`, `cpcost-red → $c-bad`. No TS change needed. |
| 3 | Bare `<b>D</b>` after every penalty input. | Wrap in `.dice-suffix` (small uppercase, accent gold). |
| 4 | Section headers were `<div class=\"center\"><b>X</b></div>` — tiny, centered, no weight. | Replace with `<h3 class=\"dialog-section\">` carrying a gold scribe rule across the row, matched to the sheet's other gold accent treatments. |
| 5 | Submit button had no class, default browser styling. | `.dialog-submit` using the same gold-accent pattern as `.create-character`. |
| 6 | `OD6S.USE_BONUS_PIPS` was `\"Bonus Pips:+\"` (en/fr) and `\"Pips:+\"` (es). The `+` meant \"added\" but read as a typo. | Drop the trailing `+`. |

### Style tokens used
All new CSS pulls from existing tokens — `$c-accent`, `$c-text-primary`, `$c-bad`, `$grad-rule`, `$grad-banner`, `$c-shadow-inset`, `$font-display` — so the dialog now sits in the same visual family as the sheet header / `.create-character` button / chat cards.

### Scope
New partial `scss/components/_dialogs.scss` is scoped to `.od6s.dialog` so we don't bleed into Foundry's generic DialogV2 confirms used elsewhere in the system.

### Regression coverage
New smoke spec `tier-3-roll-dialog-cosmetic.spec.ts` opens the roll dialog and asserts:
- no `class=\"column>\"` typo
- no surviving `<div.center><b>` section pattern
- 2 `.dialog-section` headers (Penalties + Modifiers)
- 4 `.dice-suffix` (one per penalty input)
- no inline color on `.cpcost`
- `.cpcost-{color}` class present
- `.dialog-submit` on the Roll button
- Bonus Pips label has no trailing `+`

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build:css && pnpm run build:ts` — bundles updated
- [x] Container restart picks up template changes
- [x] `tier-3-roll-dialog-cosmetic.spec.ts` — passing
- [x] Full smoke suite — **32/32 passing**
- [ ] Manual: open a skill roll → dialog has visible CP cost, sectioned Penalties/Modifiers with gold rules, gold-accent Roll button, no jagged columns