### PR TITLE
fix: cargo-hold dialog + V1 Dialog port + sheet header glow-up (#64)

### DIFF
--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -118,11 +118,21 @@
     }
 
     h2.charname {
-      height: 44px;
-      padding: 0;
+      // Reset the h2's own font-size so the input's `font-size: 2.1em`
+      // is relative to the sheet base, not the browser's default h2 size
+      // (~1.5em). With the cascade, the input was resolving to ~50px,
+      // exceeding the box and getting clipped by .sheet-header's
+      // overflow:hidden. Use flex centering so the input sits in the
+      // box regardless of intrinsic height.
+      font-size: 1em;
+      line-height: 1;
+      min-height: 50px;
+      padding: 4px 0 6px;
       margin: 0 0 6px;
       border: none;
       position: relative;
+      display: flex;
+      align-items: center;
 
       &::after {
         content: "";
@@ -136,12 +146,12 @@
 
       input {
         width: 100%;
-        height: 100%;
         margin: 0;
         font-family: $font-display;
         font-size: 2.1em;
         font-weight: 700;
         letter-spacing: 0.04em;
+        line-height: 1.2;
         color: $c-accent;
         background: transparent;
         border: none;

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -24,7 +24,7 @@ export async function addToCrew(actor: Actor, vehicleId: string): Promise<unknow
         };
 
         const addTemplate = "systems/od6s/templates/actor/common/verify-new-crew.html";
-        const html = await renderTemplate(addTemplate, data);
+        const html = await foundry.applications.handlebars.renderTemplate(addTemplate, data);
         const label = game.i18n.localize("OD6S.TRANSFER_VEHICLE");
 
         const confirmed = await foundry.applications.api.DialogV2.confirm({
@@ -281,8 +281,11 @@ export async function onCargoHoldItemCreate(actor: Actor, event: Event): Promise
         return a.localeCompare(b);
     })
 
-    // Render the entity creation form
-    const html = await renderTemplate(template, {
+    // Render the entity creation form. The V1 globals (renderTemplate,
+    // Dialog, FormDataExtended) are deprecated in v13+ and produce the
+    // unstyled grey/white-text dialog reported in #64; route through
+    // the V2 namespaces instead.
+    const html = await foundry.applications.handlebars.renderTemplate(template, {
         name: data.name || game.i18n.format("OD6S.NEW_ITEM", {entity: label}),
         folder: data.folder,
         folders: folders,
@@ -296,20 +299,18 @@ export async function onCargoHoldItemCreate(actor: Actor, event: Event): Promise
         hasTypes: types.length > 1
     });
 
-    // Render the confirmation dialog window
-    return Dialog.prompt({
-        title: title,
+    // DialogV2.input parses the rendered <form>'s named inputs into an
+    // object on submit, and returns null on cancel.
+    const result = await foundry.applications.api.DialogV2.input({
+        window: {title},
         content: html,
-        label: title,
-        callback: html => {
-            const form = html[0].querySelector("form");
-            const fd = new FormDataExtended(form);
-            foundry.utils.mergeObject(data, fd.object);
-            if (!data.folder) delete data["folder"];
-            if (types.length === 1) data.type = types[0];
-            data.name = data.name || game.i18n.localize('OD6S.NEW') + " " + game.i18n.localize(OD6S.itemLabels[data.type]);
-            return actor.createEmbeddedDocuments('Item', [data]);
-        },
-        rejectClose: false
+        ok: {label: title},
     });
+    if (!result) return undefined;
+
+    foundry.utils.mergeObject(data, result);
+    if (!data.folder) delete data["folder"];
+    if (types.length === 1) data.type = types[0];
+    data.name = data.name || game.i18n.localize('OD6S.NEW') + " " + game.i18n.localize(OD6S.itemLabels[data.type]);
+    return actor.createEmbeddedDocuments('Item', [data]);
 }

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -176,7 +176,13 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
                 vehicle_weapons.push(i);
             } else if (i.type === "vehicle-gear") {
                 vehicle_gear.push(i);
-            } else if (i.type === "armor" || i.type === "weapon" || i.type === "gear") {
+            } else if (OD6S.cargo_hold.includes(i.type)) {
+                // Cargo can hold any cargo-eligible type that isn't a
+                // native equipped slot for this actor (vehicle-weapon /
+                // vehicle-gear handled above). Without this catch-all,
+                // items added via the cargo-hold + dialog of types like
+                // starship-weapon / starship-gear are created but never
+                // displayed.
                 cargo_hold.push(i);
             }
         }
@@ -206,7 +212,13 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
                 starship_weapons.push(i);
             } else if (i.type === "starship-gear") {
                 starship_gear.push(i);
-            } else if (i.type === "armor" || i.type === "weapon" || i.type === "gear") {
+            } else if (OD6S.cargo_hold.includes(i.type)) {
+                // Cargo can hold any cargo-eligible type that isn't a
+                // native equipped slot for this actor (starship-weapon /
+                // starship-gear handled above). Without this catch-all,
+                // items added via the cargo-hold + dialog of types like
+                // vehicle-weapon / vehicle-gear are created but never
+                // displayed.
                 cargo_hold.push(i);
             }
         }

--- a/src/module/actor/sheet-helpers/item-crud.ts
+++ b/src/module/actor/sheet-helpers/item-crud.ts
@@ -1,5 +1,8 @@
 import OD6S from "../../config/config-od6s";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
+
 /**
  * Delete an item from the actor, with confirmation dialog.
  */
@@ -27,15 +30,15 @@ export async function deleteItem(sheet: any, ev: Event) {
             const li = ct.closest<HTMLElement>(".item");
             itemId = li?.dataset.itemId;
         }
-        const confirmText = "<p>" + game.i18n.localize("OD6S.DELETE_CONFIRM") + "</p>";
-        await Dialog.prompt({
-            title: game.i18n.localize("OD6S.DELETE"),
-            content: confirmText,
-            callback: async () => {
-                await sheet.document.deleteEmbeddedDocuments('Item', [itemId]);
-                sheet.render(false);
-            }
-        })
+        // V1 Dialog.prompt rendered with the unstyled grey template; use
+        // DialogV2.confirm for the same yes/no shape with the V2 styling.
+        const ok = await foundry.applications.api.DialogV2.confirm({
+            window: {title: game.i18n.localize("OD6S.DELETE")},
+            content: `<p>${game.i18n.localize("OD6S.DELETE_CONFIRM")}</p>`,
+        });
+        if (!ok) return;
+        await sheet.document.deleteEmbeddedDocuments('Item', [itemId]);
+        sheet.render(false);
     } else {
         await sheet.document.deleteEmbeddedDocuments('Item', [ct.dataset.itemId]);
         sheet.render(false);

--- a/src/module/actor/sheet-listeners/scores.ts
+++ b/src/module/actor/sheet-listeners/scores.ts
@@ -6,6 +6,9 @@ import {od6sattributeedit} from "../attribute-edit";
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const foundry: any;
+
 interface DiceScore { dice: number; pips: number }
 
 /**
@@ -115,14 +118,14 @@ export function registerScoreListeners(
     // Roll Body Points
     el.querySelectorAll<HTMLElement>('.rollbodypoints').forEach((elem) =>
         elem.addEventListener('click', async () => {
-            const confirmText = "<p>" + game.i18n.localize("OD6S.CONFIRM_ROLL_BODYPOINTS") + "</p>";
-            await Dialog.prompt({
-                title: game.i18n.localize("OD6S.ROLL") + " " + game.i18n.localize(OD6S.bodyPointsName),
-                content: confirmText,
-                callback: () => {
-                    return sheet._rollBodyPoints();
-                }
-            })
+            // V1 Dialog.prompt rendered with the unstyled grey template;
+            // use DialogV2.confirm for the same yes/no shape with the V2
+            // styling.
+            const ok = await foundry.applications.api.DialogV2.confirm({
+                window: {title: game.i18n.localize("OD6S.ROLL") + " " + game.i18n.localize(OD6S.bodyPointsName)},
+                content: `<p>${game.i18n.localize("OD6S.CONFIRM_ROLL_BODYPOINTS")}</p>`,
+            });
+            if (ok) await sheet._rollBodyPoints();
         }));
 
     // Edit active effect (score-related effects)

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -200,12 +200,14 @@ export class OD6SItem extends Item {
         );
 
         // DialogV2.input parses the rendered <form>'s named inputs into
-        // an object on submit, and returns null on cancel.
+        // an object on submit, and returns null on cancel. Note: the V1
+        // Dialog.prompt forwarded `options` here, but those are
+        // document-create options (renderSheet etc.) that get passed to
+        // this.create below — not dialog config. Don't spread them.
         const result = await foundry.applications.api.DialogV2.input({
             window: {title},
             content: html,
             ok: {label: title},
-            ...options,
         });
         if (!result) return null;
 

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -178,38 +178,42 @@ export class OD6SItem extends Item {
             return a.localeCompare(b);
         })
 
-        // Render the document creation form
-        const html = await renderTemplate("templates/sidebar/document-create.html", {
-            folders,
-            name: (data as any).name || game.i18n.format("DOCUMENT.New", {type: label}),
-            folder: (data as any).folder,
-            hasFolders: folders.length >= 1,
-            type: (data as any).type || CONFIG[documentName]?.defaultType || types[0],
-            types: types.reduce((obj, t) => {
-                const label = CONFIG[documentName]?.typeLabels?.[t] ?? t;
-                (obj as any)[t] = game.i18n.has(label) ? game.i18n.localize(label) : t;
-                return obj;
-            }, {}),
-            hasTypes: types.length > 1
-        });
-
-        // Render the confirmation dialog window
-        return Dialog.prompt({
-            title: title,
-            content: html,
-            label: title,
-            callback: html => {
-                const form = html[0].querySelector("form");
-                const fd = new FormDataExtended(form);
-                foundry.utils.mergeObject(data, fd.object, {inplace: true});
-                if ( !(data as any).folder ) delete (data as any).folder;
-                if ( types.length === 1 ) (data as any).type = types[0];
-                if ( !(data as any).name?.trim() ) (data as any).name = this.defaultName();
-                return this.create(data, {parent, pack, renderSheet: true});
+        // Render the document creation form. The V1 globals
+        // (renderTemplate, Dialog, FormDataExtended) produce the
+        // unstyled grey/white-text dialog; route through the V2
+        // namespaces instead.
+        const html = await foundry.applications.handlebars.renderTemplate(
+            "templates/sidebar/document-create.html",
+            {
+                folders,
+                name: (data as any).name || game.i18n.format("DOCUMENT.New", {type: label}),
+                folder: (data as any).folder,
+                hasFolders: folders.length >= 1,
+                type: (data as any).type || CONFIG[documentName]?.defaultType || types[0],
+                types: types.reduce((obj, t) => {
+                    const label = CONFIG[documentName]?.typeLabels?.[t] ?? t;
+                    (obj as any)[t] = game.i18n.has(label) ? game.i18n.localize(label) : t;
+                    return obj;
+                }, {}),
+                hasTypes: types.length > 1
             },
-            rejectClose: false,
-            options
+        );
+
+        // DialogV2.input parses the rendered <form>'s named inputs into
+        // an object on submit, and returns null on cancel.
+        const result = await foundry.applications.api.DialogV2.input({
+            window: {title},
+            content: html,
+            ok: {label: title},
+            ...options,
         });
+        if (!result) return null;
+
+        foundry.utils.mergeObject(data, result, {inplace: true});
+        if (!(data as any).folder) delete (data as any).folder;
+        if (types.length === 1) (data as any).type = types[0];
+        if (!(data as any).name?.trim()) (data as any).name = this.defaultName();
+        return this.create(data, {parent, pack, renderSheet: true});
     }
 
     /**


### PR DESCRIPTION
## Summary
Three things wrong on the starship/vehicle cargo-hold + button (#64), plus a cascade of related V1→V2 cleanup uncovered along the way.

### 1. Cargo-hold dialog uses V1 globals (the bug as reported)
\`crew-vehicle.ts:onCargoHoldItemCreate\` opened the dialog via deprecated globals (\`renderTemplate\`, \`Dialog.prompt\`, \`FormDataExtended\`). The unstyled grey/white-text dialog shown in #64 was V1 layout, and submit hit the V1 callback path which didn't surface as a save. Port to:
- \`foundry.applications.handlebars.renderTemplate(...)\`
- \`foundry.applications.api.DialogV2.input(...)\` — parses the form into an object on submit, returns \`null\` on cancel.

### 2. cargo_hold prep filter dropped vehicle-* / starship-* items silently
\`_prepareStarshipItems\` / \`_prepareVehicleItems\` only put \`armor / weapon / gear\` into the cargo_hold display. The dialog's allowed-types filter permitted \`vehicle-*\` types on starships (and \`starship-*\` on vehicles), so adding "Vehicle Gear" to a starship cargo created the item but rendered nothing. Broaden the prep filter to use \`OD6S.cargo_hold\` (matching the dialog's allowed list) so cargo-hold display and dialog stay in sync.

### 3. h2.charname clipped by sheet-header overflow
Browser default \`h2 { font-size: 1.5em }\` cascaded through, so the input's \`font-size: 2.1em\` resolved to ~50px instead of the intended ~33.6px and was clipped at the top by \`.sheet-header { overflow: hidden }\`. Reset h2 font-size to \`1em\`, flex-center the input, bump min-height to 50px with padding, and add explicit \`line-height\` for the display font's ascenders.

### 4. Bonus: clear out remaining V1 Dialog call sites
Same migration pattern, no behavior change but matching v14 styling and removing deprecation warnings:
- \`item-crud.ts\` actor item-delete confirm → \`DialogV2.confirm\`
- \`scores.ts\` roll-body-points confirm → \`DialogV2.confirm\`
- \`item.ts:createDialog\` (sidebar Item create dialog) → \`DialogV2.input\`
- \`crew-vehicle.ts:addToCrew\` template render → V2 namespace

A grep for \`Dialog.prompt | new Dialog | new FormDataExtended | bare renderTemplate\` returns clean across \`src/module/\` after this PR.

## Test plan
- [x] Manual: starship cargo-hold + → V2-styled dialog opens; create vehicle-gear → item appears in cargo-hold list; create armor → same.
- [x] Manual: actor item delete → V2 confirm dialog (matches existing template-clear style).
- [x] Manual: starship sheet name input — no top-clipping at default browser h2 sizes.
- [x] \`pnpm run typecheck\` clean.
- [ ] Manual: roll-body-points dialog (when wounds setting enabled).
- [ ] Manual: sidebar Item create dialog.