### PR TITLE
refactor: narrow roll-execute via type guards

### DIFF
--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -5,6 +5,7 @@ import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {getDifficulty, applyDifficultyEffects, applyDamageEffects} from "./roll-difficulty";
 import {applyDifficultyModifiers} from "./difficulty-math";
+import {isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem, isWeaponItem} from "../../system/type-guards";
 import type {Modifier} from "./difficulty-math";
 import type {RollData, RollMessageFlags, DiceValue} from "./roll-data";
 import {computeHighHitDamage, computeWildDieReduction, resolveRollMode} from "./roll-execute-math";
@@ -40,8 +41,8 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
 
     let difficulty;
 
-    if (actor.type !== 'vehicle' && actor.type !== 'starship') {
-        strModDice = od6sutilities.getDiceFromScore((rollData.actor.system as OD6SCharacterSystem).strengthdamage.score);
+    if (isCharacterActor(actor)) {
+        strModDice = od6sutilities.getDiceFromScore(actor.system.strengthdamage.score);
     }
 
     rollData.isknown = true;
@@ -106,16 +107,18 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         rollString += "+" + rollData.bonuspips;
     }
 
-    // Apply costs
+    // Apply costs (character points / fate points only exist on character actors)
     const charSys = actor.system as OD6SCharacterSystem;
