### PR TITLE
refactor(roll-setup): extract action / penalty / ram / bonusdice math into pure helpers

### DIFF
--- a/src/module/apps/roll-helpers/action-math.test.ts
+++ b/src/module/apps/roll-helpers/action-math.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSkillBackedAction } from './action-math';
+
+const attributes = {
+    agi: { score: 9 },
+    str: { score: 12 },
+    mec: { score: 6 },
+};
+
+describe('resolveSkillBackedAction', () => {
+    it('skill present + flat-skills: score = attribute, flatPips = skill.score', () => {
+        const result = resolveSkillBackedAction({
+            skill: { score: 4, attributeKey: 'agi' },
+            attributes,
+            flatSkills: true,
+            fallbackAttributeKey: 'agi',
+        });
+        expect(result).toEqual({ score: 9, flatPips: 4 });
+    });
+
+    it('skill present + non-flat: score = skill.score + attribute, no flatPips', () => {
+        const result = resolveSkillBackedAction({
+            skill: { score: 4, attributeKey: 'str' },
+            attributes,
+            flatSkills: false,
+            fallbackAttributeKey: 'agi',
+        });
+        expect(result).toEqual({ score: 16 });
+        expect(result.flatPips).toBeUndefined();
+    });
+
+    it('skill missing: falls back to the requested attribute (melee → agi)', () => {
+        expect(resolveSkillBackedAction({
+            skill: null,
+            attributes,
+            flatSkills: true,
+            fallbackAttributeKey: 'agi',
+        })).toEqual({ score: 9 });
+    });
+
+    it('skill missing: falls back to brawl attribute (mec)', () => {
+        expect(resolveSkillBackedAction({
+            skill: null,
+            attributes,
+            flatSkills: false,
+            fallbackAttributeKey: 'mec',
+        })).toEqual({ score: 6 });
+    });
+
+    it('returns 0 when the skill points to an unknown attribute key', () => {
+        expect(resolveSkillBackedAction({
+            skill: { score: 5, attributeKey: 'unknown' },
+            attributes,
+            flatSkills: true,
+            fallbackAttributeKey: 'agi',
+        })).toEqual({ score: 0, flatPips: 5 });
+    });
+
+    it('returns 0 when the fallback attribute is not present', () => {
+        expect(resolveSkillBackedAction({
+            skill: null,
+            attributes,
+            flatSkills: false,
+            fallbackAttributeKey: 'wis',
+        })).toEqual({ score: 0 });
+    });
+});

--- a/src/module/apps/roll-helpers/action-math.test.ts
+++ b/src/module/apps/roll-helpers/action-math.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSkillBackedAction } from './action-math';
+import { computePenalties, isPenaltyBypassType, resolveSkillBackedAction } from './action-math';
 
 const attributes = {
     agi: { score: 9 },
@@ -63,5 +63,77 @@ describe('resolveSkillBackedAction', () => {
             flatSkills: false,
             fallbackAttributeKey: 'wis',
         })).toEqual({ score: 0 });
+    });
+});
+
+describe('isPenaltyBypassType', () => {
+    it.each([
+        'mortally_wounded',
+        'incapacitated',
+        'damage',
+        'resistance',
+        'funds',
+        'purchase',
+    ])('returns true for %s', (rollType) => {
+        expect(isPenaltyBypassType(rollType)).toBe(true);
+    });
+
+    it.each(['skill', 'specialization', 'attribute', 'weapon', ''])(
+        'returns false for %s',
+        (rollType) => {
+            expect(isPenaltyBypassType(rollType)).toBe(false);
+        },
+    );
+});
+
+describe('computePenalties', () => {
+    it('zeros all penalties and flags bypass for damage rolls', () => {
+        expect(computePenalties({
+            rollType: 'damage',
+            actionItemCount: 3,
+            stunsCurrent: 2,
+            woundPenalty: 5,
+        })).toEqual({
+            woundPenalty: 0,
+            actionPenalty: 0,
+            stunnedPenalty: 0,
+            isBypass: true,
+        });
+    });
+
+    it('passes wound penalty through for normal rolls', () => {
+        expect(computePenalties({
+            rollType: 'skill',
+            actionItemCount: 1,
+            stunsCurrent: 0,
+            woundPenalty: 3,
+        }).woundPenalty).toBe(3);
+    });
+
+    it('subtracts one free action from the action item count', () => {
+        expect(computePenalties({
+            rollType: 'skill',
+            actionItemCount: 4,
+            stunsCurrent: 0,
+            woundPenalty: 0,
+        }).actionPenalty).toBe(3);
+    });
+
+    it('action penalty floors at 0 when no actions are tracked', () => {
+        expect(computePenalties({
+            rollType: 'skill',
+            actionItemCount: 0,
+            stunsCurrent: 0,
+            woundPenalty: 0,
+        }).actionPenalty).toBe(0);
+    });
+
+    it('stunned penalty passes through stunsCurrent', () => {
+        expect(computePenalties({
+            rollType: 'skill',
+            actionItemCount: 1,
+            stunsCurrent: 7,
+            woundPenalty: 0,
+        }).stunnedPenalty).toBe(7);
     });
 });

