### PR TITLE
refactor: narrow remaining small-cast files via type guards

### DIFF
--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -1,5 +1,6 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
+import {isVehicleActor} from "../../system/type-guards";
 
 export async function addEmbeddedPilot(actor: Actor, pilotActor: Actor): Promise<void> {
     /* Copy attributes and items to vehicle */
@@ -72,7 +73,8 @@ export async function removeFromCrew(actor: Actor, vehicleID: string): Promise<v
 }
 
 export async function forceRemoveCrewmember(actor: Actor, crewID: string): Promise<void> {
-    const crewMembers = (actor.system as OD6SVehicleSystem).crewmembers.filter((e) => e.uuid !== crewID);
+    if (!isVehicleActor(actor)) return;
+    const crewMembers = actor.system.crewmembers.filter((e) => e.uuid !== crewID);
     const update: any = {};
     update.system = {};
     update.system.crewmembers = crewMembers;
@@ -84,8 +86,12 @@ export function isCrewMember(actor: Actor): boolean {
 }
 
 export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void> {
+    if (!isVehicleActor(actor)) return;
     const data: any = {};
-    const sys = actor.system as OD6SVehicleSystem & Record<string, any>;
+    // OD6SVehicleSystem augmentation lacks the runtime-defined `attribute`,
+    // `skill`, `specialization` fields from vehicle-common.ts schema; keep
+    // a Record fallback until that gap is closed.
+    const sys = actor.system as typeof actor.system & Record<string, any>;
     data.uuid = actor.uuid;
     data.name = actor.name;
     data.type = actor.type;

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -1,6 +1,7 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {onDropCharacterTemplate, onDropItemGroup, onDropSpeciesTemplate} from "./templates";
+import {isSkillItem, isSpecializationItem} from "../../system/type-guards";
 
 /**
  * Override for the _onDrop handler.
@@ -37,7 +38,8 @@ export async function onDrop(sheet: any, event: any) {
                 case "species-template":
                     return onDropSpeciesTemplate(sheet, event, item, data);
                 case "skill": {
-                    const sys = item.system as OD6SSkillItemSystem;
+                    if (!isSkillItem(item)) return;
+                    const sys = item.system;
                     if (typeof (sys.attribute) === 'undefined' || sys.attribute === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_ATTRIBUTE'))
                         return;
@@ -46,7 +48,8 @@ export async function onDrop(sheet: any, event: any) {
                     }
                 }
                 case "specialization": {
-                    const sys = item.system as OD6SSpecializationItemSystem;
+                    if (!isSpecializationItem(item)) return;
+                    const sys = item.system;
                     if (typeof (sys.attribute) === 'undefined' || sys.attribute === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_ATTRIBUTE'))
                         return;

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -53,10 +53,10 @@ export async function onDrop(sheet: any, event: any) {
                     if (typeof (sys.attribute) === 'undefined' || sys.attribute === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_ATTRIBUTE'))
                         return;
-                    } else if (typeof (sys.attribute) === 'undefined' || sys.skill === '') {
+                    } else if (typeof (sys.skill) === 'undefined' || sys.skill === '') {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_SKILL'))
                         return;
-                    } else if (!(actor.items.find((i: any) => i.type === 'specialization' && i.name === item.name))) {
+                    } else if (!(actor.items.find((i: Item) => i.type === 'skill' && i.name === sys.skill))) {
                         ui.notifications.warn(game.i18n.localize('OD6S.DOES_NOT_POSSESS_SKILL'));
                         return;
                     } else {

--- a/src/module/actor/sheet-helpers/item-crud.ts
+++ b/src/module/actor/sheet-helpers/item-crud.ts
@@ -1,4 +1,5 @@
 import OD6S from "../../config/config-od6s";
+import {isSkillItem} from "../../system/type-guards";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
@@ -76,10 +77,10 @@ export async function addItem(
     const cEntries = od6sutilities.getItemsFromCompendiumByType(data.type);
 
     if (data.type === 'skill') {
-        worldItems = worldItems.filter((i: Item) => (i.system as OD6SSkillItemSystem).attribute === data.attrname);
+        worldItems = worldItems.filter((i: Item) => isSkillItem(i) && i.system.attribute === data.attrname);
         for (const i of cEntries) {
             const item = await od6sutilities._getItemFromCompendium((i as Item).name);
-            if (item && (item.system as OD6SSkillItemSystem).attribute === data.attrname) {
+            if (item && isSkillItem(item) && item.system.attribute === data.attrname) {
                 compendiumItems.push(item);
             }
         }

--- a/src/module/actor/sheet-helpers/templates.ts
+++ b/src/module/actor/sheet-helpers/templates.ts
@@ -1,5 +1,6 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
+import {isSkillItem} from "../../system/type-guards";
 
 /**
  * Add a character template to an actor via drop.
@@ -128,8 +129,8 @@ export async function templateItems(sheet: any, itemList: any) {
         }
 
         // Metaphysics skills get 1D if the attribute is not used
-        if (templateItem.type === 'skill' && (templateItem.system as OD6SSkillItemSystem).attribute === 'met' && game.settings.get('od6s', 'metaphysics_attribute_optional')) {
-            (templateItem.system as OD6SSkillItemSystem).base = OD6S.pipsPerDice;
+        if (isSkillItem(templateItem) && templateItem.system.attribute === 'met' && game.settings.get('od6s', 'metaphysics_attribute_optional')) {
+            templateItem.system.base = OD6S.pipsPerDice;
         }
 
         result.push(templateItem);

--- a/src/module/apps/chat-menu.ts
+++ b/src/module/apps/chat-menu.ts
@@ -1,3 +1,5 @@
+import {isCharacterActor} from "../system/type-guards";
+
 export class OD6SChat {
 
     static chatContextMenu(html: any, options: any[]) {
@@ -14,9 +16,10 @@ export class OD6SChat {
                     }
 
                     if (message!.getFlag('od6s', 'canUseCp') &&
-                        (game.user.isGM || actor!.isOwner) &&
-                        (actor!.type === "character"||actor!.type === "npc") &&
-                        (actor!.system as OD6SCharacterSystem).characterpoints.value > 0) {
+                        actor && (game.user.isGM || actor.isOwner) &&
+                        isCharacterActor(actor) &&
+                        (actor.type === "character" || actor.type === "npc") &&
+                        actor.system.characterpoints.value > 0) {
                         return true;
                     }
                 }

--- a/src/module/apps/roll-helpers/roll-effects.ts
+++ b/src/module/apps/roll-helpers/roll-effects.ts
@@ -3,9 +3,11 @@
  */
 
 import type {RollData} from "./roll-data";
+import {isCharacterActor, isSpecializationItem} from "../../system/type-guards";
 
 export function getEffectMod(type: string, name: string, actor: Actor): number {
-    const sys = actor.system as OD6SCharacterSystem;
+    if (!isCharacterActor(actor)) return 0;
+    const sys = actor.system;
     if (type === 'skill') {
         if (typeof (sys.customeffects?.skills[name]) !== 'undefined') {
             return sys.customeffects.skills[name];
@@ -18,10 +20,9 @@ export function getEffectMod(type: string, name: string, actor: Actor): number {
         }
 
         const spec = actor.items.filter((i: Item) => i.type === type && i.name === name)[0];
-        if (typeof (spec) !== 'undefined') {
-            const specSys = spec.system as OD6SSpecializationItemSystem;
-            if (typeof (sys.customeffects.skills[specSys.skill]) !== 'undefined') {
-                return sys.customeffects.skills[specSys.skill];
+        if (spec && isSpecializationItem(spec)) {
+            if (typeof (sys.customeffects.skills[spec.system.skill]) !== 'undefined') {
+                return sys.customeffects.skills[spec.system.skill];
             }
         }
     }

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -3,6 +3,7 @@ declare const foundry: any;
 import {od6sutilities} from "../system/utilities";
 import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
 import OD6S from "../config/config-od6s";
+import {isWeaponItem} from "../system/type-guards";
 
 
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
@@ -120,8 +121,8 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
                 return item;
 
             case "weapon":
-                if (item.type === "specialization") {
-                    (this.item.system as OD6SWeaponItemSystem).stats.specialization = (item as Item).name;
+                if (item.type === "specialization" && isWeaponItem(this.item)) {
+                    this.item.system.stats.specialization = (item as Item).name;
                     await this.item.update(this.item.system, {diff: true});
                 }
         }

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -168,11 +168,10 @@ export async function promptResistanceRolls(msg: any) {
         if (typeof (target) !== 'undefined' && target) {
             if (isVehicleActor(target.actor)) {
                 if(!target.actor.isOwner) return;
+                if (target.actor.system.crewmembers.length < 1) return;
                 const crew = await od6sutilities.getActorFromUuid(target.actor.system.crewmembers[0].uuid);
-                if (typeof (crew) !== 'undefined' || crew !== null) {
-                    if (crew?.hasPlayerOwner && crew?.isOwner) {
-                        return crew.rollAction('vehicletoughness', msg);
-                    }
+                if (crew && crew.hasPlayerOwner && crew.isOwner) {
+                    return crew.rollAction('vehicletoughness', msg);
                 }
             }
 

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -1,5 +1,6 @@
 import {od6sutilities} from "./system/utilities";
 import OD6S from "./config/config-od6s";
+import {isVehicleActor} from "./system/type-guards";
 
 export function registerSocketlib() {
     Hooks.once("socketlib.ready", () => {
@@ -165,9 +166,9 @@ export async function promptResistanceRolls(msg: any) {
         if (msg.getFlag('od6s', 'wild') && !msg.getFlag('od6s', 'wildHandled')) return;
 
         if (typeof (target) !== 'undefined' && target) {
-            if (target.actor.type === 'starship' || target.actor.type === 'vehicle') {
+            if (isVehicleActor(target.actor)) {
                 if(!target.actor.isOwner) return;
-                const crew = await od6sutilities.getActorFromUuid((target.actor.system as OD6SVehicleSystem).crewmembers[0].uuid);
+                const crew = await od6sutilities.getActorFromUuid(target.actor.system.crewmembers[0].uuid);
                 if (typeof (crew) !== 'undefined' || crew !== null) {
                     if (crew?.hasPlayerOwner && crew?.isOwner) {
                         return crew.rollAction('vehicletoughness', msg);

--- a/src/module/system/utilities/opposed.ts
+++ b/src/module/system/utilities/opposed.ts
@@ -2,6 +2,7 @@ import OD6S from "../../config/config-od6s";
 import { boolCheck } from "./converters";
 import { getActorFromUuid, getTokenFromUuid } from "./actors";
 import { getInjury } from "./wounds";
+import { isVehicleActor } from "../type-guards";
 
 /**
  * Pure stun-effect calculator extracted from handleOpposedRoll.
@@ -260,8 +261,8 @@ export async function generateOpposedRoll(token: TokenDocument, msg: ChatMessage
     if (!token.actor.hasPlayerOwner) {
         if (msg.getFlag('od6s', 'type') === 'damage' || msg.getFlag('od6s','type') === 'explosive') {
             const type = msg.getFlag('od6s', 'damageType');
-            if (token.actor.type === 'vehicle' || token.actor.type === 'starship') {
-                const sys = token.actor.system as OD6SVehicleSystem;
+            if (isVehicleActor(token.actor)) {
+                const sys = token.actor.system;
                 if (sys.embedded_pilot.value || sys.crewmembers.length < 1) {
                     await token.actor.rollAction('vehicletoughness', msg);
                     return;

--- a/src/module/system/utilities/wounds.ts
+++ b/src/module/system/utilities/wounds.ts
@@ -1,4 +1,5 @@
 import OD6S from "../../config/config-od6s";
+import {isCharacterActor} from "../type-guards";
 
 // ---- Pure functions (testable without Foundry globals) ----
 
@@ -55,7 +56,7 @@ export function lookupInjury(
  * Get the action penalty from the actor's wound level vs. the system wound levels
  */
 export function getWoundPenalty(actor: Actor): number {
-    if (actor.type === 'vehicle' || actor.type === 'starship') return 0;
+    if (!isCharacterActor(actor)) return 0;
 
     let deadlinessLevel: number;
     if (OD6S.woundConfig === 1) {
@@ -66,7 +67,7 @@ export function getWoundPenalty(actor: Actor): number {
             : 'deadliness';
         deadlinessLevel = game.settings.get('od6s', settingKey) as number;
     }
-    return lookupWoundPenalty(OD6S.deadliness[deadlinessLevel], (actor.system as OD6SCharacterSystem).wounds.value);
+    return lookupWoundPenalty(OD6S.deadliness[deadlinessLevel], actor.system.wounds.value);
 }
 
 export function getWoundLevel(value: number, actor: Actor): string {


### PR DESCRIPTION
## Summary

- Continues the #57 discriminated-unions sweep across the ten remaining low-cast files (1–2 casts each).
- Replaces `as OD6S<X>System` casts with the type guards from `system/type-guards.ts` (`isCharacterActor`, `isVehicleActor`, `isSkillItem`, `isSpecializationItem`, `isWeaponItem`), so `system` is narrowed at the branch instead of cast per-access.
- `sendVehicleData` in `crew-vehicle.ts` keeps a `Record<string, any>` fallback — the `OD6SVehicleSystem` augmentation is missing the runtime `attribute` / `skill` / `specialization` fields from `vehicle-common.ts`. Now commented as an explicit gap rather than hidden behind a cast.

Touches: `roll-effects.ts`, `templates.ts`, `item-crud.ts`, `drops.ts`, `crew-vehicle.ts`, `wounds.ts`, `opposed.ts`, `socketlib.ts`, `item-sheet.ts`, `chat-menu.ts`.

After this PR the only remaining casts are the deferred tails of `roll-setup.ts` (~18) and `item.ts` (~16), both better tackled alongside the #82/#83 decomposition work.

## Test plan

- [x] `pnpm run check` (lint 0 errors / 709 warnings, typecheck clean, 185 unit + 250 domain tests pass)
- [ ] Manual smoke: drop skill/specialization onto character sheet; drop character template; force-remove crew member from vehicle; chat-menu "Use a Character Point" on a roll