### PR TITLE
fix: prose-mirror editor fills box so clicks reach contenteditable (#54)

### DIFF
--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -645,9 +645,18 @@
     margin: 2px;
   }
 
-  // Generic prose-mirror editor — give it a panel background
+  // Generic prose-mirror editor — give it a panel background.
+  // Foundry's <prose-mirror> uses an absolutely-positioned toolbar (so
+  // .menu-container reports height 0) plus an .editor-container that
+  // holds the contenteditable .editor-content. Without an explicit flex
+  // chain, .editor-content collapses to its content height (~30px) while
+  // the floating toolbar buttons overlay the rest of the box, intercepting
+  // clicks. Make prose-mirror a flex column and let editor-container /
+  // editor-content fill the available height so the contenteditable
+  // actually receives the click that focuses it.
   prose-mirror {
-    display: block;
+    display: flex;
+    flex-direction: column;
     background: rgba(0, 0, 0, 0.32);
     border: 1px solid $c-border;
     border-radius: 2px;
@@ -655,6 +664,23 @@
     margin-bottom: 8px;
     min-height: 80px;
     padding: 4px;
+
+    .menu-container {
+      flex: 0 0 auto;
+    }
+
+    .editor-container {
+      flex: 1 1 auto;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .editor-content {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+    }
   }
 
   .resource-label {

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -598,12 +598,21 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
 
         const result = await evalInWorld(page, async () => {
             const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
-            // The biography tab is where the actor description prose-mirror lives.
-            (actor as any).tabGroups = {primary: "description"};
-            await actor.sheet.render(true);
+            // bindPrimaryTabs reads tabGroups.primary off the *sheet* app
+            // instance, not the actor document. Set it on the sheet before
+            // first render so the biography tab is the active one and the
+            // description prose-mirrors are visible (non-zero rects).
+            const sheet: any = actor.sheet;
+            (sheet.tabGroups ??= {}).primary = "description";
+            await sheet.render(true);
             await new Promise((r) => setTimeout(r, 400));
 
-            const root = actor.sheet.element as HTMLElement;
+            const root = sheet.element as HTMLElement;
+            // Sanity: confirm the biography tab is actually the active pane.
+            // If not, the rest of the test would silently pass vacuously
+            // because hidden tabs have zero-sized descendants.
+            const activeTab = root.querySelector(".sheet-body > .tab.active") as HTMLElement | null;
+            const activeTabName = activeTab?.dataset.tab ?? null;
             const pms = [...root.querySelectorAll("prose-mirror")] as HTMLElement[];
             const out = pms.map((pm) => {
                 const ec = pm.querySelector(".editor-content") as HTMLElement | null;
@@ -622,13 +631,18 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
                     hitTag: top?.tagName ?? "(none)",
                 };
             });
-            await actor.sheet.close();
-            return out;
+            await sheet.close();
+            return {activeTabName, editors: out};
         });
+
+        // Pin the precondition so a future change to the tab plumbing can't
+        // turn this into a vacuous pass (hidden tabs have zero rects, which
+        // the .height filter would silently drop).
+        expect(result.activeTabName, "biography tab is the active pane").toBe("description");
 
         // Description tab must render at least one prose-mirror with a
         // sized editor-content whose center belongs to the editor.
-        const usable = result.filter((r) => r.hasEditor && r.height && r.height > 0);
+        const usable = result.editors.filter((r) => r.hasEditor && r.height && r.height > 0);
         expect(usable.length, "at least one prose-mirror has a sized editor-content").toBeGreaterThan(0);
         for (const r of usable) {
             expect(r.height, "editor-content fills more than one line").toBeGreaterThan(60);

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -585,6 +585,57 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         }
     });
 
