### PR TITLE
refactor(roll-setup): extract weapon mods/stun/modifier math into pure helpers

### DIFF
--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -9,6 +9,12 @@ import {isCharacterActor, isVehicleActor, isSkillItem} from "../../system/type-g
 import {bucketRangeFromDistance} from "./difficulty-math";
 import type {Modifier} from "./difficulty-math";
 import type {IncomingRollData, RollData, DiceValue} from "./roll-data";
+import {
+    applyWeaponMods,
+    buildDamagedWeaponModifier,
+    buildStrengthDamageModifier,
+    computeStunFlags,
+} from "./weapon-context-math";
 
 export async function setupRollData(data: IncomingRollData): Promise<RollData | false> {
     let attribute;
@@ -147,25 +153,22 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             }
         }
         if (weapon.system.scale.score) attackerScale = weapon.system.scale.score;
-        if (weapon.system.mods.damage !== 0) damageScore += weapon.system.mods.damage;
-        if (weapon.system.mods.difficulty !== 0) miscMod += weapon.system.mods.difficulty;
-        if (weapon.system.mods.attack !== 0) bonusmod += weapon.system.mods.attack;
+        ({damageScore, miscMod, bonusmod} = applyWeaponMods(
+            {damageScore, miscMod, bonusmod},
+            weapon.system.mods,
+        ));
 
         if (OD6S.meleeDifficulty) {
             weapon.system.difficulty ? difficultyLevel = weapon.system.difficulty : difficultyLevel = 'OD6S.DIFFICULTY_EASY';
         }
 
-        if(isExplosive) {
-            onlyStun = weapon.system.stun?.stun_only;
-            if (game.settings.get('od6s','explosive_zones')) {
-                canStun = onlyStun || weapon.system.blast_radius["1"].stun_damage > 0;
-            } else {
-                canStun = onlyStun || weapon.system.stun.damage > 0;
-            }
-        } else {
-            onlyStun = weapon.system.stun?.stun_only;
-            canStun = onlyStun || weapon.system.stun?.score > 0 ;
-        }
+        ({onlyStun, canStun} = computeStunFlags({
+            stunOnly: weapon.system.stun?.stun_only,
+            weaponStunScore: weapon.system.stun?.score ?? 0,
+            isExplosive,
+            explosiveZonesEnabled: Boolean(game.settings.get('od6s', 'explosive_zones')),
+            blastZone1StunDamage: weapon.system.blast_radius?.["1"]?.stun_damage ?? 0,
+        }));
 
         if(data.subtype === 'rangedattack') {
             data.range = await od6sutilities.getWeaponRange(data.actor, weapon) as typeof data.range;
@@ -174,21 +177,13 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             data.range = weapon.system.range as typeof data.range;
         }
 
-        if (weapon.system.damaged > 0) {
-           const damageMod = {
-               "name": 'OD6S.WEAPON_DAMAGED',
-               "value": -(OD6S.weaponDamage[weapon.system.damaged].penalty),
-               "level": OD6S.weaponDamage[weapon.system.damaged].label
-           }
-           damageModifiers.push(damageMod);
-        }
+        const damagedMod = buildDamagedWeaponModifier(weapon.system.damaged, OD6S.weaponDamage);
+        if (damagedMod) damageModifiers.push(damagedMod);
 
         if (weapon.system.damage.muscle) {
-            const strmod = {
-                "name": 'OD6S.STRENGTH_DAMAGE_BONUS',
-                "value": (data.actor.system as OD6SCharacterSystem).strengthdamage.score
-            }
-            damageModifiers.push(strmod);
+            damageModifiers.push(buildStrengthDamageModifier(
+                (data.actor.system as OD6SCharacterSystem).strengthdamage.score,
+            ));
         }
 
         // Check for effect modifiers
@@ -227,9 +222,10 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             const vwSys = vehicleWeapon.system as OD6SVehicleWeaponItemSystem;
             damageScore = vwSys.damage.score;
             damageType = vwSys.damage.type;
-            if (vwSys.mods.damage !== 0) damageScore += vwSys.mods.damage;
-            if (vwSys.mods.difficulty !== 0) miscMod += vwSys.mods.difficulty;
-            if (vwSys.mods.attack !== 0) bonusmod += vwSys.mods.attack;
+            ({damageScore, miscMod, bonusmod} = applyWeaponMods(
+                {damageScore, miscMod, bonusmod},
+                vwSys.mods,
+            ));
             if (vwSys.scale.score) {
                 attackerScale = vwSys.scale.score;
             } else if (isVehicleActor(data.actor)) {

--- a/src/module/apps/roll-helpers/weapon-context-math.test.ts
+++ b/src/module/apps/roll-helpers/weapon-context-math.test.ts
@@ -84,6 +84,12 @@ describe('computeStunFlags', () => {
             ...baseInput, isExplosive: true, explosiveZonesEnabled: false, stunOnly: true,
         }).canStun).toBe(true);
     });