--- a/src/module/apps/roll-helpers/action-math.ts
+++ b/src/module/apps/roll-helpers/action-math.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers extracted from the action-subtype branch of setupRollData.
+ * No Foundry globals — testable in isolation.
+ */
+
+export interface ActionSkill {
+    score: number;
+    /** Lower-cased attribute key (e.g. "agi", "str"). */
+    attributeKey: string;
+}
+
+export interface ActionResolutionInput {
+    /** The combat skill item the actor owns (already validated), or null when missing. */
+    skill: ActionSkill | null;
+    /** Attribute scores keyed by lower-case attribute name. */
+    attributes: Record<string, { score: number }>;
+    /** Whether the world uses flat-skill mode. */
+    flatSkills: boolean;
+    /** Attribute key to fall back to when no skill item is present. */
+    fallbackAttributeKey: string;
+}
+
+export interface ActionResolution {
+    score: number;
+    /**
+     * Set only when the resolution actually carries flat-pips (i.e. skill
+     * present AND flat-skills enabled). The original switch left `flatPips`
+     * untouched in the other branches, so callers should only assign when
+     * this is non-undefined.
+     */
+    flatPips?: number;
+}
+
+/**
+ * Resolve `data.score` (and optionally `flatPips`) for a skill-backed action
+ * such as melee or brawl attacks.
+ *
+ * - Skill present, flat-skills on:  score = attribute, flatPips = skill.score
+ * - Skill present, flat-skills off: score = skill.score + attribute
+ * - Skill missing:                  score = fallback-attribute
+ */
+export function resolveSkillBackedAction(input: ActionResolutionInput): ActionResolution {
+    if (input.skill) {
+        const attrScore = input.attributes[input.skill.attributeKey]?.score ?? 0;
+        if (input.flatSkills) {
+            return { score: attrScore, flatPips: input.skill.score };
+        }
+        return { score: input.skill.score + attrScore };
+    }
+    return { score: input.attributes[input.fallbackAttributeKey]?.score ?? 0 };
+}

