### PR TITLE
fix: players can't roll off sheet (#76)

### DIFF
--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -211,7 +211,7 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
         }
     }
 
-    let rollMode: any = "roll";
+    let rollMode: any = (CONST as any).DICE_ROLL_MODES.PUBLIC;
     if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
         rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
     }

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -220,9 +220,7 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
         speaker: ChatMessage.getSpeaker({actor: (game as any).actors.find((a: any) => a.id === actor.id)}),
         flavor: label,
         flags: {od6s: flags},
-        rollMode,
-        create: true,
-    });
+    }, {rollMode, create: true});
 
     if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
         const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -211,9 +211,9 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
         }
     }
 
-    let rollMode: any = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+    let rollMode: any = CONST.DICE_ROLL_MODES.PUBLIC;
     if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
-        rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
     }
 
     const rollMessage = await roll.toMessage({

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -704,9 +704,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         await roll.toMessage({
             speaker: ChatMessage.getSpeaker(),
             flavor: label,
-            rollMode,
-            create: true,
-        });
+        }, {rollMode, create: true});
 
         await this.document.update({"system.wounds.body_points.max": roll.total});
     }

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -7,9 +7,9 @@ import OD6SCreateCharacter from "../apps/character-creation";
 
 // Listener modules
 import {registerInventoryListeners} from "./sheet-listeners/inventory";
-import {registerCombatActionListeners} from "./sheet-listeners/combat-actions";
+import {registerCombatActionListeners, registerCombatRollListeners} from "./sheet-listeners/combat-actions";
 import {registerVehicleListeners} from "./sheet-listeners/vehicle";
-import {registerScoreListeners} from "./sheet-listeners/scores";
+import {registerScoreListeners, registerRollListeners} from "./sheet-listeners/scores";
 import {registerEffectListeners} from "./sheet-listeners/effects";
 import {registerDragListeners} from "./sheet-listeners/drag";
 
@@ -252,9 +252,16 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         bindPrimaryTabs(this as any, root);
 
-        if (!this.isEditable) return;
-
+        // Roll triggers must be bound for any owner regardless of edit mode —
+        // V2 sheets render in PLAY mode by default (isEditable === false), but
+        // rolling a skill/attack is a play-mode action. See issue #76.
         const html = [root];
+        if (this.actor.isOwner) {
+            registerRollListeners(html, this);
+            registerCombatRollListeners(html, this);
+        }
+
+        if (!this.isEditable) return;
 
         root.querySelectorAll(".alpha-item-sort-button").forEach((elem) =>
             elem.addEventListener("click", async () => {
@@ -689,7 +696,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         const label = game.i18n.localize("OD6S.ROLLING") + " " + game.i18n.localize(OD6S.bodyPointsName);
 
-        let rollMode: any = 0;
+        let rollMode: any = (CONST as any).DICE_ROLL_MODES.PUBLIC;
         if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
             rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
         }

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -696,9 +696,9 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         const label = game.i18n.localize("OD6S.ROLLING") + " " + game.i18n.localize(OD6S.bodyPointsName);
 
-        let rollMode: any = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+        let rollMode: any = CONST.DICE_ROLL_MODES.PUBLIC;
         if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
-            rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+            rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
         }
         const roll = await new Roll(rollString).evaluate();
         await roll.toMessage({

--- a/src/module/actor/sheet-listeners/combat-actions.ts
+++ b/src/module/actor/sheet-listeners/combat-actions.ts
@@ -1,4 +1,27 @@
 /**
+ * Register the play-mode-safe combat-action roll triggers (combat-action /
+ * vehicle-action click). Bound regardless of `isEditable` so non-edit-mode
+ * sheets can still roll attacks.
+ */
+export function registerCombatRollListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
+    const el = html[0];
+
+    el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            await sheet._rollAvailableAction(ev);
+        }));
+
+    el.querySelectorAll<HTMLElement>('.vehicle-action').forEach((elem: HTMLElement) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            await sheet._rollAvailableVehicleAction(ev);
+        }));
+}
+
+/**
  * Register combat action-related event listeners on the actor sheet.
  */
 export function registerCombatActionListeners(
@@ -17,18 +40,6 @@ export function registerCombatActionListeners(
     el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
         elem.addEventListener('contextmenu', (ev: Event) => {
             sheet._onAvailableActionAdd(ev);
-        }));
-
-    // Roll available action
-    el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
-        elem.addEventListener('click', async (ev: Event) => {
-            await sheet._rollAvailableAction(ev);
-        }));
-
-    // Roll available vehicle action
-    el.querySelectorAll<HTMLElement>('.vehicle-action').forEach((elem: HTMLElement) =>
-        elem.addEventListener('click', async (ev: Event) => {
-            await sheet._rollAvailableVehicleAction(ev);
         }));
 
     // Edit misc action

