### PR TITLE
feat: add + controls for special-abilities tab (#62)

### DIFF
--- a/src/templates/actor/common/tabs/special-abilities.html
+++ b/src/templates/actor/common/tabs/special-abilities.html
@@ -3,8 +3,15 @@
         <div class="row">
             <div class="column">
                 <div>
-                    <div class="flex-group-center">
-                        <b>{{localize 'OD6S.CHAR_ADVANTAGES'}}</b>
+                    <div class="grid title-add-grid">
+                        <div class="flexrow flex-group-center">
+                            <b>{{localize 'OD6S.CHAR_ADVANTAGES'}}</b>
+                        </div>
+                        <div class="flexrow flex-group-center item-controls"
+                             title="{{localize 'OD6S.ADD'}} {{localize 'OD6S.ADVANTAGE'}}">
+                            <a class="item-add" data-type="advantage">
+                                <i class="fas fa-plus"></i></a>
+                        </div>
                     </div>
                     <div>
                         <ul class="advantages-list">
@@ -36,8 +43,15 @@
             </div>
             <div class="column">
                 <div>
-                    <div class="flex-group-center">
-                        <b>{{localize 'OD6S.CHAR_DISADVANTAGES'}}</b>
+                    <div class="grid title-add-grid">
+                        <div class="flexrow flex-group-center">
+                            <b>{{localize 'OD6S.CHAR_DISADVANTAGES'}}</b>
+                        </div>
+                        <div class="flexrow flex-group-center item-controls"
+                             title="{{localize 'OD6S.ADD'}} {{localize 'OD6S.DISADVANTAGE'}}">
+                            <a class="item-add" data-type="disadvantage">
+                                <i class="fas fa-plus"></i></a>
+                        </div>
                     </div>
                 </div>
                 <div>
@@ -73,8 +87,15 @@
     <p></p>
     <div class="row">
         <div class="column">
-            <div class="flex-group-center">
-                <b>{{localize 'OD6S.CHAR_SPECIAL_ABILITIES'}}</b>
+            <div class="grid title-add-grid">
+                <div class="flexrow flex-group-center">
+                    <b>{{localize 'OD6S.CHAR_SPECIAL_ABILITIES'}}</b>
+                </div>
+                <div class="flexrow flex-group-center item-controls"
+                     title="{{localize 'OD6S.ADD'}} {{localize 'OD6S.SPECIAL_ABILITY'}}">
+                    <a class="item-add" data-type="specialability">
+                        <i class="fas fa-plus"></i></a>
+                </div>
             </div>
             <div>
                 <ul class="specialabilities-list">


### PR DESCRIPTION
## Summary
- The special-abilities tab template never rendered `+` buttons. Users could only add advantages/disadvantages/special abilities by dragging from the compendium or a world Item.
- With compendium drag-drop currently broken (#61), this absence became user-blocking — see #62.
- Add `<a class=\"item-add\" data-type=\"...\">` controls next to each list title, matching the Inventory tab pattern. The `.item-add` listener in \`actor/sheet-listeners/inventory.ts:148\` is already wired generically across the sheet, so the existing add-item dialog flow handles these without code changes.

## Honest framing
This is **not a regression** — git history shows the template was committed without these buttons in the very first commit (`683426e`). It's a never-implemented feature whose absence became visible because #61 took away the only working alternative. Filing as `feat:` rather than `fix:` for that reason. Closes #62 either way.

#61 (drag-drop absent) remains the bigger root cause and is the next planned bug.

## UX note
Shown **unconditionally** rather than gated on Free Edit mode (the bug report asked for the latter). Inventory adds aren't gated on Free Edit either, so staying consistent felt like better UX than introducing a one-off pattern.

## Test plan
- [x] Manual: open a character sheet, switch to Special Abilities tab, click each `+` to add a new entry; existing edit/delete controls untouched.
- [ ] CI smoke (no new spec — the existing add-item dialog flow is exercised by other inventory specs and the new buttons just hook into it)