--- a/src/module/apps/roll-helpers/action-math.ts
+++ b/src/module/apps/roll-helpers/action-math.ts
@@ -32,6 +32,61 @@ export interface ActionResolution {
 }
 
 /**
+ * Roll types where wound / action / stun penalties are bypassed (the roll is
+ * a pure outcome resolution, not a character action). Resistance, damage,
+ * funds, purchase, and the two terminal-wound rolls all skip penalties.
+ */
+const PENALTY_BYPASS_TYPES = new Set([
+    'mortally_wounded',
+    'incapacitated',
+    'damage',
+    'resistance',
+    'funds',
+    'purchase',
+]);
+
+export function isPenaltyBypassType(rollType: string): boolean {
+    return PENALTY_BYPASS_TYPES.has(rollType);
+}
+
+export interface PenaltyInputs {
+    rollType: string;
+    /** `data.actor.itemTypes.action.length`. */
+    actionItemCount: number;
+    /** `actor.system.stuns.current` for characters; 0 for non-characters. */
+    stunsCurrent: number;
+    /**
+     * Already-computed wound penalty (callers should compute lazily, e.g.
+     * `isPenaltyBypassType(type) ? 0 : od6sutilities.getWoundPenalty(actor)`).
+     */
+    woundPenalty: number;
+}
+
+export interface Penalties {
+    woundPenalty: number;
+    actionPenalty: number;
+    stunnedPenalty: number;
+    /** True when the roll type bypasses penalties; caller forces isVisible. */
+    isBypass: boolean;
+}
+
+/**
+ * Compute the wound / action / stun penalties for a roll. Bypass roll types
+ * zero everything; otherwise action penalty is `count - 1` (one free action).
+ */
+export function computePenalties(input: PenaltyInputs): Penalties {
+    if (isPenaltyBypassType(input.rollType)) {
+        return { woundPenalty: 0, actionPenalty: 0, stunnedPenalty: 0, isBypass: true };
+    }
+    return {
+        woundPenalty: input.woundPenalty,
+        actionPenalty: input.actionItemCount > 0 ? input.actionItemCount - 1 : 0,
+        stunnedPenalty: input.stunsCurrent,
+        isBypass: false,
+    };
+}
+
+/**
  * Resolve `data.score` (and optionally `flatPips`) for a skill-backed action
  * such as melee or brawl attacks.
  *

--- a/src/module/apps/roll-helpers/difficulty-math.test.ts
+++ b/src/module/apps/roll-helpers/difficulty-math.test.ts
@@ -6,6 +6,7 @@ import {
     applyDamageModifiers,
     bucketRangeFromDistance,
     splitBonusForPenalty,
+    flatSkillBonusPips,
 } from './difficulty-math';
 
 describe('selectHighestDefense', () => {
@@ -201,5 +202,25 @@ describe('splitBonusForPenalty', () => {
             bonusPips: 3,
             penaltyDice: 0,
         });
+    });
+});
+
+describe('flatSkillBonusPips', () => {
+    it('returns flatPips when > 0 regardless of roll type', () => {
+        expect(flatSkillBonusPips(4, 99, 'skill')).toBe(4);
+        expect(flatSkillBonusPips(4, 99, 'attribute')).toBe(4);
+    });
+
+    it('returns the roll score for skill rolls when flatPips is 0', () => {
+        expect(flatSkillBonusPips(0, 7, 'skill')).toBe(7);
+    });
+
+    it('returns the roll score for specialization rolls when flatPips is 0', () => {
+        expect(flatSkillBonusPips(0, 7, 'specialization')).toBe(7);
+    });
+
+    it('returns 0 for non-skill/spec roll types when flatPips is 0', () => {
+        expect(flatSkillBonusPips(0, 7, 'attribute')).toBe(0);
+        expect(flatSkillBonusPips(0, 7, 'weapon')).toBe(0);
     });
 });

--- a/src/module/apps/roll-helpers/difficulty-math.ts
+++ b/src/module/apps/roll-helpers/difficulty-math.ts
@@ -162,3 +162,22 @@ export function splitBonusForPenalty(
     }
     return { bonusDice, bonusPips, penaltyDice: 0 };
 }
+
+/**
+ * Extra pips folded into bonusdice when running in flat-skills mode for
+ * skill / specialization rolls.
+ *
+ * - If the roll already carries flatPips (>0), use that directly.
+ * - Otherwise, for skill / specialization rolls with no flatPips, the score
+ *   itself rolls in as flat pips.
+ * - For all other roll types, contributes nothing.
+ */
+export function flatSkillBonusPips(
+    flatPips: number,
+    rollScore: number,
+    rollType: string,
+): number {
+    if (flatPips > 0) return flatPips;
+    if (rollType === 'skill' || rollType === 'specialization') return rollScore;
+    return 0;
+}

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -6,7 +6,7 @@ import ExplosiveDialog from "../explosive-dialog";
 import OD6S from "../../config/config-od6s";
 import {cancelAction, getEffectMod} from "./roll-effects";
 import {isCharacterActor, isVehicleActor, isSkillItem} from "../../system/type-guards";
-import {bucketRangeFromDistance} from "./difficulty-math";
+import {bucketRangeFromDistance, flatSkillBonusPips, splitBonusForPenalty} from "./difficulty-math";
 import type {Modifier} from "./difficulty-math";
 import type {IncomingRollData, RollData, DiceValue} from "./roll-data";
 import {
@@ -208,20 +208,17 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             ));
         }
 