--- a/src/module/actor/sheet-listeners/scores.ts
+++ b/src/module/actor/sheet-listeners/scores.ts
@@ -35,6 +35,37 @@ function recalcScoreFromInput(
 }
 
 /**
+ * Register the play-mode-safe roll triggers (skill/attribute/spec/init click,
+ * weapon-action click, body-points roll). Bound regardless of `isEditable` —
+ * V2 sheets render in PLAY mode by default, where `isEditable` is false, but
+ * rolling is a play-mode action and must work for any owner.
+ */
+export function registerRollListeners(
+    html: HTMLElement[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sheet: any,
+): void {
+    const el = html[0];
+
+    const rollDialog = new (od6sroll);
+    el.querySelectorAll<HTMLElement>('.rolldialog').forEach((elem) =>
+        elem.addEventListener('click', rollDialog._onRollEvent.bind(sheet)));
+    el.querySelectorAll<HTMLElement>('.initrolldialog').forEach((elem) =>
+        elem.addEventListener('click', od6sInitRoll._onInitRollDialog.bind(sheet) as unknown as EventListener));
+    el.querySelectorAll<HTMLElement>('.actionroll').forEach((elem) =>
+        elem.addEventListener('click', rollDialog._onRollItem.bind(sheet)));
+
+    el.querySelectorAll<HTMLElement>('.rollbodypoints').forEach((elem) =>
+        elem.addEventListener('click', async () => {
+            const ok = await foundry.applications.api.DialogV2.confirm({
+                window: {title: game.i18n.localize("OD6S.ROLL") + " " + game.i18n.localize(OD6S.bodyPointsName)},
+                content: `<p>${game.i18n.localize("OD6S.CONFIRM_ROLL_BODYPOINTS")}</p>`,
+            });
+            if (ok) await sheet._rollBodyPoints();
+        }));
+}
+
+/**
  * Register score-related event listeners (attributes, skills, specializations,
  * advances, funds, toughness, maneuverability, body points, etc.) on the actor sheet.
  */
@@ -44,15 +75,6 @@ export function registerScoreListeners(
     sheet: any,
 ): void {
     const el = html[0];
-
-    // Rollable abilities.
-    const rollDialog = new (od6sroll);
-    el.querySelectorAll<HTMLElement>('.rolldialog').forEach((elem) =>
-        elem.addEventListener('click', rollDialog._onRollEvent.bind(sheet)));
-    el.querySelectorAll<HTMLElement>('.initrolldialog').forEach((elem) =>
-        elem.addEventListener('click', od6sInitRoll._onInitRollDialog.bind(sheet) as unknown as EventListener));
-    el.querySelectorAll<HTMLElement>('.actionroll').forEach((elem) =>
-        elem.addEventListener('click', rollDialog._onRollItem.bind(sheet)));
 
     // Attribute/skill advances
     const advanceDialog = new (od6sadvance);
@@ -113,19 +135,6 @@ export function registerScoreListeners(
             const target = ev.target as HTMLInputElement;
             await sheet.document.setWoundLevelFromBodyPoints(+target.value);
             sheet.render();
-        }));
-
-    // Roll Body Points
-    el.querySelectorAll<HTMLElement>('.rollbodypoints').forEach((elem) =>
-        elem.addEventListener('click', async () => {
-            // V1 Dialog.prompt rendered with the unstyled grey template;
-            // use DialogV2.confirm for the same yes/no shape with the V2
-            // styling.
-            const ok = await foundry.applications.api.DialogV2.confirm({
-                window: {title: game.i18n.localize("OD6S.ROLL") + " " + game.i18n.localize(OD6S.bodyPointsName)},
-                content: `<p>${game.i18n.localize("OD6S.CONFIRM_ROLL_BODYPOINTS")}</p>`,
-            });
-            if (ok) await sheet._rollBodyPoints();
         }));
 
     // Edit active effect (score-related effects)

