### PR TITLE
fix: actor sheet drop falls through to V2 createEmbeddedDocuments (#61)

### DIFF
--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -147,7 +147,10 @@ export async function onDropItem(sheet: any, event: any, data: any) {
                 sourceActor = game.actors.get(data.actorId);
             }
             if (game.user.isGM || sourceActor!.isOwner) {
-                if (await sheet._onDropItemCreate(itemData)) {
+                // V1 ActorSheet provided _onDropItemCreate; V2 does not.
+                // Inline the equivalent createEmbeddedDocuments call.
+                const created = await sheet.document.createEmbeddedDocuments("Item", [itemData]);
+                if (created?.length) {
                     // @ts-expect-error
                     await sourceActor!.deleteEmbeddedDocuments('Item', [system._id]);
                 }
@@ -155,7 +158,7 @@ export async function onDropItem(sheet: any, event: any, data: any) {
                 ui.notifications.warn('OD6S.WARN_NOT_DELETING_ITEM_OWNER');
             }
         } else {
-            await sheet._onDropItemCreate(itemData);
+            await sheet.document.createEmbeddedDocuments("Item", [itemData]);
         }
     }
     sheet.render();

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -151,8 +151,7 @@ export async function onDropItem(sheet: any, event: any, data: any) {
                 // Inline the equivalent createEmbeddedDocuments call.
                 const created = await sheet.document.createEmbeddedDocuments("Item", [itemData]);
                 if (created?.length) {
-                    // @ts-expect-error
-                    await sourceActor!.deleteEmbeddedDocuments('Item', [system._id]);
+                    await sourceActor!.deleteEmbeddedDocuments('Item', [item.id]);
                 }
             } else {
                 ui.notifications.warn('OD6S.WARN_NOT_DELETING_ITEM_OWNER');


### PR DESCRIPTION
## Summary
- V1 \`ActorSheet\` provided \`_onDropItemCreate\`. \`ActorSheetV2\` does not. Our \`sheet-helpers/drops.ts\` still called \`sheet._onDropItemCreate(itemData)\`, raising \`TypeError\` so every drop onto the actor sheet silently failed — reported as "drag-and-drop produces no discernible result".
- Closes #61.

## Diagnostic
The drop wiring itself was fine — \`ActorSheetV2._dragDrop\` getter auto-binds \`_onDrop\` to the form root in \`super._onRender\`, our \`_onDrop\` override calls \`onDrop(this, event)\`, and \`event.dataTransfer.getData("text/plain")\` parses correctly:
```
⬇ raw drop on form ['text/plain'] text/plain: {"type":"Item","uuid":"Item.…"}
Uncaught TypeError: sheet._onDropItemCreate is not a function
    at onDropItem (drops.ts:158)
```
The failure was the very last step — calling a method that no longer exists on the V2 sheet.

## Fix
Inline the V2 equivalent (`this.document.createEmbeddedDocuments("Item", [itemData])`) for both the same-actor and cross-actor paths. The cross-actor path now checks \`created.length\` before delete, matching the prior intent of the always-truthy \`if (await ...)\`.

## Scope notes
\`drops.ts\` still routes \`data.type === "Folder"\` and \`data.type === "ActiveEffect"\` to V1-only methods (\`_onDropFolder\`, \`_onDropActiveEffect\`) and will throw the same way for those drop types. Tracked separately in #71.

## Test plan
- [x] Manual: drag a world Item onto a character sheet — Item is created, no console error.
- [ ] Manual: drag a compendium Item onto a character sheet (same code path; works once compendium content is present).
- [ ] CI smoke (no new spec — drag-drop in Playwright requires data-transfer plumbing that's worth a follow-up rather than blocking this fix).