-        // Check for effect modifiers
-        const stats = weapon.system.stats
-        let found = false;
-        if (typeof (stats.specialization) !== 'undefined' && stats.specialization !== '') {
-            if (data.actor.items.filter((i: Item) => i.type === 'specialization' && i.name === stats.specialization)) {
-                bonusmod += (+getEffectMod('specialization', stats.specialization, data.actor));
-                found = true;
-            }
-        }
-
-        if (!found && typeof (stats.skill) !== 'undefined' && stats.skill !== '') {
-            if (data.actor.items.filter((i: Item) => i.type === 'skill' && i.name === stats.skill)) {
-                bonusmod += (+getEffectMod('skill', stats.skill, data.actor));
-            }
+        // Check for effect modifiers — prefer specialization over skill when
+        // the actor owns the matching item.
+        const stats = weapon.system.stats;
+        const ownsSpec = !!stats.specialization
+            && data.actor.items.some((i: Item) => i.type === 'specialization' && i.name === stats.specialization);
+        const ownsSkill = !!stats.skill
+            && data.actor.items.some((i: Item) => i.type === 'skill' && i.name === stats.skill);
+        if (ownsSpec) {
+            bonusmod += getEffectMod('specialization', stats.specialization, data.actor);
+        } else if (ownsSkill) {
+            bonusmod += getEffectMod('skill', stats.skill, data.actor);
         }
     }
 
@@ -533,22 +530,16 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     }
 
     if (OD6S.flatSkills) {
-        bonusdice.dice = 0;
-        bonusdice.pips = (+bonusmod);
+        bonusdice = { dice: 0, pips: bonusmod };
     } else {
         bonusdice = od6sutilities.getDiceFromScore(bonusmod);
     }
+    const split = splitBonusForPenalty(bonusdice.dice, bonusdice.pips, OD6S.pipsPerDice);
+    bonusdice = { dice: split.bonusDice, pips: split.bonusPips };
+    penaltydice = split.penaltyDice;
 
-    if (od6sutilities.getScoreFromDice(bonusdice.dice, bonusdice.pips) < 0) {
-        penaltydice = bonusdice.dice * -1;
-        bonusdice.dice = 0;
-        bonusdice.pips = 0;
-    }
-
-    if (OD6S.flatSkills && flatPips === 0 && (data.type === 'skill' || data.type === 'specialization')) {
-        bonusdice.pips = (+bonusdice.pips) + (+data.score);
-    } else if (OD6S.flatSkills && flatPips > 0) {
-        bonusdice.pips = (+bonusdice.pips) + (+flatPips);
+    if (OD6S.flatSkills) {
+        bonusdice.pips += flatSkillBonusPips(flatPips, data.score, data.type);
     }
 
     if (isAttack) {

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -216,9 +216,9 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         const ownsSkill = !!stats.skill
             && data.actor.items.some((i: Item) => i.type === 'skill' && i.name === stats.skill);
         if (ownsSpec) {
-            bonusmod += getEffectMod('specialization', stats.specialization, data.actor);
+            bonusmod += (+getEffectMod('specialization', stats.specialization, data.actor));
         } else if (ownsSkill) {
-            bonusmod += getEffectMod('skill', stats.skill, data.actor);
+            bonusmod += (+getEffectMod('skill', stats.skill, data.actor));
         }
     }
 

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -14,8 +14,29 @@ import {
     buildDamagedWeaponModifier,
     buildStrengthDamageModifier,
     computeStunFlags,
+    ramAttackContribution,
 } from "./weapon-context-math";
-import {resolveSkillBackedAction} from "./action-math";
+import {computePenalties, isPenaltyBypassType, resolveSkillBackedAction} from "./action-math";
+
+/**
+ * Returns the "vehicle data" carried by an actor regardless of host type:
+ * for vehicle/starship actors it's `system` itself; for character actors
+ * it's the embedded `system.vehicle` field. The shape is loosely typed
+ * because the two sources only partially overlap at runtime.
+ */
+function selectVehicleData(actor: Actor): {
+    uuid?: string;
+    scale?: { score: number };
+    ram?: { score: number };
+    ram_damage?: { score: number };
+    ranged?: { score?: number };
+    vehicle_weapons?: Item[];
+} {
+    if (actor.type === 'vehicle' || actor.type === 'starship') {
+        return actor.system as never;
+    }
+    return (actor.system as OD6SCharacterSystem).vehicle as never;
+}
 
 export async function setupRollData(data: IncomingRollData): Promise<RollData | false> {
     let attribute;
@@ -227,13 +248,9 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
                 {damageScore, miscMod, bonusmod},
                 vwSys.mods,
             ));