--- a/src/module/apps/init-roll.ts
+++ b/src/module/apps/init-roll.ts
@@ -96,7 +96,7 @@ export class od6sInitRoll {
         const messageOptions: any = {
             'flags.od6s.canUseCp': true
         };
-        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) messageOptions.rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) messageOptions.rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
         await game.combats.active.rollInitiative(rollData.combatantId, {
             "formula": rollString,
             "messageOptions": messageOptions

--- a/src/module/apps/init-roll.ts
+++ b/src/module/apps/init-roll.ts
@@ -96,7 +96,7 @@ export class od6sInitRoll {
         const messageOptions: any = {
             'flags.od6s.canUseCp': true
         };
-        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) messageOptions.messageMode = "gm";
+        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) messageOptions.rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
         await game.combats.active.rollInitiative(rollData.combatantId, {
             "formula": rollString,
             "messageOptions": messageOptions

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -45,7 +45,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     rollData.isknown = true;
-    let rollMode: string = 'roll';
+    let rollMode: string = (CONST as any).DICE_ROLL_MODES.PUBLIC;
     if (rollData.fatepoint) {
         rollData.dice = (+rollData.originaldice * 2);
         rollData.pips = (+rollData.originalpips * 2);
@@ -439,14 +439,14 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) {
-        rollMode = "gm";
+        rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
     }
     const rollMessage = await roll.toMessage({
             speaker: ChatMessage.getSpeaker({actor: actor}),
             flavor: label,
             flags: {od6s: flags}
         },
-        {messageMode: rollMode, create: true}
+        {rollMode, create: true}
     );
 
     if (flags.wild === true && parseInt(OD6S.wildDieOneDefault) === 2 && parseInt(OD6S.wildDieOneAuto) === 0) {

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -45,7 +45,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     rollData.isknown = true;
-    let rollMode: string = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+    let rollMode: string = CONST.DICE_ROLL_MODES.PUBLIC;
     if (rollData.fatepoint) {
         rollData.dice = (+rollData.originaldice * 2);
         rollData.pips = (+rollData.originalpips * 2);
@@ -439,7 +439,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) {
-        rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
     }
     const rollMessage = await roll.toMessage({
             speaker: ChatMessage.getSpeaker({actor: actor}),

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -218,8 +218,8 @@ export function registerChatLogListeners() {
                 }
             }
 
-            let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
-            if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+            let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
+            if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
 
             const rollMessage = await roll.toMessage({
                 speaker: ChatMessage.getSpeaker({actor: game.actors.find(a => a.id === data.actor)}),

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -218,8 +218,8 @@ export function registerChatLogListeners() {
                 }
             }
 
-            let rollMode = 'roll';
-            if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = "gm";
+            let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+            if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
 
             const rollMessage = await roll.toMessage({
                 speaker: ChatMessage.getSpeaker({actor: game.actors.find(a => a.id === data.actor)}),
@@ -227,8 +227,7 @@ export function registerChatLogListeners() {
                 flags: {
                     od6s: flags
                 },
-                messageMode: rollMode, create: true
-            });
+            }, {rollMode, create: true});
 
             if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
                 const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -189,9 +189,7 @@ async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
         speaker: ChatMessage.getSpeaker(),
         flavor: label,
         flags: {od6s: flags},
-        rollMode,
-        create: true,
-    });
+    }, {rollMode, create: true});
 
     if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
         const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -128,7 +128,7 @@ interface SimpleRollResult {
 async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
     let wild = false;
     let rollString = "";
-    let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+    let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
     let dice = result.dice;
     const pips = result.pips;
     const damageRoll = !!result.damageroll;
@@ -183,7 +183,7 @@ async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
     }
 
     if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
-        rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
     }
     const rollMessage = await roll.toMessage({
         speaker: ChatMessage.getSpeaker(),

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -128,7 +128,7 @@ interface SimpleRollResult {
 async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
     let wild = false;
     let rollString = "";
-    let rollMode = 0;
+    let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
     let dice = result.dice;
     const pips = result.pips;
     const damageRoll = !!result.damageroll;

--- a/src/module/overrides/combat-tracker.ts
+++ b/src/module/overrides/combat-tracker.ts
@@ -14,7 +14,7 @@ export class OD6SCombatTracker extends foundry.applications.sidebar.tabs.CombatT
         }
         const messageOptions: Record<string, unknown> = {};
         if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
-            messageOptions.messageMode = "gm";
+            messageOptions.rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
         }
         return this.viewed.rollInitiative([combatant.id], {messageOptions});
     }

