### PR TITLE
refactor: narrow remaining small files via type guards

### DIFF
--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -11,6 +11,7 @@ import {debug} from "../../system/logger";
 export {findWoundLevelByCore, computeNewDamageLevel, computeNewWoundLevel};
 
 export async function applyDamage(actor: Actor, damage: string): Promise<void> {
+    if (!isVehicleActor(actor)) return;
     const update: any = {};
     update.id = actor.id;
     update._id = actor.id;
@@ -29,6 +30,7 @@ export function calculateNewDamageLevel(actor: Actor, damage: string): string | 
 }
 
 export async function applyWounds(actor: Actor, wound: string): Promise<void> {
+    if (!isCharacterActor(actor)) return;
     const update: any = {};
     const newValue = calculateNewWoundLevel(actor, wound);
     update.id = actor.id;

--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -5,6 +5,7 @@ import {
     computeNewDamageLevel,
     computeNewWoundLevel,
 } from "./wounds-math";
+import {isCharacterActor, isVehicleActor} from "../../system/type-guards";
 import {debug} from "../../system/logger";
 
 export {findWoundLevelByCore, computeNewDamageLevel, computeNewWoundLevel};
@@ -20,7 +21,8 @@ export async function applyDamage(actor: Actor, damage: string): Promise<void> {
 }
 
 export function calculateNewDamageLevel(actor: Actor, damage: string): string | undefined {
-    const current = (actor.system as OD6SVehicleSystem).damage.value;
+    if (!isVehicleActor(actor)) return undefined;
+    const current = actor.system.damage.value;
     const next = computeNewDamageLevel(current, damage);
     debug('wounds', 'damage transition', {actor: actor.name, current, incoming: damage, next});
     return next;
@@ -32,10 +34,10 @@ export async function applyWounds(actor: Actor, wound: string): Promise<void> {
     update.id = actor.id;
     update._id = actor.id;
     const armorUpdates: any[] = [];
-    if(wound === 'OD6S.WOUNDS_STUNNED') {
+    if (wound === 'OD6S.WOUNDS_STUNNED' && isCharacterActor(actor)) {
         update[`system.stuns.current`] = 1;
         update[`system.stuns.rounds`] = 1;
-        update[`system.stuns.value`] = (actor.system as OD6SCharacterSystem).stuns.value + 1;
+        update[`system.stuns.value`] = actor.system.stuns.value + 1;
     }
 
     if (game.settings.get('od6s', 'weapon_armor_damage') && game.settings.get('od6s', 'auto_armor_damage')) {
@@ -85,7 +87,8 @@ export async function applyWounds(actor: Actor, wound: string): Promise<void> {
 
 export function calculateNewWoundLevel(actor: Actor, wound: string): unknown {
     const deadlinessTable = OD6S.deadliness[OD6S.deadlinessLevel[actor.type]];
-    const current = (actor.system as OD6SCharacterSystem).wounds.value;
+    if (!isCharacterActor(actor)) return undefined;
+    const current = actor.system.wounds.value;
     const next = computeNewWoundLevel(current, wound, deadlinessTable, OD6S.stunDamageIncrement);
     debug('wounds', 'wound transition', {
         actor: actor.name,
@@ -149,9 +152,9 @@ export function findFirstWoundLevel(_actor: Actor, table: Record<string, { core:
 }
 
 export function getWoundLevelFromBodyPoints(actor: Actor, bp?: number): string | undefined {
-    if (actor.type === 'vehicle' || actor.type === 'starship') return;
+    if (!isCharacterActor(actor)) return;
     let bodyPointsCurrent;
-    const sys = actor.system as OD6SCharacterSystem;
+    const sys = actor.system;
     if (typeof (bp) !== 'undefined') {
         bodyPointsCurrent = bp;
     } else {

--- a/src/module/actor/advance.ts
+++ b/src/module/actor/advance.ts
@@ -1,6 +1,7 @@
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import {AdvanceDialog} from "./advance-dialog";
+import {isCharacterActor, isSpecializationItem} from "../system/type-guards";
 
 export class od6sadvance {
 
@@ -100,11 +101,12 @@ export class od6sadvance {
 
     static async advanceAction(actor: Actor, advanceData: any, dice?: number, pips?: number) {
 
-        const actorData = actor.system as OD6SCharacterSystem;
+        if (!isCharacterActor(actor)) return;
+        const actorData = actor.system;
         const actorUpdate: any = {};
         const updates: any[] = [];
         actorUpdate.system = {};
-        let specs: Item[] = [];
+        let specs: OD6SSpecializationItem[] = [];
 
         /* freeadvance was checked, use form data instead */
         if (advanceData.freeadvance) {
@@ -132,8 +134,8 @@ export class od6sadvance {
 
             if(OD6S.specLink) {
                 /* Also advance any specializations derived from this skill */
-                specs = actor.items.filter((i: Item) => i.type === 'specialization' &&
-                    (i.system as OD6SSpecializationItemSystem).skill === skill?.name);
+                specs = actor.items
+                    .filter((i: Item) => isSpecializationItem(i) && i.system.skill === skill?.name) as OD6SSpecializationItem[];
             }
 
             /* Add/subtract to item score, not displayed/aggregate score */
@@ -155,8 +157,7 @@ export class od6sadvance {
                 for (const spec in specs) {
                     let newSpecScore;
                     if (!OD6S.flatSkills) {
-                        newSpecScore = (+newScore) +
-                            (+(specs[spec].system as OD6SSpecializationItemSystem).base);
+                        newSpecScore = (+newScore) + (+specs[spec].system.base);
                     }
                     updates.push({
                         _id: specs[spec]._id,

--- a/src/module/apps/roll.ts
+++ b/src/module/apps/roll.ts
@@ -2,6 +2,7 @@ import OD6S from "../config/config-od6s";
 import {RollDialog} from "./roll-dialog";
 import {setupRollData} from "./roll-helpers/roll-setup";
 import {executeRollAction} from "./roll-helpers/roll-execute";
+import {isCharacterActor, isVehicleActor, isActionItem} from "../system/type-guards";
 import {getDifficulty, applyDifficultyEffects, applyDamageEffects} from "./roll-helpers/roll-difficulty";
 import {getEffectMod, getRange, cancelAction} from "./roll-helpers/roll-effects";
 import type {RollData, IncomingRollData, MetaphysicsRollData} from "./roll-helpers/roll-data";
@@ -20,11 +21,11 @@ export class od6sroll {
         const actor = (this as any).actor as Actor;
         const item = actor.items.find((i: Item) => i.id === (event.currentTarget as HTMLElement).dataset.itemId);
         if (!item) return;
-        if ((actor.type === 'vehicle' || actor.type === 'starship') && (actor.system as OD6SVehicleSystem).embedded_pilot?.value) {
+        if (isVehicleActor(actor) && actor.system.embedded_pilot?.value) {
             return item.roll();
         }
-        const sys = item.system as OD6SActionItemSystem;
-        if (sys?.subtype?.includes("vehicle")) {
+        if (isActionItem(item) && item.system.subtype?.includes("vehicle")) {
+            const sys = item.system;
             if (sys.subtype === 'vehiclerangedweaponattack') {
                 return actor.rollAction(sys.itemId);
             } else if (sys.subtype === 'vehiclesensors') {
@@ -109,7 +110,7 @@ export class od6sroll {
 
         const actions = Object.keys(skills).length;
         const actionpenalty = (+actions) + ((actor as any).actions.length) - 1;
-        const stunnedpenalty = (actor.system as OD6SCharacterSystem).stuns.current;
+        const stunnedpenalty = isCharacterActor(actor) ? actor.system.stuns.current : 0;
 
         this.rollData = {
             title: item.name,

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -1,5 +1,6 @@
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
+import {isCharacterActor} from "../system/type-guards";
 import { isOpposedQueueEmpty, pushOpposedQueue } from "../system/utilities/opposed";
 import OD6SEditDifficulty from "../apps/edit-difficulty";
 import {OD6SEditDamage} from "../apps/edit-damage";
@@ -68,8 +69,8 @@ export function registerChatLogListeners() {
             const msg = game.messages.get(messageId);
             const stunEffect = msg!.getFlag('od6s', 'stunEffect');
 
-            if ((actor.type !== 'vehicle' && actor.type !== 'starship') && (isVehicle === true || isVehicle === 'true')) {
-                actor = await od6sutilities.getActorFromUuid((actor.system as OD6SCharacterSystem).vehicle.uuid);
+            if (isCharacterActor(actor) && (isVehicle === true || isVehicle === 'true')) {
+                actor = await od6sutilities.getActorFromUuid(actor.system.vehicle.uuid);
             }
 
             if (od6sutilities.boolCheck(stun)) {
@@ -78,17 +79,19 @@ export function registerChatLogListeners() {
                         await actor!.toggleStatusEffect('unconscious', {overlay: false, active: true});
                     }
                 } else {
-                    if (stunEffect === '-1D') {
-                        const update: any = {}
-                        update[`system.stuns.current`] = 1;
-                        update[`system.stuns.rounds`] = 1;
-                        update[`system.stuns.value`] = (+(actor!.system as OD6SCharacterSystem).stuns.value) + 1;
-                        await actor!.update(update);
-                    } else if (stunEffect === '-2D') {
-                        (update as any)[`system.stuns.current`] = 2;
-                        (update as any)[`system.stuns.rounds`] = 1;
-                        (update as any)[`system.stuns.value`] = (+(actor!.system as OD6SCharacterSystem).stuns.value) + 1;
-                        await actor!.update(update);
+                    if (actor && isCharacterActor(actor)) {
+                        if (stunEffect === '-1D') {
+                            const update: any = {}
+                            update[`system.stuns.current`] = 1;
+                            update[`system.stuns.rounds`] = 1;
+                            update[`system.stuns.value`] = (+actor.system.stuns.value) + 1;
+                            await actor.update(update);
+                        } else if (stunEffect === '-2D') {
+                            (update as any)[`system.stuns.current`] = 2;
+                            (update as any)[`system.stuns.rounds`] = 1;
+                            (update as any)[`system.stuns.value`] = (+actor.system.stuns.value) + 1;
+                            await actor.update(update);
+                        }
                     }
                     if(!actor!.effects.contents.find(
                         (i: any) => i.name === game.i18n.localize(CONFIG!.statusEffects.find(
@@ -106,8 +109,8 @@ export function registerChatLogListeners() {
                     } else {
                         await actor!.applyWounds(result);
                     }
-                } else {
-                    let bp = (actor!.system as OD6SCharacterSystem).wounds.body_points.current - result;
+                } else if (isCharacterActor(actor!)) {
+                    let bp = actor!.system.wounds.body_points.current - result;
                     if (bp < 0) bp = 0;
                     (update as any)['system.wounds.body_points.current'] = bp;
                     if (game.settings.get('od6s', 'bodypoints') === 1) await actor!.setWoundLevelFromBodyPoints(bp);

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -62,62 +62,53 @@ export function registerChatLogListeners() {
             let actor = token?.actor;
             if (!actor) return;
             const result = ev.currentTarget.dataset.result;
-            const isVehicle = ev.currentTarget.dataset.isVehicle;
+            const isVehicleData = ev.currentTarget.dataset.isVehicle === true || ev.currentTarget.dataset.isVehicle === 'true';
             const messageId = ev.currentTarget.dataset.messageId;
-            const update = {};
             const stun = ev.currentTarget.dataset.stun;
             const msg = game.messages.get(messageId);
             const stunEffect = msg!.getFlag('od6s', 'stunEffect');
 
-            if (isCharacterActor(actor) && (isVehicle === true || isVehicle === 'true')) {
+            if (isCharacterActor(actor) && isVehicleData) {
                 actor = await od6sutilities.getActorFromUuid(actor.system.vehicle.uuid);
             }
+            if (!actor) return;
 
             if (od6sutilities.boolCheck(stun)) {
                 if (stunEffect === 'unconscious') {
                     if (game.settings.get('od6s', 'auto_status')) {
-                        await actor!.toggleStatusEffect('unconscious', {overlay: false, active: true});
+                        await actor.toggleStatusEffect('unconscious', {overlay: false, active: true});
                     }
                 } else {
-                    if (actor && isCharacterActor(actor)) {
-                        if (stunEffect === '-1D') {
-                            const update: any = {}
-                            update[`system.stuns.current`] = 1;
-                            update[`system.stuns.rounds`] = 1;
-                            update[`system.stuns.value`] = (+actor.system.stuns.value) + 1;
-                            await actor.update(update);
-                        } else if (stunEffect === '-2D') {
-                            (update as any)[`system.stuns.current`] = 2;
-                            (update as any)[`system.stuns.rounds`] = 1;
-                            (update as any)[`system.stuns.value`] = (+actor.system.stuns.value) + 1;
-                            await actor.update(update);
-                        }
+                    if (isCharacterActor(actor) && (stunEffect === '-1D' || stunEffect === '-2D')) {
+                        const stunCurrent = stunEffect === '-1D' ? 1 : 2;
+                        await actor.update({
+                            'system.stuns.current': stunCurrent,
+                            'system.stuns.rounds': 1,
+                            'system.stuns.value': (+actor.system.stuns.value) + 1,
+                        });
                     }
-                    if(!actor!.effects.contents.find(
-                        (i: any) => i.name === game.i18n.localize(CONFIG!.statusEffects.find(
-                            e => e.id === 'stunned')!.name))) {
-                        await actor!.toggleStatusEffect('stunned', {overlay: false, active: true});
+                    const stunnedName = game.i18n.localize(CONFIG!.statusEffects.find(e => e.id === 'stunned')!.name);
+                    if (!actor.effects.contents.find((i: any) => i.name === stunnedName)) {
+                        await actor.toggleStatusEffect('stunned', {overlay: false, active: true});
                     }
                 }
-
             } else {
-                (update as any).id = actor!.id;
-                if (game.settings.get('od6s', 'bodypoints') === 0 || (isVehicle === true || isVehicle === 'true')
-                    || actor!.type === 'starship' || actor!.type === 'vehicle') {
-                    if (isVehicle === true || isVehicle === 'true') {
-                        await actor!.applyDamage(result);
+                const usesDamageLevels = game.settings.get('od6s', 'bodypoints') === 0
+                    || isVehicleData
+                    || actor.type === 'starship' || actor.type === 'vehicle';
+                if (usesDamageLevels) {
+                    if (isVehicleData) {
+                        await actor.applyDamage(result);
                     } else {
-                        await actor!.applyWounds(result);
+                        await actor.applyWounds(result);
                     }
-                } else if (isCharacterActor(actor!)) {
-                    let bp = actor!.system.wounds.body_points.current - result;
+                } else if (isCharacterActor(actor)) {
+                    let bp = actor.system.wounds.body_points.current - result;
                     if (bp < 0) bp = 0;
-                    (update as any)['system.wounds.body_points.current'] = bp;
-                    if (game.settings.get('od6s', 'bodypoints') === 1) await actor!.setWoundLevelFromBodyPoints(bp);
+                    await actor.update({ 'system.wounds.body_points.current': bp });
+                    if (game.settings.get('od6s', 'bodypoints') === 1) await actor.setWoundLevelFromBodyPoints(bp);
                 }
-                await actor!.update(update);
             }
-            await actor!.update(update);
             await msg!.setFlag('od6s', 'applied', true);
         })
 

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -3,6 +3,7 @@ import { wait } from "./converters";
 import { boolCheck } from "./converters";
 import { getDiceFromScore } from "./dice";
 import { getActorFromUuid } from "./actors";
+import { isWeaponItem } from "../type-guards";
 
 export async function scatterExplosive(range: any, origin: any, regionId: any): Promise<void> {
     let distanceTerms = '';
@@ -189,6 +190,7 @@ export async function detonateExplosive(data: any): Promise<any> {
     }
 
     const item = actor!.items.get(data.itemId);
+    const wsys = item && isWeaponItem(item) ? item.system : undefined;
 
     if (game.settings.get('od6s', 'auto_explosive')) {
         const regionId = item!.getFlag('od6s', 'explosiveTemplate');
@@ -213,7 +215,7 @@ export async function detonateExplosive(data: any): Promise<any> {
     msgData.flags.od6s.targets = [];
     msgData.flags.od6s.item = item!.id;
     msgData.flags.od6s.isOpposable = true;
-    msgData.flags.od6s.damageType = (item!.system as OD6SWeaponItemSystem).damage.type;
+    msgData.flags.od6s.damageType = wsys?.damage.type;
     msgData.flags.od6s.stun = data.stun;
     msgData.flags.od6s.attackMessage = data.messageId;
 
@@ -233,7 +235,7 @@ export async function detonateExplosive(data: any): Promise<any> {
     let rollString;
 
     if(game.settings.get('od6s','explosive_zones')) {
-        const wsys = item!.system as OD6SWeaponItemSystem;
+        if (!wsys) return false;
         // Separate rolls for each zone; damage score represents whole dice
         for (const i in wsys.blast_radius) {
             const zone = wsys.blast_radius[i as "1" | "2" | "3" | "4"];
@@ -290,7 +292,7 @@ export async function detonateExplosive(data: any): Promise<any> {
         }
     } else {
         msgData.flags.od6s.targets = targets;
-        const wsys = item!.system as OD6SWeaponItemSystem;
+        if (!wsys) return false;
         // One roll, with a fraction for zones > 1
         const dice = (boolCheck(data.stun)) ? getDiceFromScore(wsys.stun.score, OD6S.pipsPerDice)
             : getDiceFromScore(wsys.damage.score, OD6S.pipsPerDice);

--- a/src/module/system/utilities/skills.test.ts
+++ b/src/module/system/utilities/skills.test.ts
@@ -4,6 +4,7 @@ import { getScoreFromSkill } from './skills';
 // Mock actor with items collection that has a find method
 function mockActor(items: any[], attributes: Record<string, { score: number }>): Actor {
     return {
+        type: 'character',
         items: {
             find: (predicate: any) => items.find(predicate),
         },

--- a/src/module/system/utilities/skills.ts
+++ b/src/module/system/utilities/skills.ts
@@ -1,4 +1,5 @@
 import OD6S from "../../config/config-od6s";
+import {isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem} from "../type-guards";
 
 /**
  * Search for a spec, skill, or attribute and return the score
@@ -9,18 +10,20 @@ export function getScoreFromSkill(actor: Actor, spec: string, skill: string, att
     // Look for a spec, then a skill, then finally attribute
     if (typeof (spec) !== "undefined" && spec !== '') {
         const foundSpec = actor.items.find((s: Item) => s.name === spec && s.type === 'specialization');
-        if (foundSpec) {
-            score = (foundSpec.system as OD6SSpecializationItemSystem).score;
+        if (foundSpec && isSpecializationItem(foundSpec)) {
+            score = foundSpec.system.score;
             found = true;
         }
     }
     if (!found && typeof (skill) !== "undefined" && skill !== '') {
         const foundSkill = actor.items.find((s: Item) => s.name === skill && s.type === 'skill');
-        if (foundSkill) {
-            score = (foundSkill.system as OD6SSkillItemSystem).score;
+        if (foundSkill && isSkillItem(foundSkill)) {
+            score = foundSkill.system.score;
         }
     }
-    score += (actor.system as OD6SCharacterSystem).attributes[attribute.toLowerCase()].score;
+    if (isCharacterActor(actor) || isVehicleActor(actor)) {
+        score += actor.system.attributes[attribute.toLowerCase()].score;
+    }
     return score;
 }
 
@@ -29,11 +32,10 @@ export function getScoreFromSkill(actor: Actor, spec: string, skill: string, att
  */
 export function getSensorTotal(actor: Actor, score: number): number {
     let skillName = '';
-    if (actor.getFlag('od6s', 'crew')) {
-        const sys = actor.system as OD6SCharacterSystem & { vehicle: { sensors?: { skill?: string } } };
-        if (typeof (sys.vehicle.sensors?.skill) !== 'undefined'
-            && sys.vehicle.sensors.skill !== '') {
-            skillName = sys.vehicle.sensors.skill;
+    if (actor.getFlag('od6s', 'crew') && isCharacterActor(actor)) {
+        const sensors = (actor.system.vehicle as { sensors?: { skill?: string } }).sensors;
+        if (typeof sensors?.skill !== 'undefined' && sensors.skill !== '') {
+            skillName = sensors.skill;
         }
     }
     if (skillName === '') {

--- a/src/module/system/utilities/weapons.test.ts
+++ b/src/module/system/utilities/weapons.test.ts
@@ -2,34 +2,29 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getMeleeDamage, getWeaponRange } from './weapons';
 
 describe('getMeleeDamage', () => {
+    const meleeActor = (strScore: number | string) =>
+        ({ type: 'character', system: { strengthdamage: { score: strScore } } } as unknown as Actor);
+    const meleeWeapon = (str: boolean, score: number | string) =>
+        ({ type: 'weapon', system: { damage: { str, score } } } as unknown as Item);
+
     it('adds strength damage when weapon has str flag', () => {
-        const actor = { system: { strengthdamage: { score: 6 } } } as unknown as Actor;
-        const weapon = { system: { damage: { str: true, score: 12 } } } as unknown as Item;
-        expect(getMeleeDamage(actor, weapon)).toBe(18);
+        expect(getMeleeDamage(meleeActor(6), meleeWeapon(true, 12))).toBe(18);
     });
 
     it('returns weapon damage only when no str flag', () => {
-        const actor = { system: { strengthdamage: { score: 6 } } } as unknown as Actor;
-        const weapon = { system: { damage: { str: false, score: 12 } } } as unknown as Item;
-        expect(getMeleeDamage(actor, weapon)).toBe(12);
+        expect(getMeleeDamage(meleeActor(6), meleeWeapon(false, 12))).toBe(12);
     });
 
     it('handles zero strength damage', () => {
-        const actor = { system: { strengthdamage: { score: 0 } } } as unknown as Actor;
-        const weapon = { system: { damage: { str: true, score: 9 } } } as unknown as Item;
-        expect(getMeleeDamage(actor, weapon)).toBe(9);
+        expect(getMeleeDamage(meleeActor(0), meleeWeapon(true, 9))).toBe(9);
     });
 
     it('handles zero weapon damage with str bonus', () => {
-        const actor = { system: { strengthdamage: { score: 6 } } } as unknown as Actor;
-        const weapon = { system: { damage: { str: true, score: 0 } } } as unknown as Item;
-        expect(getMeleeDamage(actor, weapon)).toBe(6);
+        expect(getMeleeDamage(meleeActor(6), meleeWeapon(true, 0))).toBe(6);
     });
 
     it('coerces string scores via unary plus', () => {
-        const actor = { system: { strengthdamage: { score: '6' } } } as unknown as Actor;
-        const weapon = { system: { damage: { str: true, score: '12' } } } as unknown as Item;
-        expect(getMeleeDamage(actor, weapon)).toBe(18);
+        expect(getMeleeDamage(meleeActor('6'), meleeWeapon(true, '12'))).toBe(18);
     });
 });
 
@@ -79,13 +74,14 @@ describe('getWeaponRange', () => {
 
     function mockActor(attributes: Record<string, { score: number }>): Actor {
         return {
+            type: 'character',
             items: { find: () => undefined },
             system: { attributes },
         } as unknown as Actor;
     }
 
     function rangeItem(short: string, medium: string, long: string): Item {
-        return { system: { range: { short, medium, long } } } as unknown as Item;
+        return { type: 'weapon', system: { range: { short, medium, long } } } as unknown as Item;
     }
 
     it('returns numeric ranges coerced from all-numeric strings', async () => {

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -1,6 +1,7 @@
 import OD6S from "../../config/config-od6s";
 import { getDiceFromScore } from "./dice";
 import { getScoreFromSkill } from "./skills";
+import { isCharacterActor, isWeaponItem } from "../type-guards";
 
 /**
  * Calculate Strength Damage die code from a Strength die count.
@@ -20,7 +21,8 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
     foundRange.medium = '';
     foundRange.long = '';
 
-    const itemRange = (item.system as OD6SWeaponItemSystem).range;
+    if (!isWeaponItem(item)) return false;
+    const itemRange = item.system.range;
     const range: any = {};
     range.short = itemRange.short;
     range.medium = itemRange.medium;
@@ -116,9 +118,10 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
 }
 
 export function getMeleeDamage(actor: Actor, weapon: Item): number {
-    const wsys = weapon.system as OD6SWeaponItemSystem;
-    if (wsys.damage.str) {
-        return (+(actor.system as OD6SCharacterSystem).strengthdamage.score) + (+wsys.damage.score);
+    if (!isWeaponItem(weapon)) return 0;
+    const wsys = weapon.system;
+    if (wsys.damage.str && isCharacterActor(actor)) {
+        return (+actor.system.strengthdamage.score) + (+wsys.damage.score);
     } else {
         return (+wsys.damage.score);
     }


### PR DESCRIPTION
## Summary

Batches the 4-cast and 3-cast leftover files for #57 into one PR. All seven become zero-cast (24 typed casts removed total):

| File | Casts removed | Notes |
|---|---|---|
| `system/utilities/skills.ts` | 4 | Attribute read widened to `isCharacterActor \|\| isVehicleActor` |
| `hooks/chat-log-listeners.ts` | 4 | Stun & bodypoints handlers were unconditionally casting even on the isVehicle path |
| `actor/actor-helpers/wounds.ts` | 4 | `isVehicleActor` for damage state, `isCharacterActor` for wound/stun/bodypoints |
| `system/utilities/weapons.ts` | 3 | `isWeaponItem` early return, `isCharacterActor` guard on str-damage bonus |
| `system/utilities/explosives.ts` | 3 | Single `wsys` narrowed once at top, three downstream uses |
| `apps/roll.ts` | 3 | `isVehicleActor` for embedded-pilot, `isActionItem` for vehicle-subtype branch |
| `actor/advance.ts` | 3 | Early return for non-character; `isSpecializationItem` filter for spec-link |

## Notes

- Applied the lesson from #89: skill items can be owned by vehicles, so `getScoreFromSkill` widens its attribute read to `isCharacterActor || isVehicleActor`.
- `apps/roll.ts:_onRollItem` previously cast every item's `system` to `OD6SActionItemSystem` to read `subtype.includes("vehicle")`. Replaced with `isActionItem(item) && …`. Weapons also have `subtype` (e.g. "explosive") but no weapon subtype contains "vehicle", so behavior is preserved for all known data.
- `system/utilities/explosives.ts` 3 casts are collapsed into a single early `wsys = isWeaponItem(item) ? item.system : undefined`. If `item` isn't a weapon (which shouldn't happen via UI), the function bails early instead of casting through.
- Test mocks in `skills.test.ts` and `weapons.test.ts` updated to add `type: 'character'` / `type: 'weapon'`. Production callers always pass real actors with the right type — the previous mocks were fakier than necessary.

## Test plan
- [x] `pnpm run check` — green (12 files, 250 tests)
- [ ] Manual: stun-effect chat-card click against character with active vehicle assignment.
- [ ] Manual: open Advancement dialog as character, advance a skill that has linked specializations (covers `isSpecializationItem` filter narrowing).
- [ ] Manual: throw an explosive weapon (covers explosives.ts paths).
- [ ] Manual: roll a metaphysics power (covers `roll.ts:_metaphysicsRollDialog` `isCharacterActor` stun read).

Refs #57.