+
+    it('coerces undefined stunOnly to a strict boolean', () => {
+        const result = computeStunFlags({ ...baseInput, stunOnly: undefined, weaponStunScore: 2 });
+        expect(result.onlyStun).toBe(false);
+        expect(result.canStun).toBe(true);
+    });
 });
 
 describe('buildDamagedWeaponModifier', () => {
@@ -94,6 +100,10 @@ describe('buildDamagedWeaponModifier', () => {
 
     it('returns null when undamaged', () => {
         expect(buildDamagedWeaponModifier(0, table)).toBeNull();
+    });
+
+    it('returns null when the level is missing from the table', () => {
+        expect(buildDamagedWeaponModifier(99, table)).toBeNull();
     });
 
     it('returns negated penalty as the modifier value', () => {

--- a/src/module/apps/roll-helpers/weapon-context-math.test.ts
+++ b/src/module/apps/roll-helpers/weapon-context-math.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+    applyWeaponMods,
+    computeStunFlags,
+    buildDamagedWeaponModifier,
+    buildStrengthDamageModifier,
+    type ModTotals,
+    type WeaponDamageEntry,
+} from './weapon-context-math';
+
+describe('applyWeaponMods', () => {
+    const base: ModTotals = { damageScore: 10, miscMod: 0, bonusmod: 5 };
+
+    it('returns base unchanged when all mods are zero', () => {
+        expect(applyWeaponMods(base, { damage: 0, difficulty: 0, attack: 0 })).toEqual(base);
+    });
+
+    it('adds damage mod into damageScore', () => {
+        expect(applyWeaponMods(base, { damage: 3, difficulty: 0, attack: 0 }).damageScore).toBe(13);
+    });
+
+    it('adds difficulty mod into miscMod', () => {
+        expect(applyWeaponMods(base, { damage: 0, difficulty: 2, attack: 0 }).miscMod).toBe(2);
+    });
+
+    it('adds attack mod into bonusmod', () => {
+        expect(applyWeaponMods(base, { damage: 0, difficulty: 0, attack: 4 }).bonusmod).toBe(9);
+    });
+
+    it('adds negative mods', () => {
+        const result = applyWeaponMods(base, { damage: -2, difficulty: -1, attack: -3 });
+        expect(result).toEqual({ damageScore: 8, miscMod: -1, bonusmod: 2 });
+    });
+
+    it('does not mutate the input', () => {
+        const input = { ...base };
+        applyWeaponMods(input, { damage: 5, difficulty: 5, attack: 5 });
+        expect(input).toEqual(base);
+    });
+});
+
+describe('computeStunFlags', () => {
+    const baseInput = {
+        stunOnly: false,
+        weaponStunScore: 0,
+        isExplosive: false,
+        explosiveZonesEnabled: false,
+        blastZone1StunDamage: 0,
+    };
+
+    it('non-explosive: canStun follows stun.score > 0', () => {
+        expect(computeStunFlags({ ...baseInput, weaponStunScore: 3 })).toEqual({ onlyStun: false, canStun: true });
+        expect(computeStunFlags({ ...baseInput, weaponStunScore: 0 })).toEqual({ onlyStun: false, canStun: false });
+    });
+
+    it('non-explosive: stun_only forces canStun true even when score is 0', () => {
+        expect(computeStunFlags({ ...baseInput, stunOnly: true, weaponStunScore: 0 }))
+            .toEqual({ onlyStun: true, canStun: true });
+    });
+
+    it('explosive with zones: canStun follows blast_radius["1"].stun_damage', () => {
+        expect(computeStunFlags({
+            ...baseInput, isExplosive: true, explosiveZonesEnabled: true, blastZone1StunDamage: 2,
+        })).toEqual({ onlyStun: false, canStun: true });
+        expect(computeStunFlags({
+            ...baseInput, isExplosive: true, explosiveZonesEnabled: true, blastZone1StunDamage: 0,
+        })).toEqual({ onlyStun: false, canStun: false });
+    });
+
+    it('explosive without zones: canStun follows stun.score (was previously stun.damage typo)', () => {
+        expect(computeStunFlags({
+            ...baseInput, isExplosive: true, explosiveZonesEnabled: false, weaponStunScore: 4,
+        })).toEqual({ onlyStun: false, canStun: true });
+        expect(computeStunFlags({
+            ...baseInput, isExplosive: true, explosiveZonesEnabled: false, weaponStunScore: 0,
+        })).toEqual({ onlyStun: false, canStun: false });
+    });
+
+    it('explosive: stun_only always forces canStun true', () => {
+        expect(computeStunFlags({
+            ...baseInput, isExplosive: true, explosiveZonesEnabled: true, stunOnly: true,
+        }).canStun).toBe(true);
+        expect(computeStunFlags({
+            ...baseInput, isExplosive: true, explosiveZonesEnabled: false, stunOnly: true,
+        }).canStun).toBe(true);
+    });
+});
+
+describe('buildDamagedWeaponModifier', () => {
+    const table: Record<number, WeaponDamageEntry> = {
+        1: { penalty: 1, label: 'OD6S.WEAPON_DAMAGED_LIGHT' },
+        2: { penalty: 3, label: 'OD6S.WEAPON_DAMAGED_HEAVY' },
+    };
+
+    it('returns null when undamaged', () => {
+        expect(buildDamagedWeaponModifier(0, table)).toBeNull();
+    });
+
+    it('returns negated penalty as the modifier value', () => {
+        expect(buildDamagedWeaponModifier(1, table)).toEqual({
+            name: 'OD6S.WEAPON_DAMAGED', value: -1, level: 'OD6S.WEAPON_DAMAGED_LIGHT',
+        });
+        expect(buildDamagedWeaponModifier(2, table)).toEqual({
+            name: 'OD6S.WEAPON_DAMAGED', value: -3, level: 'OD6S.WEAPON_DAMAGED_HEAVY',
+        });
+    });
+});
+
+describe('buildStrengthDamageModifier', () => {
+    it('produces a modifier carrying the strength damage score', () => {
+        expect(buildStrengthDamageModifier(5)).toEqual({
+            name: 'OD6S.STRENGTH_DAMAGE_BONUS', value: 5,
+        });
+    });
+});

--- a/src/module/apps/roll-helpers/weapon-context-math.ts
+++ b/src/module/apps/roll-helpers/weapon-context-math.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure helpers extracted from the weapon-attack branch of setupRollData.
+ * No Foundry globals — testable in isolation.
+ */
+
+import type { Modifier } from "./difficulty-math";
+
+export interface WeaponMods {
+    difficulty: number;
+    attack: number;
+    damage: number;
+}
+
+export interface ModTotals {
+    damageScore: number;
+    miscMod: number;
+    bonusmod: number;
+}
+
+/**
+ * Apply a weapon's `mods` block to the running roll totals. Only non-zero
+ * mods contribute, mirroring the original guarded `+=` calls.
+ */
+export function applyWeaponMods(current: ModTotals, mods: WeaponMods): ModTotals {
+    return {
+        damageScore: current.damageScore + (mods.damage !== 0 ? mods.damage : 0),
+        miscMod: current.miscMod + (mods.difficulty !== 0 ? mods.difficulty : 0),
+        bonusmod: current.bonusmod + (mods.attack !== 0 ? mods.attack : 0),
+    };
+}
+
+export interface StunFlagInputs {
+    stunOnly: boolean;
+    weaponStunScore: number;
+    isExplosive: boolean;
+    explosiveZonesEnabled: boolean;
+    blastZone1StunDamage: number;
+}
+
+export interface StunFlags {
+    onlyStun: boolean;
+    canStun: boolean;
+}
+
+/**
+ * Decide the `onlyStun` / `canStun` flags from a weapon's stun/blast fields.
+ *
+ * Note: the original code's explosive-without-zones branch read
+ * `weapon.system.stun.damage`, but the weapon schema defines
+ * `stun.{stun_only,score,type}` — there is no `stun.damage` field, so that
+ * branch effectively never set `canStun` from a non-zero stun value. This
+ * helper uses `weaponStunScore` consistently across the non-explosive and
+ * explosive-without-zones branches, which is the apparent original intent.
+ */
+export function computeStunFlags(input: StunFlagInputs): StunFlags {
+    const onlyStun = input.stunOnly;
+    let canStun: boolean;
+    if (input.isExplosive) {
+        canStun = onlyStun || (input.explosiveZonesEnabled
+            ? input.blastZone1StunDamage > 0
+            : input.weaponStunScore > 0);
+    } else {
+        canStun = onlyStun || input.weaponStunScore > 0;
+    }
+    return { onlyStun, canStun };
+}
+
+export interface WeaponDamageEntry {
+    penalty: number;
+    label: string;
+}
+
+/**
+ * Build the OD6S.WEAPON_DAMAGED damage modifier from a weapon's `damaged`
+ * level. Returns null when `damaged === 0` (weapon undamaged).
+ */
+export function buildDamagedWeaponModifier(
+    damaged: number,
+    table: Record<number, WeaponDamageEntry>,
+): (Modifier & { level: string }) | null {
+    if (damaged <= 0) return null;
+    const entry = table[damaged];
+    return {
+        name: "OD6S.WEAPON_DAMAGED",
+        value: -entry.penalty,
+        level: entry.label,
+    };
+}
+
+/**
+ * Build the OD6S.STRENGTH_DAMAGE_BONUS damage modifier (added when the
+ * weapon's `damage.muscle` flag is set).
+ */
+export function buildStrengthDamageModifier(strScore: number): Modifier {
+    return {
+        name: "OD6S.STRENGTH_DAMAGE_BONUS",
+        value: strScore,
+    };
+}

--- a/src/module/apps/roll-helpers/weapon-context-math.ts
+++ b/src/module/apps/roll-helpers/weapon-context-math.ts
@@ -30,7 +30,7 @@ export function applyWeaponMods(current: ModTotals, mods: WeaponMods): ModTotals
 }
 
 export interface StunFlagInputs {
-    stunOnly: boolean;
+    stunOnly: boolean | undefined;
     weaponStunScore: number;
     isExplosive: boolean;
     explosiveZonesEnabled: boolean;
@@ -51,9 +51,14 @@ export interface StunFlags {
  * branch effectively never set `canStun` from a non-zero stun value. This
  * helper uses `weaponStunScore` consistently across the non-explosive and
  * explosive-without-zones branches, which is the apparent original intent.
+ *
+ * `stunOnly` accepts `undefined` because item systems that don't define a
+ * `stun` block (e.g. vehicle weapons) yield `weapon.system.stun?.stun_only
+ * === undefined`. The helper coerces to a strict boolean so callers can
+ * forward the result into `RollData` without further guarding.
  */
 export function computeStunFlags(input: StunFlagInputs): StunFlags {
-    const onlyStun = input.stunOnly;
+    const onlyStun = Boolean(input.stunOnly);
     let canStun: boolean;
     if (input.isExplosive) {
         canStun = onlyStun || (input.explosiveZonesEnabled
@@ -72,7 +77,8 @@ export interface WeaponDamageEntry {
 
 /**
  * Build the OD6S.WEAPON_DAMAGED damage modifier from a weapon's `damaged`
- * level. Returns null when `damaged === 0` (weapon undamaged).
+ * level. Returns null when `damaged <= 0` (weapon undamaged) or when the
+ * level is not present in `table` (corrupted / out-of-range value).
  */
 export function buildDamagedWeaponModifier(
     damaged: number,
@@ -80,6 +86,7 @@ export function buildDamagedWeaponModifier(
 ): (Modifier & { level: string }) | null {
     if (damaged <= 0) return null;
     const entry = table[damaged];
+    if (!entry) return null;
     return {
         name: "OD6S.WEAPON_DAMAGED",
         value: -entry.penalty,


### PR DESCRIPTION
## Summary
- New `weapon-context-math.ts` with four pure helpers extracted from the weapon-attack branch of `setupRollData`:
  - `applyWeaponMods` — fold `weapon.system.mods` into running damage/misc/attack totals (now also reused by the vehicle-weapon branch)
  - `computeStunFlags` — derive `{onlyStun, canStun}` across non-explosive, explosive-with-zones, explosive-without-zones
  - `buildDamagedWeaponModifier` — produce the `OD6S.WEAPON_DAMAGED` modifier from `weapon.system.damaged` + `OD6S.weaponDamage`
  - `buildStrengthDamageModifier` — produce the `OD6S.STRENGTH_DAMAGE_BONUS` modifier
- 14 unit tests for boundaries, zero / non-zero mods, and the four stun-flag combinations.

### Fix included
The explosive-without-zones branch read `weapon.system.stun.damage`, but the weapon schema only defines `stun.{stun_only,score,type}` — `stun.damage` is always `undefined`, so `canStun` in that branch only ever fired from `stunOnly`. The helper now uses `weaponStunScore` consistently (matching the non-explosive branch), which is the apparent original intent. Called out separately so reviewers can verify intent before this rolls into the broader #82 work.

Part of #82 (decompose `roll-setup.ts`). roll-setup.ts now 700 LOC (was 712 on prior tip).

## Test plan
- [x] `pnpm run check` — lint + typecheck + 199 unit + 250 domain green
- [ ] Smoke: explosive without `explosive_zones` setting → confirm `canStun` now matches `stun.score > 0`
- [ ] Smoke: ranged/melee/vehicle weapon attacks unchanged in damage, difficulty, and bonusmod totals