-    if ((rollData.characterpoints > 0) && (charSys.characterpoints.value > 0)) {
-        doUpdate = true;
-        charSys.characterpoints.value -= rollData.characterpoints;
-    }
+    if (isCharacterActor(actor)) {
+        if ((rollData.characterpoints > 0) && (actor.system.characterpoints.value > 0)) {
+            doUpdate = true;
+            actor.system.characterpoints.value -= rollData.characterpoints;
+        }
 
-    if (rollData.fatepoint && (charSys.fatepoints.value > 0)) {
-        doUpdate = true;
-        charSys.fatepoints.value -= 1;
+        if (rollData.fatepoint && (actor.system.fatepoints.value > 0)) {
+            doUpdate = true;
+            actor.system.fatepoints.value -= 1;
+        }
     }
 
     if (typeof (rollData.target) !== 'undefined') {
@@ -275,44 +278,40 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
 
     if (rollData.itemid) {
         const item = rollData.actor.items.get(rollData.itemid);
+        const hasAttributes = isCharacterActor(rollData.actor) || isVehicleActor(rollData.actor);
         if (typeof (item) !== 'undefined') {
-            if (item.type === 'specialization') {
-                const itemSys = item.system as OD6SSpecializationItemSystem;
-                const skill = rollData.actor.items.find((i: Item) => i.name === itemSys.skill);
-                if (typeof (skill) !== 'undefined' && skill.name !== '') {
-                    const skillSys = skill.system as OD6SSkillItemSystem;
-                    if (skillSys.min === true || String(skillSys.min).toLowerCase() === 'true') {
-                        rollMin = od6sutilities.getDiceFromScore(itemSys.score +
-                            (rollData.actor.system as OD6SCharacterSystem).attributes[itemSys.attribute].score).dice * OD6S.pipsPerDice;
+            if (isSpecializationItem(item)) {
+                const skill = rollData.actor.items.find((i: Item) => i.name === item.system.skill);
+                if (skill !== undefined && skill.name !== '' && isSkillItem(skill) && hasAttributes) {
+                    if (skill.system.min === true || String(skill.system.min).toLowerCase() === 'true') {
+                        rollMin = od6sutilities.getDiceFromScore(item.system.score +
+                            rollData.actor.system.attributes[item.system.attribute].score).dice * OD6S.pipsPerDice;
                     }
                 }
                 if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                     await item.update({'system.used.value': true});
                 }
-            } else if (item.type === "skill") {
-                const itemSys = item.system as OD6SSkillItemSystem;
-                if (itemSys.min === true || String(itemSys.min).toLowerCase() === 'true') {
-                    rollMin = od6sutilities.getDiceFromScore(itemSys.score +
-                        (rollData.actor.system as OD6SCharacterSystem).attributes[itemSys.attribute].score).dice * OD6S.pipsPerDice;
+            } else if (isSkillItem(item)) {
+                if ((item.system.min === true || String(item.system.min).toLowerCase() === 'true') && hasAttributes) {
+                    rollMin = od6sutilities.getDiceFromScore(item.system.score +
+                        rollData.actor.system.attributes[item.system.attribute].score).dice * OD6S.pipsPerDice;
                 }
                 if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                     await item.update({'system.used.value': true});
                 }
-            } else if (item.type === "weapon") {
+            } else if (isWeaponItem(item)) {
                 let found = false;
-                const itemData = item.system as OD6SWeaponItemSystem;
-                if (typeof (itemData.stats.specialization) !== 'undefined' &&
-                    itemData.stats.specialization !== 'null' && itemData.stats.specialization !== '') {
-                    const spec = rollData.actor.items.find((i: Item) => i.type === 'specialization' && i.name === itemData.stats.specialization);
-                    if (typeof (spec) !== 'undefined' && spec.name !== '') {
-                        found = true
-                        const specSys = spec.system as OD6SSpecializationItemSystem;
-                        const skill = rollData.actor.items.find((i: Item) => i.name === specSys.skill);
-                        if (typeof (skill) !== 'undefined' && skill.name !== '') {
-                            const skillSys = skill.system as OD6SSkillItemSystem;
-                            if (skillSys.min === true || String(skillSys.min).toLowerCase() === 'true') {
-                                rollMin = od6sutilities.getDiceFromScore(specSys.score +
-                                    (rollData.actor.system as OD6SCharacterSystem).attributes[skillSys.attribute].score).dice * OD6S.pipsPerDice;
+                const stats = item.system.stats;
+                if (typeof (stats.specialization) !== 'undefined' &&
+                    stats.specialization !== 'null' && stats.specialization !== '') {
+                    const spec = rollData.actor.items.find((i: Item) => i.type === 'specialization' && i.name === stats.specialization);
+                    if (spec !== undefined && spec.name !== '' && isSpecializationItem(spec)) {
+                        found = true;
+                        const skill = rollData.actor.items.find((i: Item) => i.name === spec.system.skill);
+                        if (skill !== undefined && skill.name !== '' && isSkillItem(skill) && hasAttributes) {
+                            if (skill.system.min === true || String(skill.system.min).toLowerCase() === 'true') {
+                                rollMin = od6sutilities.getDiceFromScore(spec.system.score +
+                                    rollData.actor.system.attributes[skill.system.attribute].score).dice * OD6S.pipsPerDice;
                             }
                             if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                                 await spec.update({'system.used.value': true});
@@ -321,14 +320,13 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
                     }
                 }
 
-                if (!found && typeof (itemData.stats.skill) !== 'undefined' &&
-                    itemData.stats.skill !== 'null' && itemData.stats.skill !== '') {
-                    const skill = rollData.actor.items.find((i: Item) => i.name === itemData.stats.skill);
-                    if (typeof (skill) !== 'undefined' && skill.name !== '') {
-                        const skillSys = skill.system as OD6SSkillItemSystem;
-                        if (skillSys.min === true || String(skillSys.min).toLowerCase() === 'true') {
-                            rollMin = od6sutilities.getDiceFromScore(skillSys.score +
-                                (rollData.actor.system as OD6SCharacterSystem).attributes[skillSys.attribute].score).dice * OD6S.pipsPerDice;
+                if (!found && typeof (stats.skill) !== 'undefined' &&
+                    stats.skill !== 'null' && stats.skill !== '') {
+                    const skill = rollData.actor.items.find((i: Item) => i.name === stats.skill);
+                    if (skill !== undefined && skill.name !== '' && isSkillItem(skill) && hasAttributes) {
+                        if (skill.system.min === true || String(skill.system.min).toLowerCase() === 'true') {
+                            rollMin = od6sutilities.getDiceFromScore(skill.system.score +
+                                rollData.actor.system.attributes[skill.system.attribute].score).dice * OD6S.pipsPerDice;
                         }
                         if(OD6S.skillUsed && OD6S.autoSkillUsed) {
                             await skill.update({'system.used.value': true});

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -108,9 +108,8 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     // Apply costs (character points / fate points only exist on character actors)
-    const charSys = actor.system as OD6SCharacterSystem;
     if (isCharacterActor(actor)) {
-        if ((rollData.characterpoints > 0) && (actor.system.characterpoints.value > 0)) {
+        if ((rollData.characterpoints > 0) && (actor.system.characterpoints.value >= rollData.characterpoints)) {
             doUpdate = true;
             actor.system.characterpoints.value -= rollData.characterpoints;
         }
@@ -158,8 +157,8 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         final: difficulty,
     });
 
-    if (rollData.subtype === 'brawlattack') {
-        damageScore = charSys.strengthdamage.score;
+    if (rollData.subtype === 'brawlattack' && isCharacterActor(actor)) {
+        damageScore = actor.system.strengthdamage.score;
         damageType = 'p';
     }
 
@@ -535,21 +534,25 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         }
     }
 
-    if (rollData.subtype === 'dodge' || rollData.subtype === 'parry' || rollData.subtype === 'block') {
+    if ((rollData.subtype === 'dodge' || rollData.subtype === 'parry' || rollData.subtype === 'block')
+        && isCharacterActor(actor)) {
         doUpdate = true;
         if (rollData.fulldefense) {
-            charSys[rollData.subtype].score = (+(flags.total ?? 0) + baseAttackDifficulty);
+            actor.system[rollData.subtype].score = (+(flags.total ?? 0) + baseAttackDifficulty);
         } else {
-            charSys[rollData.subtype].score = +(flags.total ?? 0);
+            actor.system[rollData.subtype].score = +(flags.total ?? 0);
         }
     }
 
     if (rollData.subtype === 'vehicledodge') {
         let vehicle: Actor | null | undefined;
-        if (rollData.actor.type === 'vehicle' || rollData.actor.type === 'starship') {
+        let vehicleUuid: string | undefined;
+        if (isVehicleActor(rollData.actor)) {
             vehicle = rollData.actor;
-        } else {
-            vehicle = await od6sutilities.getActorFromUuid(charSys.vehicle.uuid);
+            vehicleUuid = rollData.actor.uuid;
+        } else if (isCharacterActor(rollData.actor)) {
+            vehicleUuid = rollData.actor.system.vehicle.uuid;
+            vehicle = await od6sutilities.getActorFromUuid(vehicleUuid);
         }
         const dodgeScore = rollData.fulldefense
             ? (+roll.total + baseAttackDifficulty)
@@ -563,19 +566,19 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
 
         if (game.user.isGM) {
             await vehicle?.update(vehicleUpdate);
-        } else {
-            await OD6S.socket.executeAsGM('updateVehicle', charSys.vehicle.uuid, vehicleUpdate);
+        } else if (vehicleUuid) {
+            await OD6S.socket.executeAsGM('updateVehicle', vehicleUuid, vehicleUpdate);
         }
     }
 
-    if (doUpdate) {
+    if (doUpdate && isCharacterActor(actor)) {
         const update = {
             system: {
-                fatepoints: charSys.fatepoints,
-                characterpoints: charSys.characterpoints,
-                dodge: { score: charSys.dodge.score },
-                parry: { score: charSys.parry.score },
-                block: { score: charSys.block.score },
+                fatepoints: actor.system.fatepoints,
+                characterpoints: actor.system.characterpoints,
+                dodge: { score: actor.system.dodge.score },
+                parry: { score: actor.system.parry.score },
+                block: { score: actor.system.block.score },
             },
         };
         await actor.update(update);


### PR DESCRIPTION
## Summary
- Applies the #57 discriminated-union pattern to `roll-execute.ts`, dropping 12 of 13 typed casts (13 → 1).
- Three converted branches: strength-damage, character-points / fate-points cost block, and the skill/spec/weapon item branches inside the `rollData.itemid` block.
- Applies the lesson from #89: skill items can be owned by vehicle/starship actors, so `actor.system.attributes` access uses `isCharacterActor || isVehicleActor`.

## Notes
- The remaining `const charSys = actor.system as OD6SCharacterSystem` covers 8 character-only writes later in the function (dodge/parry/block scores, the final actor.update payload). Restructuring those would mean per-branch guards + a conditional update shape — saved for a follow-up to keep this PR scoped to mechanical conversions.
- Strength-damage block: replaced `actor.type !== 'vehicle' && actor.type !== 'starship'` with `isCharacterActor(actor)`. Strictly safer — excludes container too (which the original would have crashed on, though containers never reach this code path).
- Cost block: previously the cast was unconditional and only worked because `rollData.characterpoints > 0 && …` short-circuited for vehicle rolls. Now properly guarded.

## Test plan
- [x] `pnpm run check` (lint + typecheck + 250 tests) — green
- [ ] Manual: character roll spending CP and FP — confirm both decrement.
- [ ] Manual: vehicle ranged-weapon attack — confirm rollMin calc (skill `min` flag) still applies; covers the `hasAttributes` widening for vehicle-owned skills.
- [ ] Manual: dodge/parry/block reaction roll — confirms the unchanged late-file `charSys` block still works.

Refs #57.