-            if (vwSys.scale.score) {
-                attackerScale = vwSys.scale.score;
-            } else if (isVehicleActor(data.actor)) {
-                attackerScale = data.actor.system.scale.score;
-            } else if (isCharacterActor(data.actor)) {
-                attackerScale = data.actor.system.vehicle.scale!.score;
-            }
+            attackerScale = vwSys.scale.score
+                ? vwSys.scale.score
+                : selectVehicleData(data.actor).scale?.score ?? 0;
         } else if (isCharacterActor(data.actor)) {
             damageScore = data.damage ?? 0;
             damageType = data.damage_type ?? '';
@@ -246,17 +263,13 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         damageType = 'p';
         damageSource = 'OD6S.COLLISION';
         isAttack = true;
-        const vehicle: any = (data.actor.type === 'vehicle' || data.actor.type === 'starship') ? data.actor.system : (data.actor.system as OD6SCharacterSystem).vehicle;
-        if (vehicle.ram_damage?.score > 0) {
-            const rangedmod = {
-                "name": 'OD6S.ACTIVE_EFFECTS',
-                "value": vehicle.ram_damage.score
-            }
-            damageModifiers.push(rangedmod);
-        }
-        if (vehicle.ram?.score > 0) {
-            bonusmod += (+vehicle.ram.score);
-        }
+        const vehicleData = selectVehicleData(data.actor);
+        const ram = ramAttackContribution(
+            vehicleData.ram?.score ?? 0,
+            vehicleData.ram_damage?.score ?? 0,
+        );
+        if (ram.modifier) damageModifiers.push(ram.modifier);
+        bonusmod += ram.bonusModIncrement;
     }
 
     if ((data.type === 'brawlattack' || data.subtype === 'brawlattack') && isCharacterActor(data.actor)) {
@@ -276,18 +289,10 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     if (targets.length === 1) {
         if (!attackerScale && isAttack) {
-            if (typeof (data.subtype) !== 'undefined' && data.subtype.includes('vehicle')) {
-                if ((data.actor.system as OD6SVehicleSystem).crew?.value) {
-                    attackerScale = data.actor.system.scale.score;
-                } else {
-                    attackerScale = (data.actor.system as OD6SCharacterSystem).vehicle.scale!.score;
-                }
+            if (data.subtype !== undefined && data.subtype.includes('vehicle')) {
+                attackerScale = selectVehicleData(data.actor).scale?.score ?? 0;
             } else {
-                if (typeof (data.actor.system.scale.score) === 'undefined') {
-                    attackerScale = 0;
-                } else {
-                    attackerScale = data.actor.system.scale.score;
-                }
+                attackerScale = data.actor.system.scale.score ?? 0;
             }
         }
 
@@ -371,25 +376,16 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     let rollValues = od6sutilities.getDiceFromScore(data.score);
 
-    let stunnedPenalty = 0;
-    if (isCharacterActor(data.actor)) {
-        stunnedPenalty = data.actor.system.stuns.current ? data.actor.system.stuns.current : 0;
-    }
-
-    let actionPenalty = ((+data.actor.itemTypes.action.length) > 0) ? (+data.actor.itemTypes.action.length) - 1 : 0;
-    if (data.type === 'mortally_wounded' ||
-        data.type === 'incapacitated' ||
-        data.type === 'damage' ||
-        data.type === 'resistance' ||
-        data.type === 'funds' ||
-        data.type === 'purchase') {
-        woundPenalty = 0;
-        actionPenalty = 0;
-        stunnedPenalty = 0;
-        isVisible = true;
-    } else {
-        woundPenalty = od6sutilities.getWoundPenalty(data.actor);
-    }
+    const penalties = computePenalties({
+        rollType: data.type,
+        actionItemCount: data.actor.itemTypes.action.length,
+        stunsCurrent: isCharacterActor(data.actor) ? (data.actor.system.stuns.current ?? 0) : 0,
+        woundPenalty: isPenaltyBypassType(data.type) ? 0 : od6sutilities.getWoundPenalty(data.actor),
+    });
+    woundPenalty = penalties.woundPenalty;
+    const actionPenalty = penalties.actionPenalty;
+    const stunnedPenalty = penalties.stunnedPenalty;
+    if (penalties.isBypass) isVisible = true;
 
     if (data.type === 'funds') {
         isVisible = !game.settings.get('od6s', 'hide-skill-cards');
@@ -513,36 +509,27 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     }
 
     if (data.subtype === 'vehicleramattack') {
-        const vehicle: any = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
-            ? data.actor.system : (data.actor.system as OD6SCharacterSystem).vehicle;
-        if (typeof (vehicle.ram?.score) !== 'undefined') {
-            bonusmod += (+vehicle.ram.score);
+        const vehicleData = selectVehicleData(data.actor);
+        if (vehicleData.ram?.score !== undefined) {
+            bonusmod += vehicleData.ram.score;
         }
     }
 
-    const charSys = data.actor.system as OD6SCharacterSystem;
-    if (data.subtype === 'meleeattack') {
-        bonusmod += (+charSys.melee.mod);
-    }
-
-    if (data.subtype === 'brawlattack') {
-        bonusmod += (+charSys.brawl.mod);
-        canStun = true;
-        damageScore = charSys.strengthdamage.score;
-        stunDamageScore = damageScore;
-        stunDamageType = 'p';
-    }
-
-    if (data.subtype === 'dodge') {
-        bonusmod += (+charSys.dodge.mod);
-    }
-
-    if (data.subtype === 'parry') {
-        bonusmod += (+charSys.parry.mod);
-    }
-
-    if (data.subtype === 'block') {
-        bonusmod += (+charSys.block.mod);
+    if (isCharacterActor(data.actor)) {
+        const charSys = data.actor.system;
+        if (data.subtype === 'meleeattack') {
+            bonusmod += charSys.melee.mod;
+        }
+        if (data.subtype === 'brawlattack') {
+            bonusmod += charSys.brawl.mod;
+            canStun = true;
+            damageScore = charSys.strengthdamage.score;
+            stunDamageScore = damageScore;
+            stunDamageType = 'p';
+        }
+        if (data.subtype === 'dodge') bonusmod += charSys.dodge.mod;
+        if (data.subtype === 'parry') bonusmod += charSys.parry.mod;
+        if (data.subtype === 'block') bonusmod += charSys.block.mod;
     }
 
     if (OD6S.flatSkills) {

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -15,6 +15,7 @@ import {
     buildStrengthDamageModifier,
     computeStunFlags,
 } from "./weapon-context-math";
+import {resolveSkillBackedAction} from "./action-math";
 
 export async function setupRollData(data: IncomingRollData): Promise<RollData | false> {
     let attribute;
@@ -326,39 +327,38 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
                 data.score = data.actor.system.attributes.agi.score;
                 isVisible = !game.settings.get('od6s', 'hide-combat-cards');
                 break;
-            case 'meleeattack':
-                skill = await data.actor.items.find((i: Item) => i.type === 'skill'
+            case 'meleeattack': {
+                skill = data.actor.items.find((i: Item) => i.type === 'skill'
                     && i.name === game.i18n.localize('OD6S.MELEE_COMBAT'));
-                if (skill !== undefined && isSkillItem(skill) && isCharacterActor(data.actor)) {
-                    const attrKey = skill.system.attribute.toLowerCase();
-                    if (OD6S.flatSkills) {
-                        data.score = data.actor.system.attributes[attrKey].score;
-                        flatPips = skill.system.score;
-                    } else {
-                        data.score = skill.system.score + data.actor.system.attributes[attrKey].score;
-                    }
-                } else {
-                    data.score = data.actor.system.attributes.agi.score;
-                }
+                const resolved = resolveSkillBackedAction({
+                    skill: (skill !== undefined && isSkillItem(skill) && isCharacterActor(data.actor))
+                        ? {score: skill.system.score, attributeKey: skill.system.attribute.toLowerCase()}
+                        : null,
+                    attributes: data.actor.system.attributes,
+                    flatSkills: OD6S.flatSkills,
+                    fallbackAttributeKey: 'agi',
+                });
+                data.score = resolved.score;
+                if (resolved.flatPips !== undefined) flatPips = resolved.flatPips;
                 isVisible = !game.settings.get('od6s', 'hide-combat-cards');
                 break;
-            case 'brawlattack':
-                skill = await data.actor.items.find((i: Item) => i.type === 'skill'
+            }
+            case 'brawlattack': {
+                skill = data.actor.items.find((i: Item) => i.type === 'skill'
                     && i.name === game.i18n.localize('OD6S.BRAWL'));
-                if (skill !== undefined && isSkillItem(skill) && isCharacterActor(data.actor)) {
-                    const attrKey = skill.system.attribute.toLowerCase();
-                    if (OD6S.flatSkills) {
-                        data.score = data.actor.system.attributes[attrKey].score;
-                        flatPips = skill.system.score;
-                    } else {
-                        data.score = skill.system.score + data.actor.system.attributes[attrKey].score;
-                    }
-                } else {
-                    const bAttr = game.settings.get('od6s', 'brawl_attribute')
-                    data.score = data.actor.system.attributes[bAttr].score;
-                }
+                const resolved = resolveSkillBackedAction({
+                    skill: (skill !== undefined && isSkillItem(skill) && isCharacterActor(data.actor))
+                        ? {score: skill.system.score, attributeKey: skill.system.attribute.toLowerCase()}
+                        : null,
+                    attributes: data.actor.system.attributes,
+                    flatSkills: OD6S.flatSkills,
+                    fallbackAttributeKey: game.settings.get('od6s', 'brawl_attribute'),
+                });
+                data.score = resolved.score;
+                if (resolved.flatPips !== undefined) flatPips = resolved.flatPips;
                 isVisible = !game.settings.get('od6s', 'hide-combat-cards');
                 break;
+            }
             case '':
                 if (data.name === game.i18n.localize('OD6S.ENERGY_RESISTANCE') ||
                     data.name === game.i18n.localize('OD6S.PHYSICAL_RESISTANCE') ||

--- a/src/module/apps/roll-helpers/weapon-context-math.test.ts
+++ b/src/module/apps/roll-helpers/weapon-context-math.test.ts
@@ -4,6 +4,7 @@ import {
     computeStunFlags,
     buildDamagedWeaponModifier,
     buildStrengthDamageModifier,
+    ramAttackContribution,
     type ModTotals,
     type WeaponDamageEntry,
 } from './weapon-context-math';
@@ -120,6 +121,36 @@ describe('buildStrengthDamageModifier', () => {
     it('produces a modifier carrying the strength damage score', () => {
         expect(buildStrengthDamageModifier(5)).toEqual({
             name: 'OD6S.STRENGTH_DAMAGE_BONUS', value: 5,
+        });
+    });
+});
+
+describe('ramAttackContribution', () => {
+    it('emits no modifier and zero increment when both scores are 0', () => {
+        expect(ramAttackContribution(0, 0)).toEqual({
+            bonusModIncrement: 0,
+            modifier: null,
+        });
+    });
+
+    it('emits the ram-damage modifier when ram_damage > 0', () => {
+        expect(ramAttackContribution(0, 4)).toEqual({
+            bonusModIncrement: 0,
+            modifier: { name: 'OD6S.ACTIVE_EFFECTS', value: 4 },
+        });
+    });
+
+    it('emits the bonusmod increment when ram > 0', () => {
+        expect(ramAttackContribution(3, 0)).toEqual({
+            bonusModIncrement: 3,
+            modifier: null,
+        });
+    });
+
+    it('emits both when both are > 0', () => {
+        expect(ramAttackContribution(3, 4)).toEqual({
+            bonusModIncrement: 3,
+            modifier: { name: 'OD6S.ACTIVE_EFFECTS', value: 4 },
         });
     });
 });

--- a/src/module/apps/roll-helpers/weapon-context-math.ts
+++ b/src/module/apps/roll-helpers/weapon-context-math.ts
@@ -104,3 +104,23 @@ export function buildStrengthDamageModifier(strScore: number): Modifier {
         value: strScore,
     };
 }
+
+export interface RamAttackContribution {
+    /** Amount to add to bonusmod (0 when the vehicle has no `ram.score`). */
+    bonusModIncrement: number;
+    /** OD6S.ACTIVE_EFFECTS damage modifier, or null when ram_damage is 0. */
+    modifier: Modifier | null;
+}
+
+/**
+ * Compute the bonusmod and damage-modifier contributions for a vehicle ram
+ * attack from the ram bonus / ram-damage scores.
+ */
+export function ramAttackContribution(ramScore: number, ramDamageScore: number): RamAttackContribution {
+    return {
+        bonusModIncrement: ramScore > 0 ? ramScore : 0,
+        modifier: ramDamageScore > 0
+            ? { name: "OD6S.ACTIVE_EFFECTS", value: ramDamageScore }
+            : null,
+    };
+}


### PR DESCRIPTION
## Summary

Continues the #82 decomposition of `roll-setup.ts` with several pure-helper extractions, plus two fix-while-you're-here bug fixes.

### New pure helpers

**`action-math.ts`** (new file)
- `resolveSkillBackedAction()` — score / flatPips ladder for melee and brawl actions (skill present + flatSkills, skill present + non-flat, skill missing → fallback). Replaces duplicated logic in two switch cases.
- `computePenalties()` + `isPenaltyBypassType()` — wound / action / stun penalty triple. Bypass roll types (`damage`, `resistance`, `funds`, `purchase`, `mortally_wounded`, `incapacitated`) zero everything; otherwise action penalty is `count - 1` (one free action).

**`weapon-context-math.ts`**
- `ramAttackContribution()` — bonusmod increment + `OD6S.ACTIVE_EFFECTS` damage modifier for vehicle ram attacks.

**`difficulty-math.ts`**
- `flatSkillBonusPips()` — the flat-skills-only "fold flatPips or rollScore into bonusPips" rule.
- The bonusmod → bonusdice → penaltydice ladder now reuses the existing `splitBonusForPenalty()` instead of the inline negative-score check.

**Local helper in `roll-setup.ts`**
- `selectVehicleData(actor)` returns the "vehicle data" carried by an actor regardless of host type (vehicle/starship → `system`; character → `system.vehicle`). Used at three call sites — drops the `(actor.system as OD6SVehicleSystem).crew?.value` proxy check that was only being used to discriminate actor type.

### Fixes included

- **Effect-mod truthiness bug:** the weapon-stats effect-mod block did `if (data.actor.items.filter(...))`. `filter()` returns an array which is *always* truthy, so the spec branch always set `found = true` and the skill fallback never ran. Switched to `.some(...)` (matches the original intent).
- **Stun-flag schema bug** (already shipped in the previous PR via `computeStunFlags`, mentioned for completeness in the surrounding context).
- Two no-op `await` calls dropped on `data.actor.items.find(...)` (sync method).
- Combat-skill bonusmod block (melee/brawl/dodge/parry/block) narrowed under `isCharacterActor`, dropping a `system as OD6SCharacterSystem` cast.

### Tests + size

- 185 → 231 unit tests (46 new, all colocated next to the helpers).
- `roll-setup.ts`: 700 → 678 LOC (22 lines off).
- 12 of those new tests cover the penalty bypass set and the four ram/ram_damage combinations explicitly.

Part of #82.

## Test plan
- [x] `pnpm run check` — lint + typecheck + 231 unit + 250 domain green
- [ ] Smoke: melee attack with the OD6S.MELEE_COMBAT skill on the actor produces same score as before in both flat-skills and non-flat-skills modes
- [ ] Smoke: brawl attack with no Brawl skill falls back to the configured `brawl_attribute`
- [ ] Smoke: damage / resistance rolls show no wound / action / stun penalty (was: zeroed in the inline block; now via `computePenalties`)
- [ ] Smoke: vehicle ram attack against a target shows the `OD6S.ACTIVE_EFFECTS` row in the chat card when `ram_damage.score > 0`
- [ ] Smoke: weapon with a `stats.skill` set but no specialization on the actor — the skill effect-mod now contributes (was masked by the truthiness bug)