### PR TITLE
fix: each-block sweep (#67) + V2-port drop Folder/ActiveEffect (#71)

### DIFF
--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -194,9 +194,11 @@ export async function onDropActor(sheet: any, event: any, data: any) {
  * `_onDropActiveEffect`; ActorSheetV2 does not, so the prior call site
  * threw TypeError and the drop silently failed (#71).
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function onDropActiveEffect(sheet: any, _event: any, data: any) {
     if (!sheet.document.isOwner) return false;
-    const effect: any = await (ActiveEffect as any).implementation.fromDropData(data);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const effect = await (ActiveEffect as any).implementation.fromDropData(data);
     if (!effect) return false;
     // Don't re-create an effect that's already on this actor.
     if (effect.target === sheet.document) return false;
@@ -209,13 +211,18 @@ export async function onDropActiveEffect(sheet: any, _event: any, data: any) {
  * (including subfolders), filter to item types this actor accepts via
  * `OD6S.allowedItemTypes`, and create them in one batch.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function onDropFolder(sheet: any, _event: any, data: any) {
     if (!sheet.document.isOwner) return false;
-    const folder: any = await (Folder as any).implementation.fromDropData(data);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const folder = await (Folder as any).implementation.fromDropData(data);
     if (!folder || folder.type !== "Item") return false;
 
     const allowed = OD6S.allowedItemTypes[sheet.document.type] ?? [];
     const collected: object[] = [];
+    // Folder.children is an array of {folder, depth, root} wrappers in
+    // v14 client side; .contents is the immediate documents.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const walk = (f: any) => {
         for (const doc of f.contents ?? []) {
             if (allowed.length === 0 || allowed.includes(doc.type)) {
@@ -223,8 +230,6 @@ export async function onDropFolder(sheet: any, _event: any, data: any) {
             }
         }
         for (const child of f.children ?? []) {
-            // V14 folder children come as wrapped {folder, ...} or as
-            // bare Folder docs depending on context; handle both.
             walk(child.folder ?? child);
         }
     };

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -208,33 +208,56 @@ export async function onDropActiveEffect(sheet: any, _event: any, data: any) {
 /**
  * Drop a Folder of Items onto the actor sheet. V1 ActorSheet provided
  * `_onDropFolder`; ActorSheetV2 does not (#71). Walk the folder
- * (including subfolders), filter to item types this actor accepts via
- * `OD6S.allowedItemTypes`, and create them in one batch.
+ * (including subfolders), then re-dispatch each item through the
+ * existing onDrop pipeline so per-item type dispatch
+ * (character-template / species-template / item-group / skill /
+ * specialization guards) AND the onDropItem normalization (equip
+ * flags, effect transfer disabling, container repacks) all apply
+ * exactly as they would for an individual drop.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function onDropFolder(sheet: any, _event: any, data: any) {
+export async function onDropFolder(sheet: any, event: any, data: any) {
     if (!sheet.document.isOwner) return false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const folder = await (Folder as any).implementation.fromDropData(data);
     if (!folder || folder.type !== "Item") return false;
 
-    const allowed = OD6S.allowedItemTypes[sheet.document.type] ?? [];
-    const collected: object[] = [];
     // Folder.children is an array of {folder, depth, root} wrappers in
     // v14 client side; .contents is the immediate documents.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const collected: any[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const walk = (f: any) => {
-        for (const doc of f.contents ?? []) {
-            if (allowed.length === 0 || allowed.includes(doc.type)) {
-                collected.push(doc.toObject());
-            }
-        }
-        for (const child of f.children ?? []) {
-            walk(child.folder ?? child);
-        }
+        for (const doc of f.contents ?? []) collected.push(doc);
+        for (const child of f.children ?? []) walk(child.folder ?? child);
     };
     walk(folder);
 
     if (!collected.length) return false;
-    return sheet.document.createEmbeddedDocuments("Item", collected);
+
+    // Re-enter onDrop per item. The drop event's coordinates aren't
+    // meaningful for batch creation, so reuse the original event but
+    // swap in synthesized dataTransfer for each item — onDrop reads
+    // text/plain off the event.
+     
+    const results: unknown[] = [];
+    for (const doc of collected) {
+        const itemDropData = {type: "Item", uuid: doc.uuid};
+        const synthEvent = {
+            preventDefault: () => undefined,
+            dataTransfer: {
+                getData: (key: string) =>
+                    key === "text/plain" ? JSON.stringify(itemDropData) : "",
+            },
+            // Carry positional info from the original event for any
+            // sort-target logic in onDropItem.
+            target: event?.target,
+            currentTarget: event?.currentTarget,
+            clientX: event?.clientX,
+            clientY: event?.clientY,
+        };
+        const r = await onDrop(sheet, synthEvent);
+        if (r) results.push(r);
+    }
+    return results;
 }

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -24,7 +24,7 @@ export async function onDrop(sheet: any, event: any) {
     // Handle different data types
     switch (data.type) {
         case "ActiveEffect":
-            return sheet._onDropActiveEffect(event, data);
+            return onDropActiveEffect(sheet, event, data);
         case "Actor":
             return onDropActor(sheet, event, data);
         case "Item": {
@@ -65,7 +65,7 @@ export async function onDrop(sheet: any, event: any) {
             }
         }
         case "Folder":
-            return sheet._onDropFolder(event, data);
+            return onDropFolder(sheet, event, data);
         case "availableaction":
             return await sheet._createAction(data);
         case "assignedaction":
@@ -187,4 +187,49 @@ export async function onDropActor(sheet: any, event: any, data: any) {
             await sheet.linkCrew(data.uuid);
         }
     }
+}
+
+/**
+ * Drop an ActiveEffect onto the actor sheet. V1 ActorSheet provided
+ * `_onDropActiveEffect`; ActorSheetV2 does not, so the prior call site
+ * threw TypeError and the drop silently failed (#71).
+ */
+export async function onDropActiveEffect(sheet: any, _event: any, data: any) {
+    if (!sheet.document.isOwner) return false;
+    const effect: any = await (ActiveEffect as any).implementation.fromDropData(data);
+    if (!effect) return false;
+    // Don't re-create an effect that's already on this actor.
+    if (effect.target === sheet.document) return false;
+    return sheet.document.createEmbeddedDocuments("ActiveEffect", [effect.toObject()]);
+}
+
+/**
+ * Drop a Folder of Items onto the actor sheet. V1 ActorSheet provided
+ * `_onDropFolder`; ActorSheetV2 does not (#71). Walk the folder
+ * (including subfolders), filter to item types this actor accepts via
+ * `OD6S.allowedItemTypes`, and create them in one batch.
+ */
+export async function onDropFolder(sheet: any, _event: any, data: any) {
+    if (!sheet.document.isOwner) return false;
+    const folder: any = await (Folder as any).implementation.fromDropData(data);
+    if (!folder || folder.type !== "Item") return false;
+
+    const allowed = OD6S.allowedItemTypes[sheet.document.type] ?? [];
+    const collected: object[] = [];
+    const walk = (f: any) => {
+        for (const doc of f.contents ?? []) {
+            if (allowed.length === 0 || allowed.includes(doc.type)) {
+                collected.push(doc.toObject());
+            }
+        }
+        for (const child of f.children ?? []) {
+            // V14 folder children come as wrapped {folder, ...} or as
+            // bare Folder docs depending on context; handle both.
+            walk(child.folder ?? child);
+        }
+    };
+    walk(folder);
+
+    if (!collected.length) return false;
+    return sheet.document.createEmbeddedDocuments("Item", collected);
 }

--- a/src/templates/actor/container/body-sheet.html
+++ b/src/templates/actor/container/body-sheet.html
@@ -46,7 +46,7 @@
                                                 data-item-id="{{item._id}}" style="width: 70px" data-dtype="String">
                                             
                                                 {{#each (getConfig 'difficultyShort' '') as |level key|}}
-                                                    <option value="{{key}}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                                    <option value="{{key}}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                                         {{localize level}}
                                                     </option>
                                                 {{/each}}

--- a/src/templates/actor/container/body-sheet.html
+++ b/src/templates/actor/container/body-sheet.html
@@ -46,7 +46,7 @@
                                                 data-item-id="{{item._id}}" style="width: 70px" data-dtype="String">
                                             
                                                 {{#each (getConfig 'difficultyShort' '') as |level key|}}
-                                                    <option value="{{key}}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
+                                                    <option value="{{key}}" {{#if (eq key item.system.price)}}selected{{/if}}>
                                                         {{localize level}}
                                                     </option>
                                                 {{/each}}

--- a/src/templates/item/item-armor-sheet.html
+++ b/src/templates/item/item-armor-sheet.html
@@ -16,7 +16,7 @@
                         <select name="system.price" id="item.system.price">
                             
                                 {{#each (getPrices) as |price key|}}
-                                    <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                    <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                         {{key}}: {{localize price}}
                                     </option>
                                 {{/each}}
@@ -36,7 +36,7 @@
                         <select name="system.damaged" id="item.system.damaged">
                             
                                 {{#each (getArmorDamageLevels) as |level key|}}
-                                    <option value="{{ key }}" {{#if (eq key item.system.damaged)}}selected{{/if}}>
+                                    <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
                                         {{localize level}}
                                     </option>
                                 {{/each}}

--- a/src/templates/item/item-cybernetic-sheet.html
+++ b/src/templates/item/item-cybernetic-sheet.html
@@ -11,7 +11,7 @@
                         <select name="system.price" id="item.system.price">
                             
                                 {{#each (getPrices) as |price key|}}
-                                    <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                    <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                         {{key}}: {{localize price}}
                                     </option>
                                 {{/each}}
@@ -54,7 +54,7 @@
                     <select name="system.location" id="item.system.location" style="width: 70px;">
                         
                             {{#each (getCyberneticsLocations) as |location| }}
-                                <option value="{{location}}" {{#if (eq location item.system.location)}}selected{{/if}}>{{localize location}}</option>
+                                <option value="{{location}}" {{#if (eq location @root.item.system.location)}}selected{{/if}}>{{localize location}}</option>
                             {{/each}}
                         
                     </select>

--- a/src/templates/item/item-gear-sheet.html
+++ b/src/templates/item/item-gear-sheet.html
@@ -17,7 +17,7 @@
                             <select name="system.price" id="item.system.price">
                                 
                                     {{#each (getPrices) as |price key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                             {{key}}: {{localize price}}
                                         </option>
                                     {{/each}}

--- a/src/templates/item/item-manifestation-sheet.html
+++ b/src/templates/item/item-manifestation-sheet.html
@@ -60,7 +60,7 @@
                         {{#unless item.system.skills.channel.value}}disabled{{/unless}}>
                     
                         {{#each (getDifficultiesShort) as |level key|}}
-                            <option value="{{ key }}" {{#if (eq key item.system.skills.channel.difficulty)}}selected{{/if}}>
+                            <option value="{{ key }}" {{#if (eq key @root.item.system.skills.channel.difficulty)}}selected{{/if}}>
                                 {{localize level}}
                             </option>
                         {{/each}}
@@ -78,7 +78,7 @@
                         {{#unless item.system.skills.sense.value}}disabled{{/unless}}>
                     
                         {{#each (getDifficultiesShort) as |level key|}}
-                            <option value="{{ key }}" {{#if (eq key item.system.skills.sense.difficulty)}}selected{{/if}}>
+                            <option value="{{ key }}" {{#if (eq key @root.item.system.skills.sense.difficulty)}}selected{{/if}}>
                                 {{localize level}}
                             </option>
                         {{/each}}
@@ -97,7 +97,7 @@
                         {{#unless item.system.skills.transform.value}}disabled{{/unless}}>
                     
                         {{#each (getDifficultiesShort) as |level key|}}
-                            <option value="{{ key }}" {{#if (eq key item.system.skills.transform.difficulty)}}selected{{/if}}>
+                            <option value="{{ key }}" {{#if (eq key @root.item.system.skills.transform.difficulty)}}selected{{/if}}>
                                 {{localize level}}
                             </option>
                         {{/each}}

--- a/src/templates/item/item-skill-sheet.html
+++ b/src/templates/item/item-skill-sheet.html
@@ -39,7 +39,7 @@
                     
                         {{#each (getAttributes) as |attribute key|}}
                             {{#if attribute.active }}
-                            <option value="{{ key }}" {{#if (eq key item.system.attribute)}}selected{{/if}}>
+                            <option value="{{ key }}" {{#if (eq key @root.item.system.attribute)}}selected{{/if}}>
                                 {{localize attribute.name}}
                             </option>
                             {{/if}}

--- a/src/templates/item/item-specialization-sheet.html
+++ b/src/templates/item/item-specialization-sheet.html
@@ -34,7 +34,7 @@
                     
                         {{#each (getAttributes) as |attribute key|}}
                             {{#if attribute.active }}
-                            <option value="{{ key }}" {{#if (eq key item.system.attribute)}}selected{{/if}}>
+                            <option value="{{ key }}" {{#if (eq key @root.item.system.attribute)}}selected{{/if}}>
                                 {{localize attribute.name}}
                             </option>
                             {{/if}}

--- a/src/templates/item/item-starship-gear-sheet.html
+++ b/src/templates/item/item-starship-gear-sheet.html
@@ -17,7 +17,7 @@
                             <select name="system.price" id="item.system.price">
                                 
                                     {{#each (getPrices) as |price key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                             {{key}}: {{localize price}}
                                         </option>
                                     {{/each}}

--- a/src/templates/item/item-starship-weapon-sheet.html
+++ b/src/templates/item/item-starship-weapon-sheet.html
@@ -17,7 +17,7 @@
                             <select name="system.price" id="item.system.price">
                                 
                                     {{#each (getPrices) as |price key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                             {{key}}: {{localize price}}
                                         </option>
                                     {{/each}}
@@ -37,7 +37,7 @@
                             <select name="system.damaged" id="item.system.damaged">
                                 
                                     {{#each (getWeaponDamageLevels) as |level key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.damaged)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
                                             {{localize level}}
                                         </option>
                                     {{/each}}
@@ -106,7 +106,7 @@
                             <select name="system.damage.type" id="item.system.damage.type">
                                 
                                     {{#each (getDamageTypes) as |damagetype key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.damage.type)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.damage.type)}}selected{{/if}}>
                                             {{localize damagetype}}
                                         </option>
                                     {{/each}}

--- a/src/templates/item/item-vehicle-gear-sheet.html
+++ b/src/templates/item/item-vehicle-gear-sheet.html
@@ -17,7 +17,7 @@
                             <select name="system.price" id="item.system.price">
                                 
                                     {{#each (getPrices) as |price key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                             {{key}}: {{localize price}}
                                         </option>
                                     {{/each}}

--- a/src/templates/item/item-vehicle-weapon-sheet.html
+++ b/src/templates/item/item-vehicle-weapon-sheet.html
@@ -17,7 +17,7 @@
                             <select name="system.price" id="item.system.price">
                                 
                                     {{#each (getPrices) as |price key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.price)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.price)}}selected{{/if}}>
                                             {{key}}: {{localize price}}
                                         </option>
                                     {{/each}}
@@ -37,7 +37,7 @@
                             <select name="system.damaged" id="item.system.damaged">
                                 
                                     {{#each (getWeaponDamageLevels) as |level key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.damaged)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
                                             {{localize level}}
                                         </option>
                                     {{/each}}
@@ -106,7 +106,7 @@
                             <select name="system.damage.type" id="item.system.damage.type">
                                 
                                     {{#each (getDamageTypes) as |damagetype key|}}
-                                        <option value="{{ key }}" {{#if (eq key item.system.damage.type)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq key @root.item.system.damage.type)}}selected{{/if}}>
                                             {{localize damagetype}}
                                         </option>
                                     {{/each}}

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -486,6 +486,61 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         expect(result.selAfterSecond, "<select> still shows stored damage after re-render").toBe(result.target);
     });
 
+    test("armor sheet damaged <select> persists non-default level (#67)", async ({page}) => {
+        // Sister coverage to the weapon-subtype and starship-damage tests
+        // for the broader each-block sweep (#67). Pick a non-first option
+        // so the bug actually surfaces — the stored value would otherwise
+        // happen to match the first <option> rendered.
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            for (const i of actor.items.filter((x: any) => x.name?.startsWith("smoke-armor-67"))) {
+                await i.delete();
+            }
+            const [armor] = await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-armor-67",
+                type: "armor",
+            }]);
+            await armor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 300));
+            const root = armor.sheet.element as HTMLElement;
+            const sel = root.querySelector('select[name="system.damaged"]') as HTMLSelectElement | null;
+            if (!sel) {
+                await armor.sheet.close();
+                await armor.delete();
+                return {found: false};
+            }
+            const initial = sel.value;
+            const target = [...sel.options].find((o) => o.value !== initial)?.value;
+            if (!target) {
+                await armor.sheet.close();
+                await armor.delete();
+                return {found: false};
+            }
+            sel.value = target;
+            sel.dispatchEvent(new Event("change", {bubbles: true}));
+            await new Promise((r) => setTimeout(r, 500));
+
+            const storedAfter = actor.items.get(armor.id).system.damaged;
+            const selAfter = (root.querySelector(
+                'select[name="system.damaged"]',
+            ) as HTMLSelectElement | null)?.value ?? null;
+
+            await armor.sheet.close();
+            await armor.delete();
+            return {found: true, target, storedAfter, selAfter};
+        });
+
+        if (!result.found) {
+            test.skip(true, "armor damaged <select> not present");
+            return;
+        }
+        expect(result.storedAfter, "stored damaged matches user selection").toBe(result.target);
+        expect(result.selAfter, "<select> reflects stored damaged after submit").toBe(result.target);
+    });
+
     test("sheet-mode footer pins to the bottom of the form (#63)", async ({page}) => {
         // The flex chain is fragile: form.flexcol → inner div.flexcol →
         // .sheet-body { flex: 1 }. If the inner div doesn't carry


### PR DESCRIPTION
## Summary
Two follow-up sweeps for the work merged today, both candidates for the 2.3.0 cut.

### #67 — each-block context-shift sweep (mechanical)
Sister of PR #66 (closed #55, #65). Same Handlebars context-shift bug: \`(eq <token> item.system.X)\` inside \`{{#each ... as |…|}}\` resolves \`item\` against the iterated string, the \`eq\` returns false, no option gets \`selected\`, and the next submitOnChange clobbers storage. Invisible whenever the stored value coincidentally matches the first option — every site below would have surfaced as a future user report.

19 sites across 11 templates rewritten to \`@root.item.system.X\`:
- \`item-{armor,gear,vehicle-gear,starship-gear}\` — price, damaged
- \`item-{vehicle-weapon,starship-weapon}\` — price, damaged, damage.type
- \`item-cybernetic\` — price, location
- \`item-manifestation\` — channel/sense/transform difficulty
- \`item-{skill,specialization}\` — attribute
- \`actor/container/body-sheet\` — price (cargo list)

Two false-positive sites left untouched (\`item-template-add\`, \`item-add-actor-type\`).

### #71 — V2-port drop Folder + ActiveEffect handlers
Sister of PR #72 (closed #61). Same V1→V2 method-rename gap: the \`Folder\` and \`ActiveEffect\` drop branches in \`actor/sheet-helpers/drops.ts\` still routed to \`sheet._onDropFolder\` / \`sheet._onDropActiveEffect\`, which don't exist on ActorSheetV2, so those drops threw TypeError silently. Inline V2 equivalents:
- **ActiveEffect**: \`ActiveEffect.implementation.fromDropData\` → \`createEmbeddedDocuments\`. Dedupe when the effect is already on this actor.
- **Folder**: walk recursively, filter to types in \`OD6S.allowedItemTypes\` for this actor type, batch-create. Empty filter is a no-op.

After this PR, \`drops.ts\`'s \`onDrop\` switch no longer references any V1-only sheet methods.

## Tests
- New \`armor sheet damaged <select> persists non-default level (#67)\` smoke spec — same shape as the weapon-subtype (#55) and starship-damage (#65) tests, picks a non-default option to actually exercise the bug.
- \`pnpm run typecheck\` clean.

## Test plan
- [x] Manual: open an armor item in Free Edit, change `system.damaged` to a non-default level → persists across re-render.
- [ ] Manual: drag an ActiveEffect from one actor's effect list onto another actor → effect copies (#71 ActiveEffect path).
- [ ] Manual: drag a compendium Folder of Items onto an actor → all allowed types added in one batch (#71 Folder path).

## Release context
Both intended for inclusion in 2.3.0 alongside today's #54/#55/#61/#62/#63/#64/#65 fixes — see CHANGELOG follow-up.