### PR TITLE
test: cover getWeaponRange branches

### DIFF
--- a/src/module/system/utilities/weapons.test.ts
+++ b/src/module/system/utilities/weapons.test.ts
@@ -39,8 +39,6 @@ describe('getWeaponRange', () => {
     let rollEvaluate: ReturnType<typeof vi.fn>;
     let rollToMessage: ReturnType<typeof vi.fn>;
 
-    const g = globalThis as Record<string, unknown>;
-
     beforeEach(() => {
         warn.mockReset();
         settings.clear();
@@ -52,26 +50,23 @@ describe('getWeaponRange', () => {
         rollEvaluate = vi.fn(async function (this: { total: number }) { this.total = 12; return this; });
         rollToMessage = vi.fn(async () => undefined);
 
-        g.ui = { notifications: { warn } };
-        g.game = {
+        vi.stubGlobal('ui', { notifications: { warn } });
+        vi.stubGlobal('game', {
             i18n: { localize: (k: string) => k },
             settings: { get: (_ns: string, key: string) => settings.get(key) },
             user: { isGM: false },
-        };
-        g.ChatMessage = { getSpeaker: () => ({}) };
-        g.Roll = class {
+        });
+        vi.stubGlobal('ChatMessage', { getSpeaker: () => ({}) });
+        vi.stubGlobal('Roll', class {
             total = 0;
             constructor(public formula: string) {}
             evaluate = rollEvaluate;
             toMessage = rollToMessage;
-        };
+        });
     });
 
     afterEach(() => {
-        delete g.ui;
-        delete g.game;
-        delete g.ChatMessage;
-        delete g.Roll;
+        vi.unstubAllGlobals();
     });
 
     function mockActor(attributes: Record<string, { score: number }>): Actor {

--- a/src/module/system/utilities/weapons.test.ts
+++ b/src/module/system/utilities/weapons.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { getMeleeDamage } from './weapons';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getMeleeDamage, getWeaponRange } from './weapons';
 
 describe('getMeleeDamage', () => {
     it('adds strength damage when weapon has str flag', () => {
@@ -30,5 +30,119 @@ describe('getMeleeDamage', () => {
         const actor = { system: { strengthdamage: { score: '6' } } } as unknown as Actor;
         const weapon = { system: { damage: { str: true, score: '12' } } } as unknown as Item;
         expect(getMeleeDamage(actor, weapon)).toBe(18);
+    });
+});
+
+describe('getWeaponRange', () => {
+    const warn = vi.fn();
+    const settings = new Map<string, unknown>();
+    let rollEvaluate: ReturnType<typeof vi.fn>;
+    let rollToMessage: ReturnType<typeof vi.fn>;
+
+    const g = globalThis as Record<string, unknown>;
+
+    beforeEach(() => {
+        warn.mockReset();
+        settings.clear();
+        // strength_damage truthy so the lift-skill override branch is skipped
+        settings.set('strength_damage', true);
+        settings.set('static_str_range', true);
+        settings.set('hide-gm-rolls', false);
+
+        rollEvaluate = vi.fn(async function (this: { total: number }) { this.total = 12; return this; });
+        rollToMessage = vi.fn(async () => undefined);
+
+        g.ui = { notifications: { warn } };
+        g.game = {
+            i18n: { localize: (k: string) => k },
+            settings: { get: (_ns: string, key: string) => settings.get(key) },
+            user: { isGM: false },
+        };
+        g.ChatMessage = { getSpeaker: () => ({}) };
+        g.Roll = class {
+            total = 0;
+            constructor(public formula: string) {}
+            evaluate = rollEvaluate;
+            toMessage = rollToMessage;
+        };
+    });
+
+    afterEach(() => {
+        delete g.ui;
+        delete g.game;
+        delete g.ChatMessage;
+        delete g.Roll;
+    });
+
+    function mockActor(attributes: Record<string, { score: number }>): Actor {
+        return {
+            items: { find: () => undefined },
+            system: { attributes },
+        } as unknown as Actor;
+    }
+
+    function rangeItem(short: string, medium: string, long: string): Item {
+        return { system: { range: { short, medium, long } } } as unknown as Item;
+    }
+
+    it('returns numeric ranges coerced from all-numeric strings', async () => {
+        const actor = mockActor({ agi: { score: 9 } });
+        const item = rangeItem('5', '10', '20');
+        await expect(getWeaponRange(actor, item)).resolves.toEqual({
+            short: 5,
+            medium: 10,
+            long: 20,
+        });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('resolves attribute-relative ranges in static mode (AGI score 9 → 12 base)', async () => {
+        // pipsPerDice=3, score 9 → 3D+0 → static = 3*4+0 = 12; with offsets: 12, 14, 11
+        const actor = mockActor({ agi: { score: 9 } });
+        const item = rangeItem('AGI', 'AGI+2', 'AGI-1');
+        await expect(getWeaponRange(actor, item)).resolves.toEqual({
+            short: 12,
+            medium: 14,
+            long: 11,
+        });
+    });
+
+    it('resolves a different attribute (STR score 12 → 16 base)', async () => {
+        // score 12 → 4D+0 → static = 4*4+0 = 16
+        const actor = mockActor({ str: { score: 12 } });
+        const item = rangeItem('STR', 'STR+2', 'STR-1');
+        await expect(getWeaponRange(actor, item)).resolves.toEqual({
+            short: 16,
+            medium: 18,
+            long: 15,
+        });
+    });
+
+    it('warns and returns false when attributes differ across short/medium/long', async () => {
+        const actor = mockActor({ agi: { score: 9 }, str: { score: 12 } });
+        const item = rangeItem('AGI', 'STR+2', 'AGI');
+        await expect(getWeaponRange(actor, item)).resolves.toBe(false);
+        expect(warn).toHaveBeenCalledWith('OD6S.WARN_INVALID_RANGE_ATTRIBUTE');
+    });
+
+    it('warns and returns false when range string contains no known attribute', async () => {
+        const actor = mockActor({ agi: { score: 9 } });
+        const item = rangeItem('XYZ+1', '10', '20');
+        await expect(getWeaponRange(actor, item)).resolves.toBe(false);
+        expect(warn).toHaveBeenCalledWith('OD6S.WARN_INVALID_RANGE_ATTRIBUTE');
+    });
+
+    it('uses Roll and posts a chat message when static_str_range is off', async () => {
+        settings.set('static_str_range', false);
+        const actor = mockActor({ agi: { score: 9 } });
+        const item = { ...rangeItem('AGI', 'AGI+2', 'AGI-1'), name: 'Blaster' } as unknown as Item;
+        // mocked roll.total = 12 → with offsets: 12, 14, 11
+        await expect(getWeaponRange(actor, item)).resolves.toEqual({
+            short: 12,
+            medium: 14,
+            long: 11,
+        });
+        expect(rollEvaluate).toHaveBeenCalledTimes(1);
+        expect(rollToMessage).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Summary
- Adds 6 unit tests for `getWeaponRange` covering the branches the function gained in #17 and follow-up cleanup (88f14de).
- Cases: all-numeric coercion, attribute-relative parsing (AGI, STR with offsets), mixed-attribute rejection, unknown-attribute rejection, and static-vs-rolled range modes.
- No source changes — pure test addition. Pins current behavior so future refactors break loudly instead of silently.

Closes #28.

## Test plan
- [x] `pnpm run check` passes (lint 719/720, typecheck clean, 250/250 tests).
- [x] New cases exercise both `static_str_range` branches, including the `Roll` + `toMessage` path via a stubbed global `Roll`.