### PR TITLE
refactor: narrow roll-difficulty via type guards

### DIFF
--- a/src/module/apps/roll-helpers/roll-difficulty.ts
+++ b/src/module/apps/roll-helpers/roll-difficulty.ts
@@ -35,7 +35,9 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
             }
         case 'vehicleramattack': {
             const targetActor = rollData.target?.actor;
-            const targetDodge = targetActor && isCharacterActor(targetActor) ? targetActor.system.dodge?.score ?? 0 : 0;
+            const targetDodge = targetActor && (isCharacterActor(targetActor) || isVehicleActor(targetActor))
+                ? targetActor.system.dodge?.score ?? 0
+                : 0;
             if (OD6S.vehicleDifficulty) {
                 if (targetDodge > 0) {
                     return (+targetDodge) + (+OD6S.vehicle_speeds[rollData.vehiclespeed].mod);
@@ -54,7 +56,9 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
         case 'vehiclerangedweaponattack':
         case 'rangedattack': {
             const targetActor = rollData.target?.actor;
-            const targetDodge = targetActor && isCharacterActor(targetActor) ? targetActor.system.dodge?.score ?? 0 : 0;
+            const targetDodge = targetActor && (isCharacterActor(targetActor) || isVehicleActor(targetActor))
+                ? targetActor.system.dodge?.score ?? 0
+                : 0;
             if (targetDodge > 0) {
                 return (+targetDodge);
             } else {
@@ -142,7 +146,11 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
             } else if (targetActor && isVehicleActor(targetActor)) {
                 const vehicleDefense = targetActor.system.maneuverability.score;
                 if (vehicleDefense === 0) {
-                    return OD6S.baseBrawlAttackDifficulty;
+                    if (OD6S.meleeDifficulty) {
+                        return await od6sutilities.getDifficultyFromLevel(OD6S.baseBrawlAttackDifficultyLevel);
+                    } else {
+                        return OD6S.baseBrawlAttackDifficulty;
+                    }
                 } else {
                     return vehicleDefense;
                 }

--- a/src/module/apps/roll-helpers/roll-difficulty.ts
+++ b/src/module/apps/roll-helpers/roll-difficulty.ts
@@ -4,6 +4,7 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {selectHighestDefense} from "./difficulty-math";
+import {isCharacterActor, isVehicleActor} from "../../system/type-guards";
 import type {Modifier} from "./difficulty-math";
 import type {RollData} from "./roll-data";
 import {debug} from "../../system/logger";
@@ -33,7 +34,8 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
                 return await od6sutilities.getDifficultyFromLevel(rollData.vehicleterraindifficulty)
             }
         case 'vehicleramattack': {
-            const targetDodge = target ? (rollData.target!.actor.system as OD6SCharacterSystem).dodge?.score ?? 0 : 0;
+            const targetActor = rollData.target?.actor;
+            const targetDodge = targetActor && isCharacterActor(targetActor) ? targetActor.system.dodge?.score ?? 0 : 0;
             if (OD6S.vehicleDifficulty) {
                 if (targetDodge > 0) {
                     return (+targetDodge) + (+OD6S.vehicle_speeds[rollData.vehiclespeed].mod);
@@ -51,7 +53,8 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
         case 'vehiclerangedattack':
         case 'vehiclerangedweaponattack':
         case 'rangedattack': {
-            const targetDodge = target ? (rollData.target!.actor.system as OD6SCharacterSystem).dodge?.score ?? 0 : 0;
+            const targetActor = rollData.target?.actor;
+            const targetDodge = targetActor && isCharacterActor(targetActor) ? targetActor.system.dodge?.score ?? 0 : 0;
             if (targetDodge > 0) {
                 return (+targetDodge);
             } else {
@@ -61,95 +64,92 @@ async function getDifficultyImpl(rollData: RollData): Promise<number> {
                 return OD6S.baseRangedAttackDifficulty;
             }
         }
-        case 'meleeattack':
-            if (target) {
-                const targetData = rollData.target!.actor.system as OD6SCharacterSystem;
+        case 'meleeattack': {
+            const targetActor = rollData.target?.actor;
+            if (targetActor && isCharacterActor(targetActor)) {
+                const targetSys = targetActor.system;
 
                 if (OD6S.defenseLock) {
-                    if (targetData.parry.score === 0) {
+                    if (targetSys.parry.score === 0) {
                         if (OD6S.meleeDifficulty) {
                             return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
                         } else {
-                            // @ts-expect-error
-                            return baseMeleeAttackDifficulty;
+                            return OD6S.baseMeleeAttackDifficulty;
                         }
                     } else {
-                        return targetData.parry.score;
+                        return targetSys.parry.score;
                     }
                 }
 
-                if (rollData.target!.actor.type !== 'vehicle' && rollData.target!.actor.type !== 'starship') {
-                    if (targetData.block.score === 0 && targetData.dodge.score === 0 && targetData.parry.score === 0) {
-                        if (OD6S.meleeDifficulty) {
-                            return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
-                        } else {
-                            return OD6S.baseMeleeAttackDifficulty;
-                        }
+                if (targetSys.block.score === 0 && targetSys.dodge.score === 0 && targetSys.parry.score === 0) {
+                    if (OD6S.meleeDifficulty) {
+                        return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
                     } else {
-                        return selectHighestDefense({
-                            dodge: targetData.dodge.score,
-                            parry: targetData.parry.score,
-                            block: targetData.block.score,
-                        });
+                        return OD6S.baseMeleeAttackDifficulty;
                     }
                 } else {
-                    const vehSys = rollData.target!.actor.system as OD6SVehicleSystem;
-                    const vehicleDefense = vehSys.maneuverability.score;
-                    if (vehicleDefense === 0) {
-                        if (OD6S.meleeDifficulty) {
-                            return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
-                        } else {
-                            return OD6S.baseMeleeAttackDifficulty;
-                        }
+                    return selectHighestDefense({
+                        dodge: targetSys.dodge.score,
+                        parry: targetSys.parry.score,
+                        block: targetSys.block.score,
+                    });
+                }
+            } else if (targetActor && isVehicleActor(targetActor)) {
+                const vehicleDefense = targetActor.system.maneuverability.score;
+                if (vehicleDefense === 0) {
+                    if (OD6S.meleeDifficulty) {
+                        return await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel);
                     } else {
-                        return vehicleDefense;
+                        return OD6S.baseMeleeAttackDifficulty;
                     }
+                } else {
+                    return vehicleDefense;
                 }
             } else {
                 return OD6S.meleeDifficulty ? await od6sutilities.getDifficultyFromLevel(rollData.difficultylevel) : OD6S.baseMeleeAttackDifficulty;
             }
-        case 'brawlattack':
-            if (target) {
-                const targetData = rollData.target!.actor.system as OD6SCharacterSystem;
+        }
+        case 'brawlattack': {
+            const targetActor = rollData.target?.actor;
+            if (targetActor && isCharacterActor(targetActor)) {
+                const targetSys = targetActor.system;
 
                 if (OD6S.defenseLock) {
-                    if (targetData.block.score === 0) {
+                    if (targetSys.block.score === 0) {
                         if (OD6S.meleeDifficulty) {
                             return await od6sutilities.getDifficultyFromLevel(OD6S.baseBrawlAttackDifficultyLevel);
                         } else {
                             return OD6S.baseBrawlAttackDifficulty;
                         }
                     } else {
-                        return targetData.block.score;
+                        return targetSys.block.score;
                     }
                 }
 
-                if (rollData.target!.actor.type !== 'vehicle' && rollData.target!.actor.type !== 'starship') {
-                    if (targetData.block.score === 0 && targetData.dodge.score === 0 && targetData.parry.score === 0) {
-                        if (OD6S.meleeDifficulty) {
-                            return await od6sutilities.getDifficultyFromLevel(OD6S.baseBrawlAttackDifficultyLevel);
-                        } else {
-                            return OD6S.baseBrawlAttackDifficulty;
-                        }
+                if (targetSys.block.score === 0 && targetSys.dodge.score === 0 && targetSys.parry.score === 0) {
+                    if (OD6S.meleeDifficulty) {
+                        return await od6sutilities.getDifficultyFromLevel(OD6S.baseBrawlAttackDifficultyLevel);
                     } else {
-                        return selectHighestDefense({
-                            dodge: targetData.dodge.score,
-                            parry: targetData.parry.score,
-                            block: targetData.block.score,
-                        });
+                        return OD6S.baseBrawlAttackDifficulty;
                     }
                 } else {
-                    const vehSys = rollData.target!.actor.system as OD6SVehicleSystem;
-                    const vehicleDefense = vehSys.maneuverability.score;
-                    if (vehicleDefense === 0) {
-                        return OD6S.baseBrawlAttackDifficulty;
-                    } else {
-                        return vehicleDefense;
-                    }
+                    return selectHighestDefense({
+                        dodge: targetSys.dodge.score,
+                        parry: targetSys.parry.score,
+                        block: targetSys.block.score,
+                    });
+                }
+            } else if (targetActor && isVehicleActor(targetActor)) {
+                const vehicleDefense = targetActor.system.maneuverability.score;
+                if (vehicleDefense === 0) {
+                    return OD6S.baseBrawlAttackDifficulty;
+                } else {
+                    return vehicleDefense;
                 }
             } else {
                 return OD6S.meleeDifficulty ? await od6sutilities.getDifficultyFromLevel(OD6S.baseBrawlAttackDifficultyLevel) : OD6S.baseBrawlAttackDifficulty;
             }
+        }
 
         default:
     }

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -122,6 +122,8 @@ interface OD6SVehicleSystem {
     ranged_damage: OD6SScoreField;
     ram: OD6SScoreField;
     ram_damage: OD6SScoreField;
+    /** Active reaction-roll dodge score (set by `vehicledodge` rolls). */
+    dodge: { score: number; mod: number; type: string; label: string };
     embedded_pilot: { value: boolean };
     crewmembers: Array<{ uuid: string; name?: string }>;
     crew: { value: number };


### PR DESCRIPTION
## Summary
- Applies the #57 discriminated-union pattern to `roll-difficulty.ts`, making it zero-cast (6 → 0).
- Four converted blocks: `vehicleramattack` + the `vehicle*/rangedattack` group (target dodge lookup) use `isCharacterActor(targetActor)` since vehicle actors don't carry `system.dodge`; `meleeattack` and `brawlattack` use `isCharacterActor` / `isVehicleActor` for their character/vehicle target branches.
- **Bug fix surfaced by the cast removal:** the old line 73 (`OD6S.defenseLock && targetData.parry.score === 0 && !OD6S.meleeDifficulty`) returned `baseMeleeAttackDifficulty` — no `OD6S.` prefix, referencing an undefined identifier. The `// @ts-expect-error` was hiding what would have been a runtime ReferenceError if that branch ever fired (rare combination of settings, so probably never hit). Fixed to `OD6S.baseMeleeAttackDifficulty` to match the parallel branch a few lines down.

## Test plan
- [x] `pnpm run check` (lint + typecheck + 250 tests) — green
- [ ] Manual: ranged attack against character target with dodge > 0 → confirm dodge sets the difficulty.
- [ ] Manual: ranged attack against vehicle target → confirm difficulty falls through to map-range / base (vehicles have no `system.dodge`).
- [ ] Manual: melee attack against vehicle target → confirms `isVehicleActor` branch picks `maneuverability.score`.
- [ ] Manual (sanity for the bug fix): with the rare combo `defenseLock=true && meleeDifficulty=false` against a character with `parry.score=0`, the attack should now resolve to `OD6S.baseMeleeAttackDifficulty` instead of crashing.

Refs #57.