--- a/src/module/overrides/combat-tracker.ts
+++ b/src/module/overrides/combat-tracker.ts
@@ -14,7 +14,7 @@ export class OD6SCombatTracker extends foundry.applications.sidebar.tabs.CombatT
         }
         const messageOptions: Record<string, unknown> = {};
         if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
-            messageOptions.rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+            messageOptions.rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
         }
         return this.viewed.rollInitiative([combatant.id], {messageOptions});
     }

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -155,11 +155,11 @@ export async function detonateExplosives(combat: any): Promise<void> {
             if(typeof(origMessage) !== 'undefined') {
                 const cloneMessage = (origMessage as any).clone(data);
                 await origMessage.unsetFlag('od6s', 'isExplosive');
-                let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+                let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
                 if(origMessage.whisper.length > 0) {
-                    rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+                    rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
                 } else if (origMessage.blind) {
-                    rollMode = (CONST as any).DICE_ROLL_MODES.BLIND;
+                    rollMode = CONST.DICE_ROLL_MODES.BLIND;
                 }
                 await (ChatMessage as any).deleteDocuments([origMessage.id]);
                 cloneMessage.flags.od6s.canUseCp = false;

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -155,15 +155,15 @@ export async function detonateExplosives(combat: any): Promise<void> {
             if(typeof(origMessage) !== 'undefined') {
                 const cloneMessage = (origMessage as any).clone(data);
                 await origMessage.unsetFlag('od6s', 'isExplosive');
-                let rollMode = "public";
+                let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
                 if(origMessage.whisper.length > 0) {
-                    rollMode = "gm";
+                    rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
                 } else if (origMessage.blind) {
-                    rollMode = "blind";
+                    rollMode = (CONST as any).DICE_ROLL_MODES.BLIND;
                 }
                 await (ChatMessage as any).deleteDocuments([origMessage.id]);
                 cloneMessage.flags.od6s.canUseCp = false;
-                cloneMessage.rolls[0].toMessage(cloneMessage, {messageMode: rollMode});
+                cloneMessage.rolls[0].toMessage(cloneMessage, {rollMode});
             }
         }
     }

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -155,11 +155,13 @@ export async function detonateExplosives(combat: any): Promise<void> {
             if(typeof(origMessage) !== 'undefined') {
                 const cloneMessage = (origMessage as any).clone(data);
                 await origMessage.unsetFlag('od6s', 'isExplosive');
+                // Blind rolls also populate `whisper`, so the blind check
+                // must come first or it would never be reached.
                 let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
-                if(origMessage.whisper.length > 0) {
-                    rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
-                } else if (origMessage.blind) {
+                if (origMessage.blind) {
                     rollMode = CONST.DICE_ROLL_MODES.BLIND;
+                } else if (origMessage.whisper.length > 0) {
+                    rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
                 }
                 await (ChatMessage as any).deleteDocuments([origMessage.id]);
                 cloneMessage.flags.od6s.canUseCp = false;

--- a/src/module/system/utilities/weapons.test.ts
+++ b/src/module/system/utilities/weapons.test.ts
@@ -57,6 +57,14 @@ describe('getWeaponRange', () => {
             user: { isGM: false },
         });
         vi.stubGlobal('ChatMessage', { getSpeaker: () => ({}) });
+        vi.stubGlobal('CONST', {
+            DICE_ROLL_MODES: {
+                PUBLIC: 'publicroll',
+                PRIVATE: 'gmroll',
+                BLIND: 'blindroll',
+                SELF: 'selfroll',
+            },
+        });
         vi.stubGlobal('Roll', class {
             total = 0;
             constructor(public formula: string) {}

--- a/src/module/system/utilities/weapons.test.ts
+++ b/src/module/system/utilities/weapons.test.ts
@@ -147,5 +147,28 @@ describe('getWeaponRange', () => {
         });
         expect(rollEvaluate).toHaveBeenCalledTimes(1);
         expect(rollToMessage).toHaveBeenCalledTimes(1);
+        // Pin the v13+ call shape: rollMode and create must be in the
+        // options arg (second), not inside messageData (first). If they
+        // leak back into messageData, Foundry silently ignores them and
+        // the GM hide-rolls setting becomes a no-op (issue #76).
+        const [messageData, options] = rollToMessage.mock.calls[0];
+        expect(messageData).not.toHaveProperty('rollMode');
+        expect(messageData).not.toHaveProperty('create');
+        expect(options).toEqual({rollMode: 'publicroll', create: true});
+    });
+
+    it('uses gmroll mode when GM has hide-gm-rolls enabled', async () => {
+        settings.set('static_str_range', false);
+        settings.set('hide-gm-rolls', true);
+        vi.stubGlobal('game', {
+            i18n: { localize: (k: string) => k },
+            settings: { get: (_ns: string, key: string) => settings.get(key) },
+            user: { isGM: true },
+        });
+        const actor = mockActor({ agi: { score: 9 } });
+        const item = { ...rangeItem('AGI', 'AGI+2', 'AGI-1'), name: 'Blaster' } as unknown as Item;
+        await getWeaponRange(actor, item);
+        const [, options] = rollToMessage.mock.calls[0];
+        expect(options).toEqual({rollMode: 'gmroll', create: true});
     });
 });

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -102,8 +102,8 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
         flags.range = newRanges;
         flags.origRange = range;
         const label = game.i18n.localize('OD6S.RANGE_ROLL') + ": " + item.name;
-        let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
-        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
+        let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
+        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
         await roll.toMessage({
             speaker: ChatMessage.getSpeaker(),
             flavor: label,

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -102,17 +102,15 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
         flags.range = newRanges;
         flags.origRange = range;
         const label = game.i18n.localize('OD6S.RANGE_ROLL') + ": " + item.name;
-        let rollMode = 'roll';
-        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = "gm";
+        let rollMode = (CONST as any).DICE_ROLL_MODES.PUBLIC;
+        if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = (CONST as any).DICE_ROLL_MODES.PRIVATE;
         await roll.toMessage({
             speaker: ChatMessage.getSpeaker(),
             flavor: label,
             flags: {
                 od6s: flags
             },
-            messageMode: rollMode,
-            create: true
-        })
+        }, {rollMode, create: true})
     }
     return newRanges;
 }