+    test("description prose-mirror contenteditable is reachable to clicks (#54)", async ({page}) => {
+        // Foundry's <prose-mirror> uses an absolutely-positioned toolbar, so
+        // .menu-container has 0 layout height. Without a flex chain the
+        // .editor-content collapses to its content height (~30px) while
+        // floating toolbar buttons overlay the rest of the prose-mirror box,
+        // intercepting clicks meant for the contenteditable area. Assert
+        // that elementFromPoint at the center of .editor-content actually
+        // lands inside .editor-content (and isn't a BUTTON).
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            // The biography tab is where the actor description prose-mirror lives.
+            (actor as any).tabGroups = {primary: "description"};
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 400));
+
+            const root = actor.sheet.element as HTMLElement;
+            const pms = [...root.querySelectorAll("prose-mirror")] as HTMLElement[];
+            const out = pms.map((pm) => {
+                const ec = pm.querySelector(".editor-content") as HTMLElement | null;
+                if (!ec) return {hasEditor: false};
+                const r = ec.getBoundingClientRect();
+                if (r.width === 0 || r.height === 0) {
+                    return {hasEditor: true, height: r.height, hitInside: false, hitTag: "(zero-rect)"};
+                }
+                const cx = r.left + r.width / 2;
+                const cy = r.top + r.height / 2;
+                const top = document.elementFromPoint(cx, cy);
+                return {
+                    hasEditor: true,
+                    height: r.height,
+                    hitInside: !!top && ec.contains(top),
+                    hitTag: top?.tagName ?? "(none)",
+                };
+            });
+            await actor.sheet.close();
+            return out;
+        });
+
+        // Description tab must render at least one prose-mirror with a
+        // sized editor-content whose center belongs to the editor.
+        const usable = result.filter((r) => r.hasEditor && r.height && r.height > 0);
+        expect(usable.length, "at least one prose-mirror has a sized editor-content").toBeGreaterThan(0);
+        for (const r of usable) {
+            expect(r.height, "editor-content fills more than one line").toBeGreaterThan(60);
+            expect(r.hitInside, `clicks land inside editor-content (got ${r.hitTag})`).toBe(true);
+        }
+    });
+
     test("advance dialog submit does not throw on stale event.currentTarget", async ({page}) => {
         // Regression for #42: advanceAction read event.currentTarget.dataset,
         // but the dialog's submit fires async after the click event has been


### PR DESCRIPTION
## Summary
- Foundry's `<prose-mirror>` uses an absolutely-positioned toolbar, so `.menu-container` has 0 layout height. The existing `.sheet-body .editor` rule sized `<prose-mirror>` to 300px but didn't set up an internal flex chain. `.editor-content` collapsed to ~30px (one paragraph's natural height) while floating toolbar buttons overlaid the rest of the box, so clicks meant for the contenteditable landed on `<button>` elements — the field looked active but couldn't be interacted with.
- Closes #54.

## Diagnostic data that pinned this down
With the bug, on a fresh character's biography prose-mirror:
```
pmHasDisabled: false
contentEditable: "true"
pmHeight: "300px"
rect: { h: 30 }                          // editor-content is 30px tall
elementAtCenter: "BUTTON"               // center hit a toolbar button
elementAtCenterIsInsideEditor: false    // not inside .editor-content
```

## Fix
Make `<prose-mirror>` a flex column with `.menu-container` at `flex: 0 0 auto`, `.editor-container` at `flex: 1 1 auto` (itself a flex column with `min-height: 0`), and `.editor-content` at `flex: 1 1 auto; overflow-y: auto`. The contenteditable now fills the visible box.

## Test
New `description prose-mirror contenteditable is reachable to clicks (#54)` in `tier-3-sheet-persistence.spec.ts` — opens an actor sheet on its description tab and runs `elementFromPoint` at the center of every `.editor-content`, asserting the hit element is inside the editor and the box is taller than one line. On the bug, `elementFromPoint` returns a `BUTTON`.

## Test plan
- [x] Manual verification on Firefox / v14 stable: clicks now focus the editor
- [x] CSS rebuild
- [ ] CI smoke runs the new regression spec

## Scope notes
The fix is generic (applies to every `<prose-mirror>` we render), so it should also resolve identical-looking failures on item description fields (weapons, armor, gear, etc.).