### PR TITLE
refactor(roll-setup): #98 prep — classifier, mutation map, smoke probes

### DIFF
--- a/src/module/apps/roll-helpers/roll-data.test.ts
+++ b/src/module/apps/roll-helpers/roll-data.test.ts
@@ -92,6 +92,9 @@ describe('classifyRoll', () => {
             ['incapacitated', 'incapacitated'],
             ['funds', 'funds'],
             ['brawlattack', 'brawlattack'],
+            // Top-level attribute roll (Actor.rollAttribute) — distinct from
+            // action+attribute, which is dispatched via the action handler.
+            ['attribute', 'attribute'],
         ] as const)('type=%s → key=%s', (type, key) => {
             const result = classifyRoll({ type }, localize);
             expect(result).toEqual({ type, subtype: '', key });

--- a/src/module/apps/roll-helpers/roll-data.test.ts
+++ b/src/module/apps/roll-helpers/roll-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeScaleMod, coerceScale, isScoreTooLow } from './roll-data';
+import { classifyRoll, computeScaleMod, coerceScale, isScoreTooLow, type Localize } from './roll-data';
 
 describe('computeScaleMod', () => {
     it('returns 0 when scales match', () => {
@@ -62,5 +62,169 @@ describe('isScoreTooLow', () => {
         // For flatSkills mode, skill/spec rolls allow score=0 (the dice come from the attribute)
         expect(isScoreTooLow(0, pipsPerDice, true)).toBe(false);
         expect(isScoreTooLow(2, pipsPerDice, true)).toBe(false);
+    });
+});
+
+describe('classifyRoll', () => {
+    // Fake i18n table that mirrors en.json shape for the keys the classifier touches.
+    const I18N: Record<string, string> = {
+        'OD6S.RANGED': 'Ranged',
+        'OD6S.THROWN': 'Thrown',
+        'OD6S.MISSILE': 'Missile',
+        'OD6S.EXPLOSIVE': 'Explosive',
+        'OD6S.MELEE': 'Melee',
+        'OD6S.ENERGY_RESISTANCE': 'Energy Resistance',
+        'OD6S.PHYSICAL_RESISTANCE': 'Physical Resistance',
+        'OD6S.RESISTANCE_NO_ARMOR': 'Resistance (No Armor)',
+    };
+    const localize: Localize = (k) => I18N[k] ?? k;
+
+    describe('top-level types pass through unchanged', () => {
+        it.each([
+            ['weapon', 'weapon'],
+            ['starship-weapon', 'starship-weapon'],
+            ['vehicle-weapon', 'vehicle-weapon'],
+            ['damage', 'damage'],
+            ['resistance', 'resistance'],
+            ['skill', 'skill'],
+            ['specialization', 'specialization'],
+            ['mortally_wounded', 'mortally_wounded'],
+            ['incapacitated', 'incapacitated'],
+            ['funds', 'funds'],
+            ['brawlattack', 'brawlattack'],
+        ] as const)('type=%s → key=%s', (type, key) => {
+            const result = classifyRoll({ type }, localize);
+            expect(result).toEqual({ type, subtype: '', key });
+        });
+    });
+
+    describe('localized subtype aliases collapse to canonical attack subtypes', () => {
+        it.each([
+            ['Ranged'],
+            ['Thrown'],
+            ['Missile'],
+            ['Explosive'],
+        ])('weapon + localized "%s" subtype → rangedattack', (localizedSubtype) => {
+            const result = classifyRoll({ type: 'weapon', subtype: localizedSubtype }, localize);
+            expect(result.subtype).toBe('rangedattack');
+            expect(result.key).toBe('weapon');
+        });
+
+        it('weapon + localized "Melee" subtype → meleeattack', () => {
+            const result = classifyRoll({ type: 'weapon', subtype: 'Melee' }, localize);
+            expect(result.subtype).toBe('meleeattack');
+            expect(result.key).toBe('weapon');
+        });
+
+        it('localized aliases normalize regardless of host type', () => {
+            // Mirrors roll-setup.ts:135 — the alias check is unconditional on type.
+            expect(classifyRoll({ type: 'starship-weapon', subtype: 'Ranged' }, localize).subtype)
+                .toBe('rangedattack');
+            expect(classifyRoll({ type: 'vehicle-weapon', subtype: 'Melee' }, localize).subtype)
+                .toBe('meleeattack');
+        });
+
+        it('non-aliased subtypes are preserved verbatim', () => {
+            expect(classifyRoll({ type: 'weapon', subtype: 'parry' }, localize).subtype).toBe('parry');
+        });
+    });
+
+    describe('top-level type rewrites', () => {
+        it('vehicletoughness → resistance + vehicletoughness subtype', () => {
+            expect(classifyRoll({ type: 'vehicletoughness' }, localize)).toEqual({
+                type: 'resistance',
+                subtype: 'vehicletoughness',
+                key: 'resistance-vehicletoughness',
+            });
+        });
+
+        it('purchase → funds + purchase subtype', () => {
+            expect(classifyRoll({ type: 'purchase' }, localize)).toEqual({
+                type: 'funds',
+                subtype: 'purchase',
+                key: 'purchase',
+            });
+        });
+
+        it('funds with subtype=purchase already keeps the purchase key', () => {
+            expect(classifyRoll({ type: 'funds', subtype: 'purchase' }, localize).key).toBe('purchase');
+        });
+    });
+
+    describe('skill + Dodge name', () => {
+        it('rewrites subtype to "dodge"', () => {
+            const result = classifyRoll({ type: 'skill', name: 'Dodge' }, localize);
+            expect(result).toEqual({ type: 'skill', subtype: 'dodge', key: 'skill-dodge' });
+        });
+
+        it('does not trigger for non-Dodge names', () => {
+            expect(classifyRoll({ type: 'skill', name: 'Bluff' }, localize).key).toBe('skill');
+        });
+
+        it('does not trigger for non-skill types', () => {
+            expect(classifyRoll({ type: 'specialization', name: 'Dodge' }, localize).key)
+                .toBe('specialization');
+        });
+    });
+
+    describe('action subtypes', () => {
+        it.each([
+            ['meleeattack', 'action-meleeattack'],
+            ['brawlattack', 'action-brawlattack'],
+            ['rangedattack', 'action-rangedattack'],
+            ['vehiclerangedattack', 'action-vehiclerangedattack'],
+            ['vehiclerangedweaponattack', 'action-vehiclerangedweaponattack'],
+            ['vehicleramattack', 'action-vehicleramattack'],
+            ['attribute', 'action-attribute'],
+        ] as const)('action+%s → %s', (subtype, key) => {
+            const result = classifyRoll({ type: 'action', subtype }, localize);
+            expect(result).toEqual({ type: 'action', subtype, key });
+        });
+
+        it('action + vehicletoughness → resistance (subtype preserved)', () => {
+            expect(classifyRoll({ type: 'action', subtype: 'vehicletoughness' }, localize)).toEqual({
+                type: 'resistance',
+                subtype: 'vehicletoughness',
+                key: 'resistance-vehicletoughness',
+            });
+        });
+
+        it.each([
+            'Energy Resistance',
+            'Physical Resistance',
+            'Resistance (No Armor)',
+        ])('action + empty subtype + resistance name "%s" → resistance', (name) => {
+            const result = classifyRoll({ type: 'action', subtype: '', name }, localize);
+            expect(result).toEqual({ type: 'resistance', subtype: '', key: 'resistance' });
+        });
+
+        it('action + empty subtype + non-resistance name stays as action-other', () => {
+            const result = classifyRoll({ type: 'action', subtype: '', name: 'Something Else' }, localize);
+            expect(result).toEqual({ type: 'action', subtype: '', key: 'action-other' });
+        });
+
+        it('action with no subtype defaults to action-other', () => {
+            expect(classifyRoll({ type: 'action' }, localize).key).toBe('action-other');
+        });
+    });
+
+    describe('alias + rewrite interactions', () => {
+        it('action + localized "Ranged" → action-rangedattack (alias normalization runs first)', () => {
+            const result = classifyRoll({ type: 'action', subtype: 'Ranged' }, localize);
+            expect(result).toEqual({
+                type: 'action',
+                subtype: 'rangedattack',
+                key: 'action-rangedattack',
+            });
+        });
+
+        it('action + localized "Melee" → action-meleeattack', () => {
+            const result = classifyRoll({ type: 'action', subtype: 'Melee' }, localize);
+            expect(result.key).toBe('action-meleeattack');
+        });
+    });
+
+    it('throws on unknown type so unregistered paths are caught at the boundary', () => {
+        expect(() => classifyRoll({ type: 'totally-unknown' }, localize)).toThrow(/unrecognized roll type/);
     });
 });

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -249,7 +249,8 @@ export type RollTypeKey =
     | 'incapacitated'
     | 'funds'
     | 'purchase'
-    | 'brawlattack';
+    | 'brawlattack'
+    | 'attribute';
 
 /** Canonical post-normalization roll types. Output of classifyRoll. */
 export type CanonicalRollType =
@@ -257,7 +258,7 @@ export type CanonicalRollType =
     | 'action' | 'skill' | 'specialization'
     | 'damage' | 'resistance'
     | 'mortally_wounded' | 'incapacitated'
-    | 'funds' | 'brawlattack';
+    | 'funds' | 'brawlattack' | 'attribute';
 
 export interface ClassifiedRoll {
     type: CanonicalRollType;
@@ -342,7 +343,7 @@ function isCanonicalType(type: string): type is CanonicalRollType {
         case 'action': case 'skill': case 'specialization':
         case 'damage': case 'resistance':
         case 'mortally_wounded': case 'incapacitated':
-        case 'funds': case 'brawlattack':
+        case 'funds': case 'brawlattack': case 'attribute':
             return true;
         default:
             return false;
@@ -363,6 +364,7 @@ function deriveRollTypeKey(type: CanonicalRollType, subtype: string): RollTypeKe
         case 'incapacitated': return 'incapacitated';
         case 'funds': return subtype === 'purchase' ? 'purchase' : 'funds';
         case 'brawlattack': return 'brawlattack';
+        case 'attribute': return 'attribute';
         case 'action':
             switch (subtype) {
                 case 'meleeattack': return 'action-meleeattack';

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -217,3 +217,138 @@ export function isScoreTooLow(
     if (flatSkillsBypass) return false;
     return score < pipsPerDice;
 }
+
+// ---- Roll-type classification (#98 prep) ----
+
+/**
+ * Stable handler-dispatch keys for every (type, subtype) path setupRollData
+ * accepts. Drives the per-handler decomposition planned in #98 — a future
+ * `switch (key)` over this union gets TypeScript exhaustiveness for free.
+ */
+export type RollTypeKey =
+    | 'weapon'
+    | 'starship-weapon'
+    | 'vehicle-weapon'
+    | 'action-meleeattack'
+    | 'action-brawlattack'
+    | 'action-rangedattack'
+    | 'action-vehiclerangedattack'
+    | 'action-vehiclerangedweaponattack'
+    | 'action-vehicleramattack'
+    | 'action-attribute'
+    | 'action-other'
+    | 'skill'
+    | 'skill-dodge'
+    | 'specialization'
+    | 'damage'
+    | 'resistance'
+    | 'resistance-vehicletoughness'
+    | 'mortally_wounded'
+    | 'incapacitated'
+    | 'funds'
+    | 'purchase'
+    | 'brawlattack';
+
+export interface ClassifiedRoll {
+    /** Canonical type after normalization — what setupRollData ultimately uses. */
+    type: string;
+    /** Canonical subtype after normalization. Empty string when none. */
+    subtype: string;
+    /** Stable discriminator for handler dispatch. */
+    key: RollTypeKey;
+}
+
+export type Localize = (key: string) => string;
+
+const RANGED_ATTACK_ALIASES = [
+    'OD6S.RANGED',
+    'OD6S.THROWN',
+    'OD6S.MISSILE',
+    'OD6S.EXPLOSIVE',
+] as const;
+
+const RESISTANCE_NAME_ALIASES = [
+    'OD6S.ENERGY_RESISTANCE',
+    'OD6S.PHYSICAL_RESISTANCE',
+    'OD6S.RESISTANCE_NO_ARMOR',
+] as const;
+
+/**
+ * Pure classifier: maps an incoming roll request to its canonical (type, subtype)
+ * and a stable handler key. Mirrors the normalization scattered through
+ * roll-setup.ts: localized subtype aliases (RANGED/MELEE/…) → canonical attack
+ * subtypes; top-level vehicletoughness → resistance; top-level purchase → funds;
+ * skill+Dodge → skill+dodge; action+vehicletoughness → resistance;
+ * action+'' with a resistance i18n name → resistance.
+ *
+ * Pass `localize` (e.g. `game.i18n.localize.bind(game.i18n)`) so the helper
+ * stays Foundry-free and unit-testable.
+ */
+export function classifyRoll(
+    input: { type: string; subtype?: string; name?: string },
+    localize: Localize,
+): ClassifiedRoll {
+    let type = input.type;
+    let subtype = input.subtype ?? '';
+    const name = input.name ?? '';
+
+    if (RANGED_ATTACK_ALIASES.some(k => subtype === localize(k))) {
+        subtype = 'rangedattack';
+    } else if (subtype === localize('OD6S.MELEE')) {
+        subtype = 'meleeattack';
+    }
+
+    if (type === 'skill' && name === 'Dodge') {
+        subtype = 'dodge';
+    }
+
+    if (type === 'vehicletoughness') {
+        type = 'resistance';
+        subtype = 'vehicletoughness';
+    } else if (type === 'purchase') {
+        type = 'funds';
+        subtype = 'purchase';
+    }
+
+    if (type === 'action') {
+        if (subtype === 'vehicletoughness') {
+            type = 'resistance';
+        } else if (subtype === '' &&
+                   RESISTANCE_NAME_ALIASES.some(k => name === localize(k))) {
+            type = 'resistance';
+        }
+    }
+
+    return { type, subtype, key: deriveRollTypeKey(type, subtype) };
+}
+
+function deriveRollTypeKey(type: string, subtype: string): RollTypeKey {
+    switch (type) {
+        case 'weapon': return 'weapon';
+        case 'starship-weapon': return 'starship-weapon';
+        case 'vehicle-weapon': return 'vehicle-weapon';
+        case 'skill': return subtype === 'dodge' ? 'skill-dodge' : 'skill';
+        case 'specialization': return 'specialization';
+        case 'damage': return 'damage';
+        case 'resistance':
+            return subtype === 'vehicletoughness' ? 'resistance-vehicletoughness' : 'resistance';
+        case 'mortally_wounded': return 'mortally_wounded';
+        case 'incapacitated': return 'incapacitated';
+        case 'funds': return subtype === 'purchase' ? 'purchase' : 'funds';
+        case 'brawlattack': return 'brawlattack';
+        case 'action':
+            switch (subtype) {
+                case 'meleeattack': return 'action-meleeattack';
+                case 'brawlattack': return 'action-brawlattack';
+                case 'rangedattack': return 'action-rangedattack';
+                case 'vehiclerangedattack': return 'action-vehiclerangedattack';
+                case 'vehiclerangedweaponattack': return 'action-vehiclerangedweaponattack';
+                case 'vehicleramattack': return 'action-vehicleramattack';
+                case 'attribute': return 'action-attribute';
+                default: return 'action-other';
+            }
+    }
+    throw new Error(
+        `classifyRoll: unrecognized roll type "${type}"${subtype ? `, subtype "${subtype}"` : ''}`,
+    );
+}

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -220,6 +220,8 @@ export function isScoreTooLow(
 
 // ---- Roll-type classification (#98 prep) ----
 
+import { weaponTypes } from "../../config/weapons";
+
 /**
  * Stable handler-dispatch keys for every (type, subtype) path setupRollData
  * accepts. Drives the per-handler decomposition planned in #98 — a future
@@ -249,23 +251,29 @@ export type RollTypeKey =
     | 'purchase'
     | 'brawlattack';
 
+/** Canonical post-normalization roll types. Output of classifyRoll. */
+export type CanonicalRollType =
+    | 'weapon' | 'starship-weapon' | 'vehicle-weapon'
+    | 'action' | 'skill' | 'specialization'
+    | 'damage' | 'resistance'
+    | 'mortally_wounded' | 'incapacitated'
+    | 'funds' | 'brawlattack';
+
 export interface ClassifiedRoll {
-    /** Canonical type after normalization — what setupRollData ultimately uses. */
-    type: string;
-    /** Canonical subtype after normalization. Empty string when none. */
+    type: CanonicalRollType;
+    /**
+     * Canonical subtype after normalization. Empty string when none.
+     * Load-bearing for `action-other`: that key collapses every unrecognized
+     * action subtype into one bucket while preserving the original string here,
+     * so callers handling action-other can still inspect the input subtype.
+     */
     subtype: string;
-    /** Stable discriminator for handler dispatch. */
     key: RollTypeKey;
 }
 
 export type Localize = (key: string) => string;
 
-const RANGED_ATTACK_ALIASES = [
-    'OD6S.RANGED',
-    'OD6S.THROWN',
-    'OD6S.MISSILE',
-    'OD6S.EXPLOSIVE',
-] as const;
+const MELEE_WEAPON_TYPE_KEY = 'OD6S.MELEE';
 
 const RESISTANCE_NAME_ALIASES = [
     'OD6S.ENERGY_RESISTANCE',
@@ -292,10 +300,13 @@ export function classifyRoll(
     let subtype = input.subtype ?? '';
     const name = input.name ?? '';
 
-    if (RANGED_ATTACK_ALIASES.some(k => subtype === localize(k))) {
-        subtype = 'rangedattack';
-    } else if (subtype === localize('OD6S.MELEE')) {
-        subtype = 'meleeattack';
+    // Reuses the canonical weapon-type list from config/weapons so adding a
+    // new ranged weapon type there picks up alias normalization automatically.
+    for (const k of weaponTypes) {
+        if (subtype === localize(k)) {
+            subtype = k === MELEE_WEAPON_TYPE_KEY ? 'meleeattack' : 'rangedattack';
+            break;
+        }
     }
 
     if (type === 'skill' && name === 'Dodge') {
@@ -319,10 +330,26 @@ export function classifyRoll(
         }
     }
 
+    if (!isCanonicalType(type)) {
+        throw new Error(`classifyRoll: unrecognized roll type "${type}"`);
+    }
     return { type, subtype, key: deriveRollTypeKey(type, subtype) };
 }
 
-function deriveRollTypeKey(type: string, subtype: string): RollTypeKey {
+function isCanonicalType(type: string): type is CanonicalRollType {
+    switch (type) {
+        case 'weapon': case 'starship-weapon': case 'vehicle-weapon':
+        case 'action': case 'skill': case 'specialization':
+        case 'damage': case 'resistance':
+        case 'mortally_wounded': case 'incapacitated':
+        case 'funds': case 'brawlattack':
+            return true;
+        default:
+            return false;
+    }
+}
+
+function deriveRollTypeKey(type: CanonicalRollType, subtype: string): RollTypeKey {
     switch (type) {
         case 'weapon': return 'weapon';
         case 'starship-weapon': return 'starship-weapon';
@@ -348,7 +375,4 @@ function deriveRollTypeKey(type: string, subtype: string): RollTypeKey {
                 default: return 'action-other';
             }
     }
-    throw new Error(
-        `classifyRoll: unrecognized roll type "${type}"${subtype ? `, subtype "${subtype}"` : ''}`,
-    );
 }

--- a/src/module/apps/roll-helpers/roll-type-fields.test.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.test.ts
@@ -1,53 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { COMMON_FIELDS, ROLL_TYPE_FIELDS } from './roll-type-fields';
-import type { RollData, RollTypeKey } from './roll-data';
+import type { RollData } from './roll-data';
 
-/**
- * Canonical list of every keyof RollData. Sourced from the interface
- * declaration in roll-data.ts — keep in sync. The well-formedness test
- * fails loudly if RollData grows a field that's not classified.
- */
-const ALL_ROLL_DATA_FIELDS: readonly (keyof RollData)[] = [
-    'label', 'title', 'dice', 'pips', 'specSkill', 'originaldice', 'originalpips',
-    'score', 'wilddie', 'showWildDie', 'canusefp', 'fatepoint', 'fatepointeffect',
-    'characterpoints', 'canusecp', 'contact', 'cpcost', 'cpcostcolor',
-    'bonusdice', 'bonuspips', 'isvisible', 'isknown', 'isExplosive',
-    'type', 'subtype', 'attribute', 'actor', 'token',
-    'actionpenalty', 'woundpenalty', 'stunnedpenalty', 'otherpenalty',
-    'multishot', 'shots', 'fulldefense', 'itemid', 'targets', 'target',
-    'timer', 'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
-    'damagemodifiers', 'difficultylevel', 'isoppasable', 'difficulty',
-    'scaledice', 'seller', 'vehicle', 'vehiclespeed', 'vehiclecollisiontype',
-    'vehicleterraindifficulty', 'source', 'range', 'template',
-    'only_stun', 'can_stun', 'stun', 'attackerScale', 'modifiers', 'rollmode',
-];
-
-const allBucketFields = (): Set<keyof RollData> => {
-    const u = new Set<keyof RollData>();
-    for (const fields of Object.values(ROLL_TYPE_FIELDS)) {
-        for (const f of fields) u.add(f);
-    }
-    return u;
-};
-
-describe('ROLL_TYPE_FIELDS / COMMON_FIELDS partition', () => {
-    it('every keyof RollData appears in COMMON_FIELDS or at least one handler bucket', () => {
-        const common = new Set<keyof RollData>(COMMON_FIELDS);
-        const handlerOwned = allBucketFields();
-        const missing = ALL_ROLL_DATA_FIELDS.filter(f => !common.has(f) && !handlerOwned.has(f));
-        expect(missing).toEqual([]);
-    });
-
-    it('no field appears in both COMMON_FIELDS and any handler bucket (strict partition)', () => {
-        const common = new Set<keyof RollData>(COMMON_FIELDS);
-        const overlap: { key: RollTypeKey; field: keyof RollData }[] = [];
-        for (const [key, fields] of Object.entries(ROLL_TYPE_FIELDS) as [RollTypeKey, readonly (keyof RollData)[]][]) {
-            for (const f of fields) {
-                if (common.has(f)) overlap.push({ key, field: f });
-            }
-        }
-        expect(overlap).toEqual([]);
-    });
+describe('ROLL_TYPE_FIELDS / COMMON_FIELDS', () => {
+    // Partition totality and overlap are compile-time checked in roll-type-fields.ts;
+    // this file only catches what TypeScript can't: within-list duplicates.
 
     it('COMMON_FIELDS has no duplicates', () => {
         expect(COMMON_FIELDS.length).toBe(new Set(COMMON_FIELDS).size);
@@ -58,31 +15,20 @@ describe('ROLL_TYPE_FIELDS / COMMON_FIELDS partition', () => {
             expect(fields.length, `bucket ${key}`).toBe(new Set(fields).size);
         }
     });
-
-    it('ALL_ROLL_DATA_FIELDS matches the declared partition size (catches RollData growth)', () => {
-        // If RollData gains a new field, ALL_ROLL_DATA_FIELDS needs updating
-        // and the partition test above will report the missing field.
-        const partitionSize = COMMON_FIELDS.length + allBucketFields().size;
-        expect(ALL_ROLL_DATA_FIELDS.length).toBe(partitionSize);
-    });
 });
 
-describe('ROLL_TYPE_FIELDS cross-cutting visibility', () => {
-    /**
-     * Diagnostic, not asserted: documents which fields are written by
-     * multiple handlers (the cross-cutting state leaks #98 calls out).
-     * If this list shrinks dramatically, something is wrong with the map.
-     */
-    it('reports fields owned by 2+ handlers', () => {
+describe('ROLL_TYPE_FIELDS cross-cutting fields', () => {
+    // Spot-checks the well-known cross-cutting overlap zones #98 calls out as
+    // the surgery risk. If these fields stop being multi-handler, the map has
+    // drifted from the actual mutation graph.
+    it('damage/attack fields are owned by 2+ handlers', () => {
         const counts = new Map<keyof RollData, number>();
         for (const fields of Object.values(ROLL_TYPE_FIELDS)) {
             for (const f of fields) counts.set(f, (counts.get(f) ?? 0) + 1);
         }
         const crossCutting = [...counts.entries()]
             .filter(([, n]) => n >= 2)
-            .map(([f]) => f)
-            .sort();
-        // Sanity: damage/attack fields are the well-known overlap zones.
+            .map(([f]) => f);
         expect(crossCutting).toContain('damagetype');
         expect(crossCutting).toContain('damagescore');
         expect(crossCutting).toContain('attackerScale');

--- a/src/module/apps/roll-helpers/roll-type-fields.test.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { COMMON_FIELDS, ROLL_TYPE_FIELDS } from './roll-type-fields';
+import type { RollData, RollTypeKey } from './roll-data';
+
+/**
+ * Canonical list of every keyof RollData. Sourced from the interface
+ * declaration in roll-data.ts — keep in sync. The well-formedness test
+ * fails loudly if RollData grows a field that's not classified.
+ */
+const ALL_ROLL_DATA_FIELDS: readonly (keyof RollData)[] = [
+    'label', 'title', 'dice', 'pips', 'specSkill', 'originaldice', 'originalpips',
+    'score', 'wilddie', 'showWildDie', 'canusefp', 'fatepoint', 'fatepointeffect',
+    'characterpoints', 'canusecp', 'contact', 'cpcost', 'cpcostcolor',
+    'bonusdice', 'bonuspips', 'isvisible', 'isknown', 'isExplosive',
+    'type', 'subtype', 'attribute', 'actor', 'token',
+    'actionpenalty', 'woundpenalty', 'stunnedpenalty', 'otherpenalty',
+    'multishot', 'shots', 'fulldefense', 'itemid', 'targets', 'target',
+    'timer', 'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
+    'damagemodifiers', 'difficultylevel', 'isoppasable', 'difficulty',
+    'scaledice', 'seller', 'vehicle', 'vehiclespeed', 'vehiclecollisiontype',
+    'vehicleterraindifficulty', 'source', 'range', 'template',
+    'only_stun', 'can_stun', 'stun', 'attackerScale', 'modifiers', 'rollmode',
+];
+
+const allBucketFields = (): Set<keyof RollData> => {
+    const u = new Set<keyof RollData>();
+    for (const fields of Object.values(ROLL_TYPE_FIELDS)) {
+        for (const f of fields) u.add(f);
+    }
+    return u;
+};
+
+describe('ROLL_TYPE_FIELDS / COMMON_FIELDS partition', () => {
+    it('every keyof RollData appears in COMMON_FIELDS or at least one handler bucket', () => {
+        const common = new Set<keyof RollData>(COMMON_FIELDS);
+        const handlerOwned = allBucketFields();
+        const missing = ALL_ROLL_DATA_FIELDS.filter(f => !common.has(f) && !handlerOwned.has(f));
+        expect(missing).toEqual([]);
+    });
+
+    it('no field appears in both COMMON_FIELDS and any handler bucket (strict partition)', () => {
+        const common = new Set<keyof RollData>(COMMON_FIELDS);
+        const overlap: { key: RollTypeKey; field: keyof RollData }[] = [];
+        for (const [key, fields] of Object.entries(ROLL_TYPE_FIELDS) as [RollTypeKey, readonly (keyof RollData)[]][]) {
+            for (const f of fields) {
+                if (common.has(f)) overlap.push({ key, field: f });
+            }
+        }
+        expect(overlap).toEqual([]);
+    });
+
+    it('COMMON_FIELDS has no duplicates', () => {
+        expect(COMMON_FIELDS.length).toBe(new Set(COMMON_FIELDS).size);
+    });
+
+    it('each handler bucket has no duplicates', () => {
+        for (const [key, fields] of Object.entries(ROLL_TYPE_FIELDS)) {
+            expect(fields.length, `bucket ${key}`).toBe(new Set(fields).size);
+        }
+    });
+
+    it('ALL_ROLL_DATA_FIELDS matches the declared partition size (catches RollData growth)', () => {
+        // If RollData gains a new field, ALL_ROLL_DATA_FIELDS needs updating
+        // and the partition test above will report the missing field.
+        const partitionSize = COMMON_FIELDS.length + allBucketFields().size;
+        expect(ALL_ROLL_DATA_FIELDS.length).toBe(partitionSize);
+    });
+});
+
+describe('ROLL_TYPE_FIELDS cross-cutting visibility', () => {
+    /**
+     * Diagnostic, not asserted: documents which fields are written by
+     * multiple handlers (the cross-cutting state leaks #98 calls out).
+     * If this list shrinks dramatically, something is wrong with the map.
+     */
+    it('reports fields owned by 2+ handlers', () => {
+        const counts = new Map<keyof RollData, number>();
+        for (const fields of Object.values(ROLL_TYPE_FIELDS)) {
+            for (const f of fields) counts.set(f, (counts.get(f) ?? 0) + 1);
+        }
+        const crossCutting = [...counts.entries()]
+            .filter(([, n]) => n >= 2)
+            .map(([f]) => f)
+            .sort();
+        // Sanity: damage/attack fields are the well-known overlap zones.
+        expect(crossCutting).toContain('damagetype');
+        expect(crossCutting).toContain('damagescore');
+        expect(crossCutting).toContain('attackerScale');
+        expect(crossCutting).toContain('range');
+    });
+});

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -30,9 +30,10 @@ export const COMMON_FIELDS = [
     'wilddie', 'showWildDie',
     'fatepoint', 'fatepointeffect', 'characterpoints',
     'contact', 'cpcost', 'cpcostcolor',
-    // canusefp/cp diverge in funds/purchase/vehicletoughness, but always to
-    // the same value (false) — that's a finalize policy keyed by canonical
-    // type, not handler output.
+    // canusefp/cp diverge in vehicletoughness paths (always false) and in
+    // funds/purchase paths (false only when OD6S.fundsFate is off, otherwise
+    // true). Both are finalize policies keyed by canonical type and the
+    // funds_fate setting, not handler output.
     'canusefp', 'canusecp',
     // Visibility maps from RollTypeKey to a setting key in finalize, not
     // handler output.
@@ -105,6 +106,10 @@ export const ROLL_TYPE_FIELDS = {
         'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
         'can_stun', 'attackerScale',
     ],
+
+    // Top-level attribute roll (Actor.rollAttribute). Flows through
+    // setupRollData with no type-specific writes; score/dice come from input.
+    'attribute': [],
 } as const satisfies Record<RollTypeKey, readonly (keyof RollData)[]>;
 
 // ---- Compile-time partition invariants ----

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -5,100 +5,70 @@
  *   - {@link COMMON_FIELDS}: finalize sets these uniformly for every roll
  *     type. Handlers MUST NOT diverge from the default for these.
  *   - {@link ROLL_TYPE_FIELDS}[key]: fields the handler for `key` is allowed
- *     to populate in its partial output. The union across all keys plus
- *     COMMON_FIELDS must equal `keyof RollData` (asserted by the test).
+ *     to populate in its partial output.
  *
- * The cross-cutting risk the #98 issue calls out (bonusmod / miscMod /
- * damageScore are written by multiple type-specific paths and folded into
- * common-derived fields like bonusdice) shows up here as fields appearing
- * in multiple ROLL_TYPE_FIELDS buckets — that overlap is the type-specific
- * contribution. The fold itself (bonusmod → bonusdice/bonuspips) happens
- * in finalize, so bonusdice/bonuspips are COMMON even though every attack
- * handler contributes a bonusmod increment that feeds them.
+ * Partition invariants (totality, no overlap) are checked at compile time
+ * via the `_assert*` types below — bad declarations fail to type-check
+ * before any runtime test runs.
+ *
+ * The cross-cutting risk #98 calls out (bonusmod / miscMod / damageScore are
+ * written by multiple type-specific paths and folded into common-derived
+ * fields like bonusdice) shows up here as fields appearing in multiple
+ * ROLL_TYPE_FIELDS buckets — that overlap is the type-specific contribution.
+ * The fold itself happens in finalize, so bonusdice/bonuspips are COMMON
+ * even though every attack handler contributes a bonusmod increment.
  *
  * No Foundry globals; pure data + types.
  */
 
 import type { RollData, RollTypeKey } from './roll-data';
 
-/**
- * Fields finalize sets uniformly. A field belongs here iff *no* handler
- * needs to override its default — finalize fills it from input data,
- * actor state, settings, or by folding handler-contributed intermediates.
- */
-export const COMMON_FIELDS: readonly (keyof RollData)[] = [
-    // Identity / labels
+export const COMMON_FIELDS = [
     'label', 'title',
-    // Roll dice/pips — derived in finalize from score (handler may override
-    // score, but the score→dice conversion is uniform).
     'dice', 'pips', 'originaldice', 'originalpips',
-    // Bonus dice — derived in finalize from accumulated bonusmod.
     'bonusdice', 'bonuspips',
-    // Wild die — setting + actor flag, no handler diverges.
     'wilddie', 'showWildDie',
-    // Fate-point / character-point ledger — finalize-managed.
     'fatepoint', 'fatepointeffect', 'characterpoints',
     'contact', 'cpcost', 'cpcostcolor',
-    // CP/FP eligibility — flipped to false by funds/purchase/vehicletoughness
-    // policies in finalize keyed off the canonical type, not by handlers.
+    // canusefp/cp diverge in funds/purchase/vehicletoughness, but always to
+    // the same value (false) — that's a finalize policy keyed by canonical
+    // type, not handler output.
     'canusefp', 'canusecp',
-    // Visibility — every roll type sets this from a setting key. The mapping
-    // is a finalize policy keyed by RollTypeKey, not handler output.
+    // Visibility maps from RollTypeKey to a setting key in finalize, not
+    // handler output.
     'isvisible', 'isknown',
-    // Explosive flag — derived from item flag at top of setup, before dispatch.
+    // Derived from item flag at top of setup, before dispatch.
     'isExplosive',
-    // Canonical type/subtype — produced by classifyRoll, not handlers.
+    // Produced by classifyRoll, not handlers.
     'type', 'subtype',
-    // Actor / token — input.
     'actor', 'token',
-    // Penalty bundle — derived in finalize via computePenalties + splitBonus.
+    // Derived in finalize via computePenalties + splitBonusForPenalty.
     'actionpenalty', 'woundpenalty', 'stunnedpenalty', 'otherpenalty',
-    // Combat shot/defense ledger — finalize defaults.
     'multishot', 'shots', 'fulldefense', 'timer',
-    // Item / target plumbing — input.
     'itemid', 'targets', 'target',
-    // Difficulty number — input (handler may set difficultylevel string but
-    // not the number).
+    // Number — handlers may set difficultylevel string but not the number.
     'difficulty',
-    // Opposability — derived from canonical type/subtype in finalize.
+    // Derived from canonical type/subtype in finalize.
     'isoppasable',
-    // Vehicle UI defaults — literal in finalize.
     'vehiclespeed', 'vehiclecollisiontype', 'vehicleterraindifficulty',
-    // Template path — literal.
     'template',
-    // Modifiers subobject — finalize assembles from miscMod/scaleMod/range.
+    // Finalize assembles from miscMod/scaleMod/range intermediates.
     'modifiers',
-    // Roll mode — set later by execute path, optional.
+    // Set by execute path, not setup.
     'rollmode',
-];
+] as const satisfies readonly (keyof RollData)[];
 
-/**
- * Per-handler field ownership. Each handler may populate the listed fields
- * in its partial output; finalize fills the rest from {@link COMMON_FIELDS}.
- *
- * Overlap between buckets is intentional and meaningful — it documents the
- * cross-cutting fields that multiple type-specific paths contribute to.
- */
-export const ROLL_TYPE_FIELDS: Record<RollTypeKey, readonly (keyof RollData)[]> = {
-    // ---- Direct weapon rolls (hand-held, vehicle-mounted, starship-mounted) ----
-    'weapon': [
-        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
-        'damagemodifiers', 'source', 'range', 'difficultylevel',
-        'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
-    ],
-    'starship-weapon': [
-        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
-        'damagemodifiers', 'source', 'range', 'difficultylevel',
-        'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
-    ],
-    'vehicle-weapon': [
-        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
-        'damagemodifiers', 'source', 'range', 'difficultylevel',
-        'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
-        'vehicle',
-    ],
+const WEAPON_BUCKET = [
+    'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
+    'damagemodifiers', 'source', 'range', 'difficultylevel',
+    'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
+] as const satisfies readonly (keyof RollData)[];
 
-    // ---- Action rolls (skill-backed combat actions) ----
+export const ROLL_TYPE_FIELDS = {
+    'weapon': WEAPON_BUCKET,
+    'starship-weapon': WEAPON_BUCKET,
+    'vehicle-weapon': [...WEAPON_BUCKET, 'vehicle'],
+
     'action-meleeattack': ['score', 'attackerScale', 'damagescore'],
     'action-brawlattack': [
         'score', 'attackerScale',
@@ -118,25 +88,44 @@ export const ROLL_TYPE_FIELDS: Record<RollTypeKey, readonly (keyof RollData)[]> 
     'action-attribute': ['score'],
     'action-other': [],
 
-    // ---- Skill / specialization rolls ----
     'skill': ['attribute'],
     'skill-dodge': ['attribute'],
     'specialization': ['attribute', 'specSkill'],
 
-    // ---- Damage / resistance / wound / status rolls ----
     'damage': [],
     'resistance': ['scaledice'],
     'resistance-vehicletoughness': ['scaledice', 'vehicle'],
     'mortally_wounded': [],
     'incapacitated': [],
 
-    // ---- Economy ----
     'funds': [],
     'purchase': ['seller'],
 
-    // ---- Top-level brawl (sheet button shortcut) ----
     'brawlattack': [
         'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
         'can_stun', 'attackerScale',
     ],
-};
+} as const satisfies Record<RollTypeKey, readonly (keyof RollData)[]>;
+
+// ---- Compile-time partition invariants ----
+//
+// These types resolve to `never` iff the partition is well-formed; if any
+// invariant is violated, the corresponding `_assert*` constant fails to
+// type-check with the offending field name in the error.
+
+type AnyHandlerField = (typeof ROLL_TYPE_FIELDS)[RollTypeKey][number];
+type AnyCommonField = (typeof COMMON_FIELDS)[number];
+
+/** Fields in RollData not covered by COMMON_FIELDS or any handler bucket. */
+type _MissingFromPartition = Exclude<keyof RollData, AnyCommonField | AnyHandlerField>;
+
+/** Fields listed in the partition that aren't actually keyof RollData. (Should be never since `satisfies` already constrains.) */
+type _ExtraInPartition = Exclude<AnyCommonField | AnyHandlerField, keyof RollData>;
+
+/** Fields appearing in BOTH COMMON_FIELDS and a handler bucket — strict-partition violation. */
+type _CommonHandlerOverlap = Extract<AnyCommonField, AnyHandlerField>;
+
+const _assertNoMissing: [_MissingFromPartition] extends [never] ? true : never = true;
+const _assertNoExtra: [_ExtraInPartition] extends [never] ? true : never = true;
+const _assertNoOverlap: [_CommonHandlerOverlap] extends [never] ? true : never = true;
+void _assertNoMissing; void _assertNoExtra; void _assertNoOverlap;

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -1,0 +1,142 @@
+/**
+ * Mutation-map contract for #98 (per-roll-type handler decomposition).
+ *
+ * Partitions {@link RollData}'s fields into:
+ *   - {@link COMMON_FIELDS}: finalize sets these uniformly for every roll
+ *     type. Handlers MUST NOT diverge from the default for these.
+ *   - {@link ROLL_TYPE_FIELDS}[key]: fields the handler for `key` is allowed
+ *     to populate in its partial output. The union across all keys plus
+ *     COMMON_FIELDS must equal `keyof RollData` (asserted by the test).
+ *
+ * The cross-cutting risk the #98 issue calls out (bonusmod / miscMod /
+ * damageScore are written by multiple type-specific paths and folded into
+ * common-derived fields like bonusdice) shows up here as fields appearing
+ * in multiple ROLL_TYPE_FIELDS buckets — that overlap is the type-specific
+ * contribution. The fold itself (bonusmod → bonusdice/bonuspips) happens
+ * in finalize, so bonusdice/bonuspips are COMMON even though every attack
+ * handler contributes a bonusmod increment that feeds them.
+ *
+ * No Foundry globals; pure data + types.
+ */
+
+import type { RollData, RollTypeKey } from './roll-data';
+
+/**
+ * Fields finalize sets uniformly. A field belongs here iff *no* handler
+ * needs to override its default — finalize fills it from input data,
+ * actor state, settings, or by folding handler-contributed intermediates.
+ */
+export const COMMON_FIELDS: readonly (keyof RollData)[] = [
+    // Identity / labels
+    'label', 'title',
+    // Roll dice/pips — derived in finalize from score (handler may override
+    // score, but the score→dice conversion is uniform).
+    'dice', 'pips', 'originaldice', 'originalpips',
+    // Bonus dice — derived in finalize from accumulated bonusmod.
+    'bonusdice', 'bonuspips',
+    // Wild die — setting + actor flag, no handler diverges.
+    'wilddie', 'showWildDie',
+    // Fate-point / character-point ledger — finalize-managed.
+    'fatepoint', 'fatepointeffect', 'characterpoints',
+    'contact', 'cpcost', 'cpcostcolor',
+    // CP/FP eligibility — flipped to false by funds/purchase/vehicletoughness
+    // policies in finalize keyed off the canonical type, not by handlers.
+    'canusefp', 'canusecp',
+    // Visibility — every roll type sets this from a setting key. The mapping
+    // is a finalize policy keyed by RollTypeKey, not handler output.
+    'isvisible', 'isknown',
+    // Explosive flag — derived from item flag at top of setup, before dispatch.
+    'isExplosive',
+    // Canonical type/subtype — produced by classifyRoll, not handlers.
+    'type', 'subtype',
+    // Actor / token — input.
+    'actor', 'token',
+    // Penalty bundle — derived in finalize via computePenalties + splitBonus.
+    'actionpenalty', 'woundpenalty', 'stunnedpenalty', 'otherpenalty',
+    // Combat shot/defense ledger — finalize defaults.
+    'multishot', 'shots', 'fulldefense', 'timer',
+    // Item / target plumbing — input.
+    'itemid', 'targets', 'target',
+    // Difficulty number — input (handler may set difficultylevel string but
+    // not the number).
+    'difficulty',
+    // Opposability — derived from canonical type/subtype in finalize.
+    'isoppasable',
+    // Vehicle UI defaults — literal in finalize.
+    'vehiclespeed', 'vehiclecollisiontype', 'vehicleterraindifficulty',
+    // Template path — literal.
+    'template',
+    // Modifiers subobject — finalize assembles from miscMod/scaleMod/range.
+    'modifiers',
+    // Roll mode — set later by execute path, optional.
+    'rollmode',
+];
+
+/**
+ * Per-handler field ownership. Each handler may populate the listed fields
+ * in its partial output; finalize fills the rest from {@link COMMON_FIELDS}.
+ *
+ * Overlap between buckets is intentional and meaningful — it documents the
+ * cross-cutting fields that multiple type-specific paths contribute to.
+ */
+export const ROLL_TYPE_FIELDS: Record<RollTypeKey, readonly (keyof RollData)[]> = {
+    // ---- Direct weapon rolls (hand-held, vehicle-mounted, starship-mounted) ----
+    'weapon': [
+        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
+        'damagemodifiers', 'source', 'range', 'difficultylevel',
+        'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
+    ],
+    'starship-weapon': [
+        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
+        'damagemodifiers', 'source', 'range', 'difficultylevel',
+        'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
+    ],
+    'vehicle-weapon': [
+        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
+        'damagemodifiers', 'source', 'range', 'difficultylevel',
+        'only_stun', 'can_stun', 'stun', 'attackerScale', 'specSkill',
+        'vehicle',
+    ],
+
+    // ---- Action rolls (skill-backed combat actions) ----
+    'action-meleeattack': ['score', 'attackerScale', 'damagescore'],
+    'action-brawlattack': [
+        'score', 'attackerScale',
+        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore', 'can_stun',
+    ],
+    'action-rangedattack': ['score', 'range', 'difficultylevel', 'attackerScale'],
+    'action-vehiclerangedattack': [
+        'score', 'range', 'difficultylevel', 'attackerScale', 'vehicle',
+    ],
+    'action-vehiclerangedweaponattack': [
+        'damagetype', 'damagescore', 'source',
+        'range', 'difficultylevel', 'attackerScale', 'vehicle',
+    ],
+    'action-vehicleramattack': [
+        'damagetype', 'damagemodifiers', 'source', 'attackerScale', 'vehicle',
+    ],
+    'action-attribute': ['score'],
+    'action-other': [],
+
+    // ---- Skill / specialization rolls ----
+    'skill': ['attribute'],
+    'skill-dodge': ['attribute'],
+    'specialization': ['attribute', 'specSkill'],
+
+    // ---- Damage / resistance / wound / status rolls ----
+    'damage': [],
+    'resistance': ['scaledice'],
+    'resistance-vehicletoughness': ['scaledice', 'vehicle'],
+    'mortally_wounded': [],
+    'incapacitated': [],
+
+    // ---- Economy ----
+    'funds': [],
+    'purchase': ['seller'],
+
+    // ---- Top-level brawl (sheet button shortcut) ----
+    'brawlattack': [
+        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
+        'can_stun', 'attackerScale',
+    ],
+};

--- a/tests/smoke/tier-3-action-rolls.spec.ts
+++ b/tests/smoke/tier-3-action-rolls.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Tier 3b — Action-roll dispatch paths uncovered by tier-3-roll /
+ * tier-3-skill-roll / tier-3-weapon-roll.
+ *
+ * Each test triggers actor.rollAction(actionId) for one of the dispatch
+ * branches in setupRollData (#98) that has no other smoke coverage:
+ *   - brawlattack       → action-brawlattack
+ *   - vehicleramattack  → action-vehicleramattack
+ *   - vehicletoughness  → resistance-vehicletoughness (top-level type rewrite)
+ *
+ * Assertion shape mirrors tier-3-weapon-roll: dialog opens, submit produces
+ * a chat message with od6s flags. Doesn't pin specific flag values — the
+ * flag schema is unstable across the rewrite — only that the path runs end
+ * to end without throwing.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+type ActionRollResult = {
+    dialogOpened: boolean;
+    chatCreated: boolean;
+    chatType: string | null;
+    errs: string[];
+};
+
+async function ensureCharacter(page: import("@playwright/test").Page): Promise<void> {
+    await evalInWorld(page, async () => {
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-character");
+        if (!actor) {
+            actor = await window.Actor.create({name: "smoke-character", type: "character"}, {render: false});
+        }
+        // brawlattack rolls strength damage; need attributes populated.
+        if (actor.system.attributes.str.base < 1) {
+            await actor.update({
+                "system.attributes.str.base": 9,
+                "system.attributes.agi.base": 9,
+            });
+        }
+    });
+}
+
+async function ensureVehicle(page: import("@playwright/test").Page): Promise<void> {
+    await evalInWorld(page, async () => {
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-vehicle-action");
+        if (!actor) {
+            await window.Actor.create({
+                name: "smoke-vehicle-action",
+                type: "vehicle",
+                system: {
+                    scale: {score: 3},
+                    maneuverability: {score: 6},
+                    toughness: {score: 12},
+                    move: {value: 84},
+                    crew: {value: 1},
+                    skill: {value: "Vehicle Operation"},
+                    specialization: {value: ""},
+                    ram: {score: 6},
+                    ram_damage: {score: 6},
+                },
+            }, {render: false});
+        }
+    });
+}
+
+async function runActionRoll(
+    page: import("@playwright/test").Page,
+    actorName: string,
+    actionId: string,
+): Promise<ActionRollResult> {
+    return await evalInWorld(page, async (args: {actorName: string; actionId: string}) => {
+        const errs: string[] = [];
+        const onRej = (e: PromiseRejectionEvent) =>
+            errs.push("rej: " + (e.reason?.message ?? String(e.reason)));
+        window.addEventListener("unhandledrejection", onRej);
+
+        try {
+            const actor = window.game.actors.find((a: any) => a.name === args.actorName);
+            if (!actor) throw new Error(`actor ${args.actorName} not found`);
+
+            const apps0 = new Set([...window.foundry.applications.instances.keys()]);
+            await actor.rollAction(args.actionId);
+            await new Promise((r) => setTimeout(r, 500));
+
+            const dlg = [...window.foundry.applications.instances.values()].find(
+                (a: any) => !apps0.has(a.id) && a.constructor.name.includes("RollDialog"),
+            );
+
+            let chatCreated = false;
+            let chatType: string | null = null;
+            if (dlg) {
+                const msgsBefore = window.game.messages.size;
+                (dlg as any).element.querySelector('[data-action="submit"]')?.click();
+                await new Promise((r) => setTimeout(r, 800));
+                if (window.game.messages.size > msgsBefore) {
+                    chatCreated = true;
+                    const msgs = [...window.game.messages.contents];
+                    const last = msgs[msgs.length - 1];
+                    chatType = last?.flags?.od6s?.type ?? null;
+                }
+                try { await (dlg as any).close(); } catch { /* ignore */ }
+            }
+
+            await new Promise((r) => setTimeout(r, 200));
+            window.removeEventListener("unhandledrejection", onRej);
+            return {dialogOpened: !!dlg, chatCreated, chatType, errs};
+        } catch (e) {
+            window.removeEventListener("unhandledrejection", onRej);
+            return {
+                dialogOpened: false,
+                chatCreated: false,
+                chatType: null,
+                errs: [(e as Error).message],
+            };
+        }
+    }, {actorName, actionId});
+}
+
+test("brawlattack action roll opens dialog and creates chat message", async ({page}) => {
+    await loginAndWaitReady(page);
+    await ensureCharacter(page);
+
+    const result = await runActionRoll(page, "smoke-character", "brawlattack");
+
+    expect(result.errs, "unhandled rejections").toEqual([]);
+    expect(result.dialogOpened, "brawl dialog opened").toBe(true);
+    expect(result.chatCreated, "brawl chat message created").toBe(true);
+    expect(result.chatType, "message has od6s.type flag").toBeTruthy();
+});
+
+test("vehicleramattack action roll opens dialog and creates chat message", async ({page}) => {
+    await loginAndWaitReady(page);
+    await ensureVehicle(page);
+
+    const result = await runActionRoll(page, "smoke-vehicle-action", "vehicleramattack");
+
+    expect(result.errs, "unhandled rejections").toEqual([]);
+    expect(result.dialogOpened, "ram dialog opened").toBe(true);
+    expect(result.chatCreated, "ram chat message created").toBe(true);
+    expect(result.chatType, "message has od6s.type flag").toBeTruthy();
+});
+
+test("vehicletoughness action roll opens dialog and creates chat message", async ({page}) => {
+    await loginAndWaitReady(page);
+    await ensureVehicle(page);
+
+    const result = await runActionRoll(page, "smoke-vehicle-action", "vehicletoughness");
+
+    expect(result.errs, "unhandled rejections").toEqual([]);
+    expect(result.dialogOpened, "toughness dialog opened").toBe(true);
+    expect(result.chatCreated, "toughness chat message created").toBe(true);
+    // vehicletoughness top-level rewrite collapses to type='resistance' in classifyRoll.
+    expect(result.chatType, "message has od6s.type flag").toBeTruthy();
+});

--- a/tests/smoke/tier-3-action-rolls.spec.ts
+++ b/tests/smoke/tier-3-action-rolls.spec.ts
@@ -6,7 +6,10 @@
  * branches in setupRollData (#98) that has no other smoke coverage:
  *   - brawlattack       → action-brawlattack
  *   - vehicleramattack  → action-vehicleramattack
- *   - vehicletoughness  → resistance-vehicletoughness (top-level type rewrite)
+ *   - vehicletoughness  → resistance-vehicletoughness (action+vehicletoughness
+ *                         path — rollAction wraps with type='action'; the
+ *                         top-level type='vehicletoughness' rewrite remains
+ *                         uncovered by smoke)
  *
  * Assertion shape mirrors tier-3-weapon-roll: dialog opens, submit produces
  * a chat message with od6s flags. Doesn't pin specific flag values — the
@@ -149,6 +152,8 @@ test("vehicletoughness action roll opens dialog and creates chat message", async
     expect(result.errs, "unhandled rejections").toEqual([]);
     expect(result.dialogOpened, "toughness dialog opened").toBe(true);
     expect(result.chatCreated, "toughness chat message created").toBe(true);
-    // vehicletoughness top-level rewrite collapses to type='resistance' in classifyRoll.
+    // action+vehicletoughness collapses to type='resistance' via the action-
+    // subtype rewrite at roll-setup.ts:309-313 (classifier key: resistance-
+    // vehicletoughness).
     expect(result.chatType, "message has od6s.type flag").toBeTruthy();
 });


### PR DESCRIPTION
## Summary

Three pre-rewrite deliverables for #98 (decompose `setupRollData` into per-roll-type handlers), each landing in its own commit. Helpers are not yet wired into `setupRollData` — wiring belongs to the rewrite, not prep.

- **A. Classifier** (`ee668b2`) — `RollTypeKey` discriminated union (22 variants) + pure `classifyRoll(input, localize)` in `roll-data.ts`. Mirrors every type/subtype rewrite scattered through `setupRollData` (i18n alias collapse, `vehicletoughness → resistance`, `purchase → funds`, `skill+Dodge`, `action+''` resistance-by-name). 53 unit tests cover every key, every alias, and the alias × rewrite interactions. Throws on unknown types so unregistered paths fail loudly at the boundary.

- **B. Mutation map** (`75415a5`, hardened in `0fcbff9`) — `COMMON_FIELDS` + `ROLL_TYPE_FIELDS` in `roll-type-fields.ts` declaring which fields each handler is allowed to populate vs which finalize sets uniformly. Partition invariants (totality, no overlap, no extras) enforced at **compile time** via `as const satisfies` + `Exclude`/`Extract` types — bad declarations fail `tsc`, not a runtime test. Cross-cutting fields (`damagetype`, `damagescore`, `attackerScale`, `range`, etc.) intentionally appear in multiple buckets, documenting the surgery risk #98 calls out.

- **C. Smoke probes** (`7d24306`, comment fix in `92b9554`) — `tests/smoke/tier-3-action-rolls.spec.ts` covers three previously-uncovered dispatch paths via `actor.rollAction(actionId)`: `brawlattack`, `vehicleramattack`, `vehicletoughness` (action-subtype variant). Each opens the roll dialog, submits, asserts a chat message with an `od6s.type` flag.

## Why land this separately from the rewrite

`setupRollData` is fundamentally a dispatch on `(data.type, data.subtype)` over ~20 paths, expressed as 30+ mutable locals + sequential `if` blocks (#82's helper extraction plateaued at 678 LOC for this reason). The rewrite needs:
1. An enumeration of the dispatch paths in code (A).
2. A type-specific vs common partition the handlers can be typed against (B).
3. Smoke coverage for paths that today only exist as `if` blocks no test exercises (C).

Doing all three on the rewrite branch would conflate "what we're building toward" with "the build itself." Landing them first makes the rewrite a smaller, mechanically-driven transformation against a fixed contract.

## Reviews already done

- **Quality pass** (`0fcbff9`): three review agents (reuse / quality / efficiency) — surfaced reuse of `weaponTypes` from `config/weapons`, dedup of weapon buckets via `WEAPON_BUCKET`, and replaced a runtime exhaustiveness tuple with compile-time `Exclude`/`Extract` types. Tightened `ClassifiedRoll.type` to a `CanonicalRollType` literal union; `isCanonicalType` type guard makes `deriveRollTypeKey` provably exhaustive (no more unreachable runtime throw).
- **Pre-PR correctness review**: independent agent walked `setupRollData` lines 41–600 against `classifyRoll` and `ROLL_TYPE_FIELDS`; verdict was no correctness defects. One misleading comment fixed in `92b9554`.

## Still uncovered after this PR

Documented for the rewrite to verify manually:
- `vehiclerangedweaponattack` — needs a character-piloting-vehicle fixture with embedded `vehicle_weapons`; not a clean `rollAction` entry.
- `purchase` — sheet/vendor-flow driven, not reachable via `rollAction`.
- `mortally_wounded` / `incapacitated` — auto-fired during damage application, not a user-roll dialog path.
- Top-level `type='vehicletoughness'` rewrite — the smoke spec exercises action+vehicletoughness, which classifies to the same key via a different normalization path.

## Test plan

- [x] \`pnpm run check\` — lint clean (709/720), typecheck clean, 274 unit + 250 domain
- [x] Independent code review walked every type/subtype mutation in setupRollData against classifyRoll
- [x] Independent code review walked every handler bucket against the matching code path
- [x] Compile-time partition invariants verified to actually constrain
- [ ] \`pnpm run test:smoke\` — three new probes (brawlattack / vehicleramattack / vehicletoughness) — needs a live Foundry world; historically run manually