--- a/tests/smoke/tier-3-play-mode-roll.spec.ts
+++ b/tests/smoke/tier-3-play-mode-roll.spec.ts
@@ -3,16 +3,22 @@
  *
  * V2 ActorSheets render in PLAY mode by default, where `isEditable` is
  * false. Previously, _onRender early-returned on !isEditable and never
- * bound the .rolldialog click handler — so non-GM players (whose sheets
+ * bound the play-mode roll selectors — so non-GM players (whose sheets
  * default to PLAY mode) silently failed to roll. This spec opens the
- * sheet, forces it into PLAY mode, and verifies clicking a .rolldialog
- * skill row still opens the RollDialog.
+ * sheet, forces PLAY mode, and verifies *each* selector that was moved
+ * above the editability gate still fires its handler.
+ *
+ * Selectors covered: .rolldialog, .actionroll, .combat-action,
+ * .vehicle-action. Each is verified by spying on the corresponding
+ * sheet method and asserting it gets invoked on click — that way a
+ * typo or removed binding in registerRollListeners /
+ * registerCombatRollListeners surfaces here.
  */
 
 import {test, expect} from "@playwright/test";
 import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
 
-test("rolldialog click opens RollDialog while sheet is in PLAY mode", async ({page}) => {
+test("all PLAY-mode roll selectors fire their handlers", async ({page}) => {
     await loginAndWaitReady(page);
 
     await evalInWorld(page, async () => {
@@ -27,6 +33,14 @@ test("rolldialog click opens RollDialog while sheet is in PLAY mode", async ({pa
                 system: {score: 3, attribute: "agi"},
             }]);
         }
+        // Add a weapon so .actionroll renders.
+        if (!actor.items.find((i: any) => i.type === "weapon" && i.name === "smoke-blaster")) {
+            await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-blaster",
+                type: "weapon",
+                system: {damage: {score: 9, type: "p"}, subtype: "rangedattack"},
+            }]);
+        }
     });
 
     const result = await evalInWorld(page, async () => {
@@ -38,47 +52,110 @@ test("rolldialog click opens RollDialog while sheet is in PLAY mode", async ({pa
         try {
             const actor = window.game.actors.find((a: any) => a.name === "smoke-character");
 
-            // Force PLAY mode (the V2 default for non-GM owners).
             const SHEET_MODES = (window.foundry as any).applications.sheets
                 ?.DocumentSheetV2?.SHEET_MODES ?? {PLAY: 1, EDIT: 2};
             actor.sheet._mode = SHEET_MODES.PLAY;
 
-            await actor.sheet.render(true);
+            // Stub the sheet methods that the moved selectors fan out to.
+            // We swap them BEFORE render so the listener bindings capture
+            // our spy instead of the originals.
+            const calls: Record<string, number> = {
+                rolldialog: 0,
+                actionroll: 0,
+                combatAction: 0,
+                vehicleAction: 0,
+            };
+            const sheet = actor.sheet;
+            // .rolldialog goes through od6sroll._onRollEvent → _onRollDialog.
+            // We can intercept at the sheet level by stubbing _onRollDialog
+            // on the global class — but simpler to count via the dialog
+            // appearing (covered by RollDialog assertion below).
+            sheet._rollAvailableAction = async () => { calls.combatAction++; };
+            sheet._rollAvailableVehicleAction = async () => { calls.vehicleAction++; };
+
+            await sheet.render(true);
             await new Promise((r) => setTimeout(r, 300));
 
-            const root = actor.sheet.element as HTMLElement;
-            const isEditable = actor.sheet.isEditable;
+            const root = sheet.element as HTMLElement;
+            const isEditable = sheet.isEditable;
 
-            // Find the .rolldialog element for our skill (any will do — the
-            // bug was that none of them were bound).
-            const rollEl = root.querySelector<HTMLElement>(".rolldialog");
-            const rollElFound = !!rollEl;
+            const present = {
+                rolldialog: !!root.querySelector(".rolldialog"),
+                actionroll: !!root.querySelector(".actionroll"),
+                combatAction: !!root.querySelector(".combat-action"),
+                vehicleAction: !!root.querySelector(".vehicle-action"),
+            };
 
+            // .rolldialog → opens RollDialog
             const apps0 = new Set([...window.foundry.applications.instances.keys()]);
-            rollEl?.click();
+            root.querySelector<HTMLElement>(".rolldialog")?.click();
             await new Promise((r) => setTimeout(r, 400));
-
-            const dlg = [...window.foundry.applications.instances.values()].find(
+            const rollDlg = [...window.foundry.applications.instances.values()].find(
                 (a: any) => !apps0.has(a.id) && a.constructor.name.includes("RollDialog"),
             );
+            if (rollDlg) { try { await (rollDlg as any).close(); } catch { /* ignore */ } }
 
-            if (dlg) { try { await (dlg as any).close(); } catch { /* ignore */ } }
-            try { await actor.sheet.close(); } catch { /* ignore */ }
+            // .actionroll → also opens RollDialog (via _onRollItem → item.roll → _onRollDialog).
+            const apps1 = new Set([...window.foundry.applications.instances.keys()]);
+            root.querySelector<HTMLElement>(".actionroll")?.click();
+            await new Promise((r) => setTimeout(r, 400));
+            const actionDlg = [...window.foundry.applications.instances.values()].find(
+                (a: any) => !apps1.has(a.id) && a.constructor.name.includes("RollDialog"),
+            );
+            if (actionDlg) { try { await (actionDlg as any).close(); } catch { /* ignore */ } }
+
+            // .combat-action → _rollAvailableAction (stubbed)
+            root.querySelector<HTMLElement>(".combat-action")?.click();
+            await new Promise((r) => setTimeout(r, 100));
+
+            // .vehicle-action → _rollAvailableVehicleAction (stubbed)
+            root.querySelector<HTMLElement>(".vehicle-action")?.click();
+            await new Promise((r) => setTimeout(r, 100));
+
+            try { await sheet.close(); } catch { /* ignore */ }
 
             window.removeEventListener("unhandledrejection", onRej);
-            return {isEditable, rollElFound, dialogOpened: !!dlg, errs};
+            return {
+                isEditable,
+                present,
+                rollDialogOpened: !!rollDlg,
+                actionDialogOpened: !!actionDlg,
+                combatActionFired: calls.combatAction,
+                vehicleActionFired: calls.vehicleAction,
+                errs,
+            };
         } catch (e) {
             window.removeEventListener("unhandledrejection", onRej);
             return {
-                isEditable: null, rollElFound: false, dialogOpened: false,
+                isEditable: null,
+                present: {rolldialog: false, actionroll: false, combatAction: false, vehicleAction: false},
+                rollDialogOpened: false,
+                actionDialogOpened: false,
+                combatActionFired: 0,
+                vehicleActionFired: 0,
                 errs: [(e as Error).message],
             };
         }
     });
 
     expect(result.errs, "unhandled rejections").toEqual([]);
-    expect(result.rollElFound, ".rolldialog element rendered").toBe(true);
-    // Confirms we actually exercised the bug path: sheet was non-editable.
     expect(result.isEditable, "sheet was in PLAY mode (isEditable false)").toBe(false);
-    expect(result.dialogOpened, "RollDialog opened from PLAY-mode click").toBe(true);
+
+    // .rolldialog (skills/attributes) — must always be present + bound.
+    expect(result.present.rolldialog, ".rolldialog element rendered").toBe(true);
+    expect(result.rollDialogOpened, ".rolldialog click opened RollDialog").toBe(true);
+
+    // .actionroll (weapon attack) — present because we added a weapon.
+    expect(result.present.actionroll, ".actionroll element rendered").toBe(true);
+    expect(result.actionDialogOpened, ".actionroll click opened RollDialog").toBe(true);
+
+    // .combat-action / .vehicle-action — only verify if rendered. The
+    // template surfaces them only under specific actor configurations,
+    // but if present they must be bound.
+    if (result.present.combatAction) {
+        expect(result.combatActionFired, ".combat-action click invoked _rollAvailableAction").toBeGreaterThan(0);
+    }
+    if (result.present.vehicleAction) {
+        expect(result.vehicleActionFired, ".vehicle-action click invoked _rollAvailableVehicleAction").toBeGreaterThan(0);
+    }
 });

--- a/tests/smoke/tier-3-play-mode-roll.spec.ts
+++ b/tests/smoke/tier-3-play-mode-roll.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Tier 3 — Roll-from-sheet works in PLAY mode (regression for issue #76).
+ *
+ * V2 ActorSheets render in PLAY mode by default, where `isEditable` is
+ * false. Previously, _onRender early-returned on !isEditable and never
+ * bound the .rolldialog click handler — so non-GM players (whose sheets
+ * default to PLAY mode) silently failed to roll. This spec opens the
+ * sheet, forces it into PLAY mode, and verifies clicking a .rolldialog
+ * skill row still opens the RollDialog.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("rolldialog click opens RollDialog while sheet is in PLAY mode", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    await evalInWorld(page, async () => {
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-character");
+        if (!actor) {
+            actor = await window.Actor.create({name: "smoke-character", type: "character"}, {render: false});
+        }
+        if (!actor.items.find((i: any) => i.type === "skill" && i.name === "smoke-skill")) {
+            await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-skill",
+                type: "skill",
+                system: {score: 3, attribute: "agi"},
+            }]);
+        }
+    });
+
+    const result = await evalInWorld(page, async () => {
+        const errs: string[] = [];
+        const onRej = (e: PromiseRejectionEvent) =>
+            errs.push("rej: " + (e.reason?.message ?? String(e.reason)));
+        window.addEventListener("unhandledrejection", onRej);
+
+        try {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-character");
+
+            // Force PLAY mode (the V2 default for non-GM owners).
+            const SHEET_MODES = (window.foundry as any).applications.sheets
+                ?.DocumentSheetV2?.SHEET_MODES ?? {PLAY: 1, EDIT: 2};
+            actor.sheet._mode = SHEET_MODES.PLAY;
+
+            await actor.sheet.render(true);
+            await new Promise((r) => setTimeout(r, 300));
+
+            const root = actor.sheet.element as HTMLElement;
+            const isEditable = actor.sheet.isEditable;
+
+            // Find the .rolldialog element for our skill (any will do — the
+            // bug was that none of them were bound).
+            const rollEl = root.querySelector<HTMLElement>(".rolldialog");
+            const rollElFound = !!rollEl;
+
+            const apps0 = new Set([...window.foundry.applications.instances.keys()]);
+            rollEl?.click();
+            await new Promise((r) => setTimeout(r, 400));
+
+            const dlg = [...window.foundry.applications.instances.values()].find(
+                (a: any) => !apps0.has(a.id) && a.constructor.name.includes("RollDialog"),
+            );
+
+            if (dlg) { try { await (dlg as any).close(); } catch { /* ignore */ } }
+            try { await actor.sheet.close(); } catch { /* ignore */ }
+
+            window.removeEventListener("unhandledrejection", onRej);
+            return {isEditable, rollElFound, dialogOpened: !!dlg, errs};
+        } catch (e) {
+            window.removeEventListener("unhandledrejection", onRej);
+            return {
+                isEditable: null, rollElFound: false, dialogOpened: false,
+                errs: [(e as Error).message],
+            };
+        }
+    });
+
+    expect(result.errs, "unhandled rejections").toEqual([]);
+    expect(result.rollElFound, ".rolldialog element rendered").toBe(true);
+    // Confirms we actually exercised the bug path: sheet was non-editable.
+    expect(result.isEditable, "sheet was in PLAY mode (isEditable false)").toBe(false);
+    expect(result.dialogOpened, "RollDialog opened from PLAY-mode click").toBe(true);
+});


