### PR TITLE
refactor: drop `as any` casts now covered by Actor augmentation

### DIFF
--- a/src/module/apps/chat-menu.ts
+++ b/src/module/apps/chat-menu.ts
@@ -31,13 +31,15 @@ export class OD6SChat {
                 condition: canApplyCharacterPoint,
                 callback: (li: any) => {
                     const message = game.messages.get(li.attr("data-message-id"));
+                    if (!message) return;
                     let actor;
-                    if (message!.speaker.token) {
-                        actor = game.scenes.viewed.tokens.filter(t => t.id === message!.speaker.token)[0].actor;
+                    if (message.speaker.token) {
+                        actor = game.scenes.viewed?.tokens.filter(t => t.id === message.speaker.token)[0]?.actor;
                     } else {
-                        actor = game.actors.get(message!.speaker.actor);
+                        actor = game.actors.get(message.speaker.actor);
                     }
-                    return actor!.useCharacterPointOnRoll(message!);
+                    if (!actor) return;
+                    return actor.useCharacterPointOnRoll(message);
                 }
             }
         )

--- a/src/module/apps/chat-menu.ts
+++ b/src/module/apps/chat-menu.ts
@@ -37,7 +37,7 @@ export class OD6SChat {
                     } else {
                         actor = game.actors.get(message!.speaker.actor);
                     }
-                    return (actor as any).useCharacterPointOnRoll(message, message!.getRollData());
+                    return actor!.useCharacterPointOnRoll(message!);
                 }
             }
         )

--- a/src/module/hooks/actor-hooks.ts
+++ b/src/module/hooks/actor-hooks.ts
@@ -192,7 +192,7 @@ export function registerActorHooks() {
                     const crewMember = await od6sutilities.getActorFromUuid(document.actor.system.crewmembers[i].uuid);
                     if (crewMember) {
                         try {
-                            crewMember.removeFromCrew(document.actor.uuid);
+                            await crewMember.removeFromCrew(document.actor.uuid);
                         } catch {
                             // Likely the other token was simultaneously deleted
                         }

--- a/src/module/hooks/actor-hooks.ts
+++ b/src/module/hooks/actor-hooks.ts
@@ -11,7 +11,7 @@ export function registerActorHooks() {
                     for (const c in document.system.crewmembers) {
                         const actor = await od6sutilities.getActorFromUuid(document.system.crewmembers[c].uuid);
                         if (!actor) continue;
-                        await (actor as any).removeFromCrew(document.uuid);
+                        await actor.removeFromCrew(document.uuid);
                     }
                 }
             }
@@ -21,7 +21,7 @@ export function registerActorHooks() {
             if (typeof document.system.vehicle.uuid !== 'undefined' && document.system.vehicle.uuid !== '') {
                 if (game.user.isGM) {
                     const vehicle = await od6sutilities.getActorFromUuid(document.system.vehicle.uuid);
-                    if (vehicle) await (vehicle as any).forceRemoveCrewmember(document.uuid);
+                    if (vehicle) await vehicle.forceRemoveCrewmember(document.uuid);
                 }
             }
         }
@@ -192,7 +192,7 @@ export function registerActorHooks() {
                     const crewMember = await od6sutilities.getActorFromUuid(document.actor.system.crewmembers[i].uuid);
                     if (crewMember) {
                         try {
-                            (crewMember as any).removeFromCrew(document.actor.uuid);
+                            crewMember.removeFromCrew(document.actor.uuid);
                         } catch {
                             // Likely the other token was simultaneously deleted
                         }
@@ -204,7 +204,7 @@ export function registerActorHooks() {
                 const vehicle = await od6sutilities.getActorFromUuid(document.actor.getFlag('od6s', 'crew'));
                 if (vehicle) {
                     try {
-                        await (vehicle as any).forceRemoveCrewmember(document.actor.uuid);
+                        await vehicle.forceRemoveCrewmember(document.actor.uuid);
                     } catch {
                         // Likely the other token was simultaneously deleted
                     }


### PR DESCRIPTION
## Summary
- Removes 5 `as any` casts on `Actor` instances at sites whose methods are already declared in `types/od6s.d.ts` (`removeFromCrew`, `forceRemoveCrewmember`, `useCharacterPointOnRoll`).
- Fixes two latent issues that the cast at `chat-menu.ts:40` was hiding: a possibly-undefined `actor` reference and a stale second argument to `useCharacterPointOnRoll(message)`.
- Mechanical-only scope of #56. The remaining cast sites read flat top-level fields (`vehicle_weapons`, `starship_weapons`, `dodge`, `actions`) on a live `Actor` where those fields are never assigned — these look like masked runtime bugs and were spun off into #86 for behavior-level investigation.

Refs #56.

## Test plan
- [x] `pnpm run check` (lint + typecheck + unit + domain) — green
- [ ] Manual: open a vehicle/starship sheet with a crew, delete a crewmember token → confirm `forceRemoveCrewmember` still fires (covers `actor-hooks.ts` paths).
- [ ] Manual: roll on a chat card as a character with CP > 0, use the "use a character point" context-menu option → confirm `useCharacterPointOnRoll` still fires (covers `chat-menu.ts`).