### PR DESCRIPTION
Closes #76.

## Summary
- V2 sheets render in PLAY mode by default (`isEditable === false`); `_onRender` early-returned and never bound `.rolldialog`/`.actionroll`/etc. handlers — so non-GM players silently couldn't roll. Roll triggers extracted into `registerRollListeners` / `registerCombatRollListeners` and bound above the gate, guarded by `actor.isOwner`.
- `roll.toMessage` was passed `messageMode` (unknown option) with values `"roll"` / `"gm"` (invalid in v13+). `CONFIG.Dice.rollModes` lookup returned undefined and crashed on `.handler`. Sweep to `rollMode` + `CONST.DICE_ROLL_MODES.{PUBLIC,PRIVATE,BLIND}` across `roll-execute`, `init-roll`, `chat-log-listeners`, `weapons`, `explosives`, `combat-tracker`, `crew-vehicle`, `macros`.
- Side fix: in `chat-log-listeners` and `weapons` the rollMode/create were inside `messageData` (silently ignored); moved to the options arg so the GM hide-rolls setting is honored as originally intended.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 168/168 unit + domain tests pass
- [ ] `pnpm run test:smoke` — new `tier-3-play-mode-roll.spec.ts` forces PLAY mode and asserts `.rolldialog` click opens `RollDialog`
- [ ] Manual: log in as non-GM player, click a skill on the character sheet — roll dialog opens, submit posts to chat
- [ ] Manual: GM with hide-gm-rolls enabled — rolls are now actually private (previously a no-op in two flows)