### PR TITLE
refactor(roll-setup): #98 foundation — handler contract + 25 pure handlers + boundary adapter

### DIFF
--- a/src/module/actor/actor-helpers/roll-action.ts
+++ b/src/module/actor/actor-helpers/roll-action.ts
@@ -3,7 +3,7 @@ import {od6sroll} from "../../apps/roll";
 import OD6S from "../../config/config-od6s";
 
 export async function resolveRollAction(actor: any, actionId: any, msg?: any): Promise<any> {
-    const vehicle = (actor.type === 'starship' || actor.type === 'starship') ? actor.system : actor.system?.vehicle
+    const vehicle = (actor.type === 'vehicle' || actor.type === 'starship') ? actor.system : actor.system?.vehicle
     let itemId = '';
     let name = '';
     let score = 0;

--- a/src/module/apps/roll-helpers/roll-context-adapter.test.ts
+++ b/src/module/apps/roll-helpers/roll-context-adapter.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the Foundry → handler-view boundary projector.
+ *
+ * Verifies adapter output for each actor / item type covered by the
+ * handler families, plus settings/targets pass-through. Uses plain
+ * objects shaped like Foundry documents — no Foundry globals.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    adaptActor,
+    adaptContext,
+    adaptItem,
+    adaptSettings,
+    adaptTargets,
+} from './roll-context-adapter';
+import type { RollSettingsRaw } from './roll-context-adapter';
+
+const SETTINGS: RollSettingsRaw = {
+    defaultUnknownDifficulty: false,
+    diceForScale: false,
+    fundsFate: false,
+    hideCombatCards: false,
+    hideSkillCards: false,
+    showSkillSpecialization: true,
+    pipsPerDice: 3,
+    meleeDifficulty: false,
+    explosiveZones: false,
+    weaponDamageTable: { 1: { penalty: 3, label: 'OD6S.LIGHT' } },
+    flatSkills: false,
+    brawlAttribute: 'str',
+};
+
+describe('adaptActor', () => {
+    it('projects a character with attributes, scale, strengthDamage, and embedded vehicle', () => {
+        const actor = {
+            type: 'character',
+            uuid: 'Actor.x',
+            system: {
+                attributes: { str: { score: 9 }, agi: { score: '12' } },
+                scale: { score: 0 },
+                strengthdamage: { score: 6 },
+                vehicle: { uuid: 'Actor.veh' },
+            },
+        };
+        const view = adaptActor(actor);
+        expect(view).toEqual({
+            type: 'character',
+            uuid: 'Actor.x',
+            attributes: { str: { score: 9 }, agi: { score: 12 } },
+            scale: { score: 0 },
+            strengthDamage: 6,
+            vehicle: { uuid: 'Actor.veh' },
+        });
+    });
+
+    it('projects a vehicle actor with scale + ram + ram_damage', () => {
+        const view = adaptActor({
+            type: 'vehicle',
+            uuid: 'Actor.v',
+            system: { scale: { score: 6 }, ram: { score: 3 }, ram_damage: { score: 12 } },
+        });
+        expect(view).toEqual({
+            type: 'vehicle',
+            uuid: 'Actor.v',
+            scale: { score: 6 },
+            ram: { score: 3 },
+            ram_damage: { score: 12 },
+        });
+    });
+
+    it('projects an NPC like a character (same attribute/scale/vehicle surface)', () => {
+        const view = adaptActor({
+            type: 'npc',
+            uuid: 'Actor.n',
+            system: { attributes: { str: { score: 6 } } },
+        });
+        expect(view.type).toBe('npc');
+        if (view.type !== 'npc') throw new Error('narrowing failed');
+        expect(view.attributes?.str.score).toBe(6);
+    });
+
+    it('falls back to character shape for unknown actor types (handlers fail loud downstream)', () => {
+        const view = adaptActor({ type: 'unknown', uuid: 'Actor.u', system: {} });
+        expect(view.type).toBe('character');
+    });
+
+    it('omits optional fields when their source data is missing', () => {
+        const view = adaptActor({ type: 'character', uuid: 'Actor.x', system: {} });
+        expect(view).toEqual({ type: 'character', uuid: 'Actor.x' });
+    });
+});
+
+describe('adaptItem', () => {
+    it('projects a skill item with the parent attribute key', () => {
+        const view = adaptItem({
+            type: 'skill', name: 'Brawling',
+            system: { attribute: 'STR' },
+        });
+        expect(view).toEqual({ type: 'skill', name: 'Brawling', attribute: 'STR' });
+    });
+
+    it('projects a specialization item with attribute + parent skill', () => {
+        const view = adaptItem({
+            type: 'specialization', name: 'Vibroblades',
+            system: { attribute: 'STR', skill: 'Melee Combat' },
+        });
+        expect(view.type).toBe('specialization');
+        expect(view.attribute).toBe('STR');
+        expect(view.skill).toBe('Melee Combat');
+    });
+
+    it('projects a weapon with damage, stun, range, scale, mods, stats, and difficulty', () => {
+        const view = adaptItem({
+            type: 'weapon', name: 'Test Blaster',
+            system: {
+                damage: { type: 'e', score: 12, str: false, muscle: false },
+                stun: { type: 's', score: 9, stun_only: false },
+                range: { short: 10, medium: 30, long: 60 },
+                scale: { score: 0 },
+                damaged: 1,
+                mods: { dmg: { score: 3 }, misc: { score: 0 }, bonus: { score: 0 } },
+                stats: { skill: 'Blaster', specialization: 'Test Blaster' },
+                difficulty: 'OD6S.DIFFICULTY_MODERATE',
+            },
+        });
+        expect(view.damage).toEqual({ type: 'e', score: 12, str: false, muscle: false });
+        expect(view.stun).toEqual({ type: 's', score: 9, stun_only: false });
+        expect(view.range).toEqual({ short: 10, medium: 30, long: 60 });
+        expect(view.scale).toEqual({ score: 0 });
+        expect(view.damaged).toBe(1);
+        expect(view.mods).toEqual({ dmg: { score: 3 }, misc: { score: 0 }, bonus: { score: 0 } });
+        expect(view.stats).toEqual({ skill: 'Blaster', specialization: 'Test Blaster' });
+        expect(view.difficulty).toBe('OD6S.DIFFICULTY_MODERATE');
+    });
+
+    it('passes through unknown item types with just type + name', () => {
+        const view = adaptItem({ type: 'gizmo', name: 'X', system: {} });
+        expect(view).toEqual({ type: 'gizmo', name: 'X' });
+    });
+});
+
+describe('adaptTargets', () => {
+    it('extracts only scale from token actors', () => {
+        const tokens = [
+            { actor: { system: { scale: { score: 3 } } } },
+            { actor: { system: { scale: { score: 6 } } } },
+        ];
+        expect(adaptTargets(tokens)).toEqual([{ scale: 3 }, { scale: 6 }]);
+    });
+
+    it('defaults missing scale to 0', () => {
+        expect(adaptTargets([{}, { actor: {} }])).toEqual([{ scale: 0 }, { scale: 0 }]);
+    });
+});
+
+describe('adaptSettings + adaptContext', () => {
+    it('adaptSettings is an immutable copy', () => {
+        const view = adaptSettings(SETTINGS);
+        expect(view).toEqual(SETTINGS);
+        expect(view).not.toBe(SETTINGS);
+    });
+
+    it('adaptContext composes the parts', () => {
+        const ctx = adaptContext(
+            { type: 'character', uuid: 'Actor.x', system: { attributes: { str: { score: 9 } } } },
+            { type: 'weapon', name: 'X', system: { damage: { type: 'e', score: 9 } } },
+            {
+                settings: SETTINGS,
+                localize: (k) => k,
+                canvasTargets: [{ actor: { system: { scale: { score: 3 } } } }],
+            },
+        );
+        expect(ctx.actor.type).toBe('character');
+        expect(ctx.item?.type).toBe('weapon');
+        expect(ctx.targets.length).toBe(1);
+        expect(ctx.settings.brawlAttribute).toBe('str');
+        expect(ctx.localize('OD6S.X')).toBe('OD6S.X');
+    });
+
+    it('adaptContext omits item when not provided', () => {
+        const ctx = adaptContext(
+            { type: 'character', uuid: 'Actor.x', system: {} },
+            undefined,
+            { settings: SETTINGS, localize: (k) => k, canvasTargets: [] },
+        );
+        expect(ctx.item).toBeUndefined();
+    });
+});

--- a/src/module/apps/roll-helpers/roll-context-adapter.test.ts
+++ b/src/module/apps/roll-helpers/roll-context-adapter.test.ts
@@ -80,9 +80,10 @@ describe('adaptActor', () => {
         expect(view.attributes?.str.score).toBe(6);
     });
 
-    it('falls back to character shape for unknown actor types (handlers fail loud downstream)', () => {
-        const view = adaptActor({ type: 'unknown', uuid: 'Actor.u', system: {} });
-        expect(view.type).toBe('character');
+    it('throws on unknown actor types — silent coercion would let unsupported actors through', () => {
+        expect(() => adaptActor({ type: 'unknown', uuid: 'Actor.u', system: {} })).toThrow(
+            /unsupported actor type/i,
+        );
     });
 
     it('omits optional fields when their source data is missing', () => {
@@ -110,7 +111,7 @@ describe('adaptItem', () => {
         expect(view.skill).toBe('Melee Combat');
     });
 
-    it('projects a weapon with damage, stun, range, scale, mods, stats, and difficulty', () => {
+    it('projects a weapon with damage, stun, range, scale, mods, stats, and difficulty (mods are flat numbers matching the schema)', () => {
         const view = adaptItem({
             type: 'weapon', name: 'Test Blaster',
             system: {
@@ -119,7 +120,7 @@ describe('adaptItem', () => {
                 range: { short: 10, medium: 30, long: 60 },
                 scale: { score: 0 },
                 damaged: 1,
-                mods: { dmg: { score: 3 }, misc: { score: 0 }, bonus: { score: 0 } },
+                mods: { damage: 3, attack: 0, difficulty: 0 },
                 stats: { skill: 'Blaster', specialization: 'Test Blaster' },
                 difficulty: 'OD6S.DIFFICULTY_MODERATE',
             },
@@ -129,9 +130,18 @@ describe('adaptItem', () => {
         expect(view.range).toEqual({ short: 10, medium: 30, long: 60 });
         expect(view.scale).toEqual({ score: 0 });
         expect(view.damaged).toBe(1);
-        expect(view.mods).toEqual({ dmg: { score: 3 }, misc: { score: 0 }, bonus: { score: 0 } });
+        expect(view.mods).toEqual({ damage: 3, attack: 0, difficulty: 0 });
         expect(view.stats).toEqual({ skill: 'Blaster', specialization: 'Test Blaster' });
         expect(view.difficulty).toBe('OD6S.DIFFICULTY_MODERATE');
+        expect(view.isExplosive).toBe(false);
+    });
+
+    it('flags isExplosive=true when weapon subtype is "explosive" (case-insensitive)', () => {
+        const view = adaptItem({
+            type: 'weapon', name: 'Frag Grenade',
+            system: { damage: { type: 'p', score: 12 }, subtype: 'Explosive' },
+        });
+        expect(view.isExplosive).toBe(true);
     });
 
     it('passes through unknown item types with just type + name', () => {

--- a/src/module/apps/roll-helpers/roll-context-adapter.ts
+++ b/src/module/apps/roll-helpers/roll-context-adapter.ts
@@ -87,9 +87,7 @@ export function adaptActor(actor: {
                 strengthDamage: actor.system?.strengthdamage ? +actor.system.strengthdamage.score : undefined,
                 vehicle: actor.system?.vehicle?.uuid ? { uuid: actor.system.vehicle.uuid } : undefined,
             };
-        default:
-            // 'character' (and any unknown actor type — handlers throw on unknown
-            // via the discriminated union, so unknown actors fail loudly downstream).
+        case 'character':
             return {
                 type: 'character',
                 uuid: actor.uuid,
@@ -98,6 +96,8 @@ export function adaptActor(actor: {
                 strengthDamage: actor.system?.strengthdamage ? +actor.system.strengthdamage.score : undefined,
                 vehicle: actor.system?.vehicle?.uuid ? { uuid: actor.system.vehicle.uuid } : undefined,
             };
+        default:
+            throw new Error(`adaptActor: unsupported actor type "${actor.type}"`);
     }
 }
 
@@ -153,9 +153,9 @@ export function adaptItem(item: {
             scale: sys.scale ? { score: +sys.scale.score } : undefined,
             damaged: sys.damaged !== undefined ? +sys.damaged : undefined,
             mods: sys.mods ? {
-                dmg: sys.mods.dmg ? { score: +sys.mods.dmg.score } : undefined,
-                misc: sys.mods.misc ? { score: +sys.mods.misc.score } : undefined,
-                bonus: sys.mods.bonus ? { score: +sys.mods.bonus.score } : undefined,
+                damage: +(sys.mods.damage ?? 0),
+                attack: +(sys.mods.attack ?? 0),
+                difficulty: +(sys.mods.difficulty ?? 0),
             } : undefined,
             stats: sys.stats ? { skill: sys.stats.skill, specialization: sys.stats.specialization } : undefined,
             blast_radius: sys.blast_radius ? {
@@ -164,6 +164,7 @@ export function adaptItem(item: {
                     : undefined,
             } : undefined,
             difficulty: sys.difficulty,
+            isExplosive: typeof sys.subtype === 'string' && sys.subtype.toLowerCase() === 'explosive',
         };
     }
     return base;

--- a/src/module/apps/roll-helpers/roll-context-adapter.ts
+++ b/src/module/apps/roll-helpers/roll-context-adapter.ts
@@ -1,0 +1,209 @@
+/**
+ * Boundary projection: Foundry documents/settings → narrowed handler views.
+ *
+ * This is the only file in the rules pipeline that knows about Foundry
+ * types. Handlers consume the {@link HandlerContext} produced here; they
+ * never reach back for the source documents. Keeping the projection
+ * collected in one file makes the trust boundary auditable and the
+ * handlers fully unit-testable.
+ *
+ * Each `adapt*` function is pure given its inputs — Foundry-shaped, but
+ * mockable as plain objects. Tests construct fake actors/items by shape;
+ * `game.*` access lives in the orchestrator that calls these.
+ */
+
+import type {
+    ActorView,
+    HandlerContext,
+    ItemView,
+    RollSettingsView,
+    TargetView,
+} from './roll-handlers';
+import type { Localize } from './roll-data';
+
+/**
+ * Settings values the rules pipeline depends on. The orchestrator reads
+ * these from `game.settings` / `OD6S.*` once and hands them in as a plain
+ * object so the adapter (and finalize) stay testable.
+ */
+export interface RollSettingsRaw {
+    defaultUnknownDifficulty: boolean;
+    diceForScale: boolean;
+    fundsFate: boolean;
+    hideCombatCards: boolean;
+    hideSkillCards: boolean;
+    showSkillSpecialization: boolean;
+    pipsPerDice: number;
+    meleeDifficulty: boolean;
+    explosiveZones: boolean;
+    weaponDamageTable: Record<number, { penalty: number; label: string }>;
+    flatSkills: boolean;
+    brawlAttribute: string;
+}
+
+export function adaptSettings(raw: RollSettingsRaw): RollSettingsView {
+    return { ...raw };
+}
+
+/**
+ * Project a Foundry actor down to the discriminated {@link ActorView} shape
+ * the handlers consume. Reads only what handlers reference: never the full
+ * actor surface.
+ *
+ * Vehicle/starship actors expose their own ram/scale; character/NPC pilots
+ * carry the embedded `system.vehicle` ref under `vehicle.uuid` (the deeper
+ * dereferencing for ram/scale on the embedded vehicle happens via
+ * {@link resolveVehicleStats}, called separately by the orchestrator when
+ * a vehicle-action handler will run).
+ */
+export function adaptActor(actor: {
+    type: string;
+    uuid: string;
+    system: any;
+}): ActorView {
+    switch (actor.type) {
+        case 'vehicle':
+            return {
+                type: 'vehicle',
+                uuid: actor.uuid,
+                scale: actor.system?.scale ? { score: +actor.system.scale.score } : undefined,
+                ram: actor.system?.ram ? { score: +actor.system.ram.score } : undefined,
+                ram_damage: actor.system?.ram_damage ? { score: +actor.system.ram_damage.score } : undefined,
+            };
+        case 'starship':
+            return {
+                type: 'starship',
+                uuid: actor.uuid,
+                scale: actor.system?.scale ? { score: +actor.system.scale.score } : undefined,
+                ram: actor.system?.ram ? { score: +actor.system.ram.score } : undefined,
+                ram_damage: actor.system?.ram_damage ? { score: +actor.system.ram_damage.score } : undefined,
+            };
+        case 'npc':
+            return {
+                type: 'npc',
+                uuid: actor.uuid,
+                attributes: adaptAttributes(actor.system?.attributes),
+                scale: actor.system?.scale ? { score: +actor.system.scale.score } : undefined,
+                strengthDamage: actor.system?.strengthdamage ? +actor.system.strengthdamage.score : undefined,
+                vehicle: actor.system?.vehicle?.uuid ? { uuid: actor.system.vehicle.uuid } : undefined,
+            };
+        default:
+            // 'character' (and any unknown actor type — handlers throw on unknown
+            // via the discriminated union, so unknown actors fail loudly downstream).
+            return {
+                type: 'character',
+                uuid: actor.uuid,
+                attributes: adaptAttributes(actor.system?.attributes),
+                scale: actor.system?.scale ? { score: +actor.system.scale.score } : undefined,
+                strengthDamage: actor.system?.strengthdamage ? +actor.system.strengthdamage.score : undefined,
+                vehicle: actor.system?.vehicle?.uuid ? { uuid: actor.system.vehicle.uuid } : undefined,
+            };
+    }
+}
+
+function adaptAttributes(
+    attributes: Record<string, { score: number | string }> | undefined,
+): Record<string, { score: number }> | undefined {
+    if (!attributes) return undefined;
+    const out: Record<string, { score: number }> = {};
+    for (const [key, value] of Object.entries(attributes)) {
+        out[key] = { score: +value.score };
+    }
+    return out;
+}
+
+/**
+ * Project a Foundry item to the {@link ItemView} the handlers consume. The
+ * weapon family reads the broadest field surface; skill / specialization
+ * only need attribute / skill. Unknown item types pass through with just
+ * `type` set so handlers can early-out on missing weapon fields.
+ */
+export function adaptItem(item: {
+    type: string;
+    name?: string;
+    system: any;
+}): ItemView {
+    const base: ItemView = { type: item.type, name: item.name };
+    if (item.type === 'skill') {
+        return { ...base, attribute: item.system?.attribute };
+    }
+    if (item.type === 'specialization') {
+        return {
+            ...base,
+            attribute: item.system?.attribute,
+            skill: item.system?.skill,
+        };
+    }
+    if (item.type === 'weapon' || item.type === 'starship-weapon' || item.type === 'vehicle-weapon') {
+        const sys = item.system ?? {};
+        return {
+            ...base,
+            damage: sys.damage ? {
+                type: sys.damage.type,
+                score: +sys.damage.score,
+                str: !!sys.damage.str,
+                muscle: !!sys.damage.muscle,
+            } : undefined,
+            stun: sys.stun ? {
+                type: sys.stun.type,
+                score: sys.stun.score !== undefined ? +sys.stun.score : undefined,
+                stun_only: !!sys.stun.stun_only,
+            } : undefined,
+            range: sys.range ?? false,
+            scale: sys.scale ? { score: +sys.scale.score } : undefined,
+            damaged: sys.damaged !== undefined ? +sys.damaged : undefined,
+            mods: sys.mods ? {
+                dmg: sys.mods.dmg ? { score: +sys.mods.dmg.score } : undefined,
+                misc: sys.mods.misc ? { score: +sys.mods.misc.score } : undefined,
+                bonus: sys.mods.bonus ? { score: +sys.mods.bonus.score } : undefined,
+            } : undefined,
+            stats: sys.stats ? { skill: sys.stats.skill, specialization: sys.stats.specialization } : undefined,
+            blast_radius: sys.blast_radius ? {
+                '1': sys.blast_radius['1']
+                    ? { stun_damage: +sys.blast_radius['1'].stun_damage }
+                    : undefined,
+            } : undefined,
+            difficulty: sys.difficulty,
+        };
+    }
+    return base;
+}
+
+/**
+ * Project canvas tokens to the minimal {@link TargetView} shape — only the
+ * scale matters for the rules math (range bucketing is preflight; positions
+ * stay there).
+ */
+export function adaptTargets(
+    tokens: ReadonlyArray<{ actor?: { system?: { scale?: { score?: number } } } }>,
+): ReadonlyArray<TargetView> {
+    return tokens.map((t) => ({
+        scale: +(t.actor?.system?.scale?.score ?? 0),
+    }));
+}
+
+/**
+ * Compose the four adapters into a {@link HandlerContext}. Pre-resolution
+ * helpers (actionSkill, vehicleStats) are attached separately by the
+ * orchestrator when a key needs them; this function builds the always-on
+ * fields.
+ */
+export interface AdaptContextDeps {
+    settings: RollSettingsRaw;
+    localize: Localize;
+    canvasTargets: ReadonlyArray<{ actor?: { system?: { scale?: { score?: number } } } }>;
+}
+
+export function adaptContext(
+    actor: { type: string; uuid: string; system: any },
+    item: { type: string; name?: string; system: any } | undefined,
+    deps: AdaptContextDeps,
+): HandlerContext {
+    return {
+        actor: adaptActor(actor),
+        item: item ? adaptItem(item) : undefined,
+        targets: adaptTargets(deps.canvasTargets),
+        settings: adaptSettings(deps.settings),
+        localize: deps.localize,
+    };
+}

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -20,6 +20,7 @@
 
 import type { ClassifiedRoll, IncomingRollData, Localize, RollData, RollTypeKey } from './roll-data';
 import type { ROLL_TYPE_FIELDS } from './roll-type-fields';
+import { getDiceFromScore } from '../../system/utilities/dice';
 
 export type HandlerOutput<K extends RollTypeKey> =
     Pick<RollData, (typeof ROLL_TYPE_FIELDS)[K][number]>;
@@ -56,6 +57,8 @@ export interface CharacterActorView {
 export interface NpcActorView {
     type: 'npc';
     uuid: string;
+    /** Embedded vehicle reference when the NPC is piloting one. */
+    vehicle?: { uuid: string };
 }
 
 export interface VehicleActorView {
@@ -131,6 +134,30 @@ const specializationHandler: Handler<'specialization'> = (_input, ctx) => ({
     specSkill: ctx.settings.showSkillSpecialization && ctx.item?.skill ? ctx.item.skill : '',
 });
 
+const scaleToDice = (input: HandlerInput, ctx: HandlerContext): number =>
+    ctx.settings.diceForScale
+        ? getDiceFromScore(input.scale ?? 0, ctx.settings.pipsPerDice).dice
+        : 0;
+
+const damageHandler: Handler<'damage'> = () => ({});
+const mortallyWoundedHandler: Handler<'mortally_wounded'> = () => ({});
+const incapacitatedHandler: Handler<'incapacitated'> = () => ({});
+
+const resistanceHandler: Handler<'resistance'> = (input, ctx) => ({
+    scaledice: scaleToDice(input, ctx),
+});
+
+const resistanceVehicleToughnessHandler: Handler<'resistance-vehicletoughness'> = (input, ctx) => {
+    const vehicleUuid =
+        ctx.actor.type === 'vehicle' || ctx.actor.type === 'starship'
+            ? ctx.actor.uuid
+            : ctx.actor.vehicle?.uuid ?? '';
+    return {
+        scaledice: scaleToDice(input, ctx),
+        vehicle: vehicleUuid,
+    };
+};
+
 export const HANDLERS = {
     'weapon': notImplemented('weapon'),
     'starship-weapon': notImplemented('starship-weapon'),
@@ -149,12 +176,12 @@ export const HANDLERS = {
     'skill-dodge': skillDodgeHandler,
     'specialization': specializationHandler,
 
-    'damage': notImplemented('damage'),
-    'resistance': notImplemented('resistance'),
-    'resistance-vehicletoughness': notImplemented('resistance-vehicletoughness'),
+    'damage': damageHandler,
+    'resistance': resistanceHandler,
+    'resistance-vehicletoughness': resistanceVehicleToughnessHandler,
 
-    'mortally_wounded': notImplemented('mortally_wounded'),
-    'incapacitated': notImplemented('incapacitated'),
+    'mortally_wounded': mortallyWoundedHandler,
+    'incapacitated': incapacitatedHandler,
 
     'funds': notImplemented('funds'),
     'purchase': notImplemented('purchase'),

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -50,6 +50,8 @@ export type ActorView =
 export interface CharacterActorView {
     type: 'character';
     uuid: string;
+    /** Strength damage score (added to melee damage when weapon.damage.str is set). */
+    strengthDamage?: number;
     /** Embedded vehicle reference when the character is piloting one. */
     vehicle?: { uuid: string };
 }
@@ -57,6 +59,8 @@ export interface CharacterActorView {
 export interface NpcActorView {
     type: 'npc';
     uuid: string;
+    /** Strength damage score (added to melee damage when weapon.damage.str is set). */
+    strengthDamage?: number;
     /** Embedded vehicle reference when the NPC is piloting one. */
     vehicle?: { uuid: string };
 }
@@ -73,10 +77,32 @@ export interface StarshipActorView {
 
 export interface ItemView {
     type: string;
+    /** Display name of the item. */
+    name?: string;
     /** Skill / specialization item: parent attribute key (case-insensitive). */
     attribute?: string;
     /** Specialization item: parent skill name. */
     skill?: string;
+    // ---- Weapon item fields ----
+    /** Primary damage. `str` = add strength damage in melee; `muscle` = explicit
+     *  strength-damage rider on damage modifiers. */
+    damage?: { type: string; score: number; str?: boolean; muscle?: boolean };
+    /** Stun damage block. `stun_only` forces stun-only mode. */
+    stun?: { type?: string; score?: number; stun_only?: boolean };
+    /** Per-band range table or `false` when out-of-range was already resolved. */
+    range?: { short: number; medium: number; long: number } | false;
+    /** Weapon-defined scale (overrides actor scale when set). */
+    scale?: { score: number };
+    /** Damage state index (0 = pristine, higher = degraded; resolves to a penalty). */
+    damaged?: number;
+    /** Weapon mod totals — keep open-shaped; resolved by applyWeaponMods. */
+    mods?: { dmg?: { score?: number }; misc?: { score?: number }; bonus?: { score?: number } };
+    /** Weapon's authored skill/specialization context. */
+    stats?: { skill?: string; specialization?: string };
+    /** Blast radius for explosives — only zone "1"'s stun damage is read here. */
+    blast_radius?: { '1'?: { stun_damage?: number } };
+    /** Authored difficulty label override (when meleeDifficulty setting is on). */
+    difficulty?: string;
 }
 
 export interface TargetView {
@@ -98,6 +124,12 @@ export interface RollSettingsView {
     showSkillSpecialization: boolean;
     /** System-constant pips per die (3 in standard OpenD6). */
     pipsPerDice: number;
+    /** When true, weapon-authored difficulty overrides the default for melee. */
+    meleeDifficulty: boolean;
+    /** When true, explosive zones (multi-radius blasts) are active. */
+    explosiveZones: boolean;
+    /** Damage state → penalty/label table (system constant from OD6S.weaponDamage). */
+    weaponDamageTable: Record<number, { penalty: number; label: string }>;
 }
 
 export interface HandlerContext {

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -35,13 +35,37 @@ export type HandlerInput = Omit<IncomingRollData, 'actor'> & {
 };
 
 /**
- * Read-only narrowed view of an actor for handler consumption. Empty by
- * design — fields are added as Phase 2 handlers need them, so the surface
- * stays a tight reflection of actual rules dependencies rather than a
- * Foundry-shaped god object.
+ * Read-only narrowed view of an actor for handler consumption. Discriminated
+ * by `type` so handlers branching on actor kind get exhaustive narrowing.
+ * Fields grow per family as Phase 2 handlers need them — kept tight rather
+ * than mirroring the Foundry shape.
  */
-export interface ActorView {
-    type: 'character' | 'npc' | 'vehicle' | 'starship';
+export type ActorView =
+    | CharacterActorView
+    | NpcActorView
+    | VehicleActorView
+    | StarshipActorView;
+
+export interface CharacterActorView {
+    type: 'character';
+    uuid: string;
+    /** Embedded vehicle reference when the character is piloting one. */
+    vehicle?: { uuid: string };
+}
+
+export interface NpcActorView {
+    type: 'npc';
+    uuid: string;
+}
+
+export interface VehicleActorView {
+    type: 'vehicle';
+    uuid: string;
+}
+
+export interface StarshipActorView {
+    type: 'starship';
+    uuid: string;
 }
 
 export interface ItemView {
@@ -69,6 +93,8 @@ export interface RollSettingsView {
     hideSkillCards: boolean;
     /** When true, the dialog exposes the parent-skill link for specializations. */
     showSkillSpecialization: boolean;
+    /** System-constant pips per die (3 in standard OpenD6). */
+    pipsPerDice: number;
 }
 
 export interface HandlerContext {

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -79,6 +79,22 @@ const notImplemented = <K extends RollTypeKey>(key: K): Handler<K> =>
         throw new Error(`Roll handler not implemented: ${key}`);
     };
 
+const skillItemAttribute = (item: ItemView | undefined): string | null =>
+    item?.attribute ? item.attribute.toLowerCase() : null;
+
+const skillHandler: Handler<'skill'> = (_input, ctx) => ({
+    attribute: skillItemAttribute(ctx.item),
+});
+
+const skillDodgeHandler: Handler<'skill-dodge'> = (_input, ctx) => ({
+    attribute: skillItemAttribute(ctx.item),
+});
+
+const specializationHandler: Handler<'specialization'> = (_input, ctx) => ({
+    attribute: skillItemAttribute(ctx.item),
+    specSkill: ctx.settings.showSkillSpecialization && ctx.item?.skill ? ctx.item.skill : '',
+});
+
 export const HANDLERS = {
     'weapon': notImplemented('weapon'),
     'starship-weapon': notImplemented('starship-weapon'),
@@ -93,9 +109,9 @@ export const HANDLERS = {
     'action-attribute': notImplemented('action-attribute'),
     'action-other': notImplemented('action-other'),
 
-    'skill': notImplemented('skill'),
-    'skill-dodge': notImplemented('skill-dodge'),
-    'specialization': notImplemented('specialization'),
+    'skill': skillHandler,
+    'skill-dodge': skillDodgeHandler,
+    'specialization': specializationHandler,
 
     'damage': notImplemented('damage'),
     'resistance': notImplemented('resistance'),

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -36,6 +36,10 @@ export interface ActorView {
 
 export interface ItemView {
     type: string;
+    /** Skill / specialization item: parent attribute key (case-insensitive). */
+    attribute?: string;
+    /** Specialization item: parent skill name. */
+    skill?: string;
 }
 
 export interface TargetView {
@@ -53,6 +57,8 @@ export interface RollSettingsView {
     hideCombatCards: boolean;
     /** When true, hide skill cards from non-GM observers. */
     hideSkillCards: boolean;
+    /** When true, the dialog exposes the parent-skill link for specializations. */
+    showSkillSpecialization: boolean;
 }
 
 export interface HandlerContext {

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -18,11 +18,21 @@
  * than silently producing partial output).
  */
 
-import type { ClassifiedRoll, Localize, RollData, RollTypeKey } from './roll-data';
+import type { ClassifiedRoll, IncomingRollData, Localize, RollData, RollTypeKey } from './roll-data';
 import type { ROLL_TYPE_FIELDS } from './roll-type-fields';
 
 export type HandlerOutput<K extends RollTypeKey> =
     Pick<RollData, (typeof ROLL_TYPE_FIELDS)[K][number]>;
+
+/**
+ * Request data the orchestrator hands to a handler. A projection of
+ * {@link IncomingRollData} minus the Foundry `actor` (which lives in
+ * {@link HandlerContext.actor} as a narrowed view) plus the classifier
+ * output. Handlers consume input + ctx; nothing else.
+ */
+export type HandlerInput = Omit<IncomingRollData, 'actor'> & {
+    classified: ClassifiedRoll;
+};
 
 /**
  * Read-only narrowed view of an actor for handler consumption. Empty by
@@ -70,7 +80,7 @@ export interface HandlerContext {
 }
 
 export type Handler<K extends RollTypeKey> = (
-    input: ClassifiedRoll,
+    input: HandlerInput,
     ctx: HandlerContext,
 ) => HandlerOutput<K>;
 

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-roll-type handler contract for #98.
+ *
+ * Each {@link RollTypeKey} maps to a pure {@link Handler} that produces only
+ * the fields its bucket in {@link ROLL_TYPE_FIELDS} owns. Handlers are
+ * Foundry-free: they consume narrowed views ({@link ActorView},
+ * {@link ItemView}, {@link TargetView}, {@link RollSettingsView}) and a
+ * pre-computed {@link ClassifiedRoll}. The boundary projection from Foundry
+ * documents to these views lives in `roll-context-adapter.ts` (Phase 1 step 2).
+ *
+ * The output type is mechanically derived from `ROLL_TYPE_FIELDS[key]`, so a
+ * handler that tries to write outside its bucket fails to compile. Combined
+ * with the partition invariants in `roll-type-fields.ts`, this gives
+ * compile-time enforcement of the mutation map.
+ *
+ * The stub registry below throws on every key so unimplemented handlers fail
+ * loudly (and so any miswiring during Phase 2 is caught at first call rather
+ * than silently producing partial output).
+ */
+
+import type { ClassifiedRoll, Localize, RollData, RollTypeKey } from './roll-data';
+import type { ROLL_TYPE_FIELDS } from './roll-type-fields';
+
+export type HandlerOutput<K extends RollTypeKey> =
+    Pick<RollData, (typeof ROLL_TYPE_FIELDS)[K][number]>;
+
+/**
+ * Read-only narrowed view of an actor for handler consumption. Empty by
+ * design — fields are added as Phase 2 handlers need them, so the surface
+ * stays a tight reflection of actual rules dependencies rather than a
+ * Foundry-shaped god object.
+ */
+export interface ActorView {
+    type: 'character' | 'npc' | 'vehicle' | 'starship';
+}
+
+export interface ItemView {
+    type: string;
+}
+
+export interface TargetView {
+    scale: number;
+}
+
+export interface RollSettingsView {
+    /** When true, "Unknown" is the default difficulty label instead of "Easy". */
+    defaultUnknownDifficulty: boolean;
+    /** When true, scale modifiers are paid in dice rather than score adjustments. */
+    diceForScale: boolean;
+    /** When true, fate-point spends apply to funds/purchase rolls. */
+    fundsFate: boolean;
+    /** When true, hide combat cards from non-GM observers. */
+    hideCombatCards: boolean;
+    /** When true, hide skill cards from non-GM observers. */
+    hideSkillCards: boolean;
+}
+
+export interface HandlerContext {
+    actor: ActorView;
+    item?: ItemView;
+    targets: ReadonlyArray<TargetView>;
+    settings: RollSettingsView;
+    localize: Localize;
+}
+
+export type Handler<K extends RollTypeKey> = (
+    input: ClassifiedRoll,
+    ctx: HandlerContext,
+) => HandlerOutput<K>;
+
+const notImplemented = <K extends RollTypeKey>(key: K): Handler<K> =>
+    () => {
+        throw new Error(`Roll handler not implemented: ${key}`);
+    };
+
+export const HANDLERS = {
+    'weapon': notImplemented('weapon'),
+    'starship-weapon': notImplemented('starship-weapon'),
+    'vehicle-weapon': notImplemented('vehicle-weapon'),
+
+    'action-meleeattack': notImplemented('action-meleeattack'),
+    'action-brawlattack': notImplemented('action-brawlattack'),
+    'action-rangedattack': notImplemented('action-rangedattack'),
+    'action-vehiclerangedattack': notImplemented('action-vehiclerangedattack'),
+    'action-vehiclerangedweaponattack': notImplemented('action-vehiclerangedweaponattack'),
+    'action-vehicleramattack': notImplemented('action-vehicleramattack'),
+    'action-attribute': notImplemented('action-attribute'),
+    'action-other': notImplemented('action-other'),
+
+    'skill': notImplemented('skill'),
+    'skill-dodge': notImplemented('skill-dodge'),
+    'specialization': notImplemented('specialization'),
+
+    'damage': notImplemented('damage'),
+    'resistance': notImplemented('resistance'),
+    'resistance-vehicletoughness': notImplemented('resistance-vehicletoughness'),
+
+    'mortally_wounded': notImplemented('mortally_wounded'),
+    'incapacitated': notImplemented('incapacitated'),
+
+    'funds': notImplemented('funds'),
+    'purchase': notImplemented('purchase'),
+
+    'brawlattack': notImplemented('brawlattack'),
+    'attribute': notImplemented('attribute'),
+} as const satisfies { [K in RollTypeKey]: Handler<K> };

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -27,7 +27,10 @@ import {
     buildDamagedWeaponModifier,
     buildStrengthDamageModifier,
     computeStunFlags,
+    ramAttackContribution,
 } from './weapon-context-math';
+import type { ActionSkill } from './action-math';
+import { resolveSkillBackedAction } from './action-math';
 
 export type HandlerOutput<K extends RollTypeKey> =
     Pick<RollData, (typeof ROLL_TYPE_FIELDS)[K][number]>;
@@ -57,6 +60,10 @@ export type ActorView =
 export interface CharacterActorView {
     type: 'character';
     uuid: string;
+    /** Attribute scores keyed by lower-case attribute name (str, agi, mec, kno, …). */
+    attributes?: Record<string, { score: number }>;
+    /** Actor scale (used as attackerScale fallback). */
+    scale?: { score: number };
     /** Strength damage score (added to melee damage when weapon.damage.str is set). */
     strengthDamage?: number;
     /** Embedded vehicle reference when the character is piloting one. */
@@ -66,20 +73,28 @@ export interface CharacterActorView {
 export interface NpcActorView {
     type: 'npc';
     uuid: string;
-    /** Strength damage score (added to melee damage when weapon.damage.str is set). */
+    attributes?: Record<string, { score: number }>;
+    scale?: { score: number };
     strengthDamage?: number;
-    /** Embedded vehicle reference when the NPC is piloting one. */
     vehicle?: { uuid: string };
 }
 
 export interface VehicleActorView {
     type: 'vehicle';
     uuid: string;
+    scale?: { score: number };
+    /** Vehicle ram bonus (skill bonus on ram attacks). */
+    ram?: { score: number };
+    /** Vehicle ram damage (additive damage modifier on ram attacks). */
+    ram_damage?: { score: number };
 }
 
 export interface StarshipActorView {
     type: 'starship';
     uuid: string;
+    scale?: { score: number };
+    ram?: { score: number };
+    ram_damage?: { score: number };
 }
 
 export interface ItemView {
@@ -137,6 +152,10 @@ export interface RollSettingsView {
     explosiveZones: boolean;
     /** Damage state → penalty/label table (system constant from OD6S.weaponDamage). */
     weaponDamageTable: Record<number, { penalty: number; label: string }>;
+    /** When true, skill-backed actions roll skill score as flat-pips on top of attribute. */
+    flatSkills: boolean;
+    /** Fallback attribute key for brawl action when no Brawling skill item exists. */
+    brawlAttribute: string;
 }
 
 export interface HandlerContext {
@@ -145,6 +164,24 @@ export interface HandlerContext {
     targets: ReadonlyArray<TargetView>;
     settings: RollSettingsView;
     localize: Localize;
+    /**
+     * Pre-resolved skill backing for skill-backed action handlers
+     * (action-meleeattack / action-brawlattack). The orchestrator looks up the
+     * actor's skill item by the action's configured skill name and projects it
+     * here; null when no matching skill item exists.
+     */
+    actionSkill?: ActionSkill | null;
+    /**
+     * Vehicle stats for vehicle-action handlers when the actor is a character
+     * piloting a vehicle (the orchestrator dereferences `actor.system.vehicle`
+     * once at the boundary). For vehicle/starship actors, handlers should read
+     * from the actor view directly.
+     */
+    vehicleStats?: {
+        scale?: { score: number };
+        ram?: { score: number };
+        ram_damage?: { score: number };
+    };
 }
 
 export type Handler<K extends RollTypeKey> = (

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -21,6 +21,13 @@
 import type { ClassifiedRoll, IncomingRollData, Localize, RollData, RollTypeKey } from './roll-data';
 import type { ROLL_TYPE_FIELDS } from './roll-type-fields';
 import { getDiceFromScore } from '../../system/utilities/dice';
+import type { Modifier } from './difficulty-math';
+import {
+    applyWeaponMods,
+    buildDamagedWeaponModifier,
+    buildStrengthDamageModifier,
+    computeStunFlags,
+} from './weapon-context-math';
 
 export type HandlerOutput<K extends RollTypeKey> =
     Pick<RollData, (typeof ROLL_TYPE_FIELDS)[K][number]>;
@@ -200,21 +207,114 @@ const brawlattackDeadPathHandler: Handler<'brawlattack'> = () => {
     );
 };
 
-const resistanceVehicleToughnessHandler: Handler<'resistance-vehicletoughness'> = (input, ctx) => {
-    const vehicleUuid =
-        ctx.actor.type === 'vehicle' || ctx.actor.type === 'starship'
-            ? ctx.actor.uuid
-            : ctx.actor.vehicle?.uuid ?? '';
+const vehicleUuidForActor = (actor: ActorView): string =>
+    actor.type === 'vehicle' || actor.type === 'starship'
+        ? actor.uuid
+        : actor.vehicle?.uuid ?? '';
+
+const characterStrengthDamage = (actor: ActorView): number =>
+    (actor.type === 'character' || actor.type === 'npc') ? actor.strengthDamage ?? 0 : 0;
+
+type WeaponBucketCommon = Pick<RollData,
+    'damagetype' | 'damagescore' | 'stundamagetype' | 'stundamagescore' |
+    'damagemodifiers' | 'source' | 'range' | 'difficultylevel' |
+    'only_stun' | 'can_stun' | 'stun' | 'attackerScale' | 'specSkill'
+>;
+
+function buildWeaponBucket(input: HandlerInput, ctx: HandlerContext): WeaponBucketCommon {
+    const item = ctx.item ?? {} as ItemView;
+    const weaponDamageScore = item.damage?.score ?? 0;
+    const weaponDamageType = item.damage?.type ?? '';
+    const isMelee = input.subtype === 'meleeattack';
+
+    let damagescore = weaponDamageScore;
+    let stundamagescore = item.stun?.score ?? 0;
+    if (isMelee && item.damage?.str) {
+        damagescore = weaponDamageScore + characterStrengthDamage(ctx.actor);
+        if (stundamagescore > 0) {
+            stundamagescore = stundamagescore + characterStrengthDamage(ctx.actor);
+        }
+    }
+
+    // applyWeaponMods folds weapon mod totals into damagescore. miscMod and
+    // bonusmod also flow through it in the original code but those land on
+    // COMMON-side accumulators, so they're discarded here — bucket discipline.
+    const modded = applyWeaponMods(
+        { damageScore: damagescore, miscMod: 0, bonusmod: 0 },
+        {
+            damage: item.mods?.dmg?.score ?? 0,
+            difficulty: item.mods?.misc?.score ?? 0,
+            attack: item.mods?.bonus?.score ?? 0,
+        },
+    );
+    damagescore = modded.damageScore;
+
+    const { onlyStun, canStun } = computeStunFlags({
+        stunOnly: item.stun?.stun_only,
+        weaponStunScore: item.stun?.score ?? 0,
+        isExplosive: false, // explosive preflight is upstream of dispatch
+        explosiveZonesEnabled: ctx.settings.explosiveZones,
+        blastZone1StunDamage: item.blast_radius?.['1']?.stun_damage ?? 0,
+    });
+
+    const damagemodifiers: Modifier[] = [];
+    const damagedMod = buildDamagedWeaponModifier(item.damaged ?? 0, ctx.settings.weaponDamageTable);
+    if (damagedMod) damagemodifiers.push(damagedMod);
+    if (item.damage?.muscle) {
+        damagemodifiers.push(buildStrengthDamageModifier(characterStrengthDamage(ctx.actor)));
+    }
+
+    const difficultylevel = ctx.settings.meleeDifficulty
+        ? (item.difficulty ?? 'OD6S.DIFFICULTY_EASY')
+        : 'OD6S.DIFFICULTY_EASY';
+
+    const specSkill =
+        ctx.settings.showSkillSpecialization && item.stats?.specialization === input.name
+            ? item.stats?.skill ?? ''
+            : '';
+
     return {
-        scaledice: scaleToDice(input, ctx),
-        vehicle: vehicleUuid,
+        damagetype: weaponDamageType,
+        damagescore,
+        stundamagetype: item.stun?.type ?? '',
+        stundamagescore,
+        damagemodifiers,
+        source: item.name ?? '',
+        // Range LABEL, not the per-band table (which is on input.range). The
+        // distance-to-target resolution (via bucketRangeFromDistance) happens
+        // downstream — handler emits the rules-default initial label.
+        range: input.subtype === 'meleeattack'
+            ? 'OD6S.RANGE_POINT_BLANK_SHORT'
+            : 'OD6S.RANGE_SHORT_SHORT',
+        difficultylevel,
+        only_stun: onlyStun,
+        can_stun: canStun,
+        // `stun` is a legacy duplicate of `only_stun` in RollData. Phase 3 cleanup.
+        stun: onlyStun,
+        attackerScale: item.scale?.score ?? 0,
+        specSkill,
     };
-};
+}
+
+const weaponHandler: Handler<'weapon'> = (input, ctx) => buildWeaponBucket(input, ctx);
+
+const starshipWeaponHandler: Handler<'starship-weapon'> = (input, ctx) =>
+    buildWeaponBucket(input, ctx);
+
+const vehicleWeaponHandler: Handler<'vehicle-weapon'> = (input, ctx) => ({
+    ...buildWeaponBucket(input, ctx),
+    vehicle: vehicleUuidForActor(ctx.actor),
+});
+
+const resistanceVehicleToughnessHandler: Handler<'resistance-vehicletoughness'> = (input, ctx) => ({
+    scaledice: scaleToDice(input, ctx),
+    vehicle: vehicleUuidForActor(ctx.actor),
+});
 
 export const HANDLERS = {
-    'weapon': notImplemented('weapon'),
-    'starship-weapon': notImplemented('starship-weapon'),
-    'vehicle-weapon': notImplemented('vehicle-weapon'),
+    'weapon': weaponHandler,
+    'starship-weapon': starshipWeaponHandler,
+    'vehicle-weapon': vehicleWeaponHandler,
 
     'action-meleeattack': notImplemented('action-meleeattack'),
     'action-brawlattack': notImplemented('action-brawlattack'),

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -117,8 +117,17 @@ export interface ItemView {
     scale?: { score: number };
     /** Damage state index (0 = pristine, higher = degraded; resolves to a penalty). */
     damaged?: number;
-    /** Weapon mod totals — keep open-shaped; resolved by applyWeaponMods. */
-    mods?: { dmg?: { score?: number }; misc?: { score?: number }; bonus?: { score?: number } };
+    /**
+     * Weapon mod totals matching the actual weapon schema (numbers, not nested
+     * objects). Mapped directly into the WeaponMods shape applyWeaponMods expects.
+     */
+    mods?: { damage?: number; attack?: number; difficulty?: number };
+    /**
+     * True when the item's subtype is `explosive`. Set by the adapter so the
+     * weapon handler can pass the real value into computeStunFlags (which has
+     * an explosive-specific blast-zone-1 stun-damage branch).
+     */
+    isExplosive?: boolean;
     /** Weapon's authored skill/specialization context. */
     stats?: { skill?: string; specialization?: string };
     /** Blast radius for explosives — only zone "1"'s stun damage is read here. */
@@ -188,11 +197,6 @@ export type Handler<K extends RollTypeKey> = (
     input: HandlerInput,
     ctx: HandlerContext,
 ) => HandlerOutput<K>;
-
-const notImplemented = <K extends RollTypeKey>(key: K): Handler<K> =>
-    () => {
-        throw new Error(`Roll handler not implemented: ${key}`);
-    };
 
 const skillItemAttribute = (item: ItemView | undefined): string | null =>
     item?.attribute ? item.attribute.toLowerCase() : null;
@@ -279,9 +283,9 @@ function buildWeaponBucket(input: HandlerInput, ctx: HandlerContext): WeaponBuck
     const modded = applyWeaponMods(
         { damageScore: damagescore, miscMod: 0, bonusmod: 0 },
         {
-            damage: item.mods?.dmg?.score ?? 0,
-            difficulty: item.mods?.misc?.score ?? 0,
-            attack: item.mods?.bonus?.score ?? 0,
+            damage: item.mods?.damage ?? 0,
+            attack: item.mods?.attack ?? 0,
+            difficulty: item.mods?.difficulty ?? 0,
         },
     );
     damagescore = modded.damageScore;
@@ -289,7 +293,7 @@ function buildWeaponBucket(input: HandlerInput, ctx: HandlerContext): WeaponBuck
     const { onlyStun, canStun } = computeStunFlags({
         stunOnly: item.stun?.stun_only,
         weaponStunScore: item.stun?.score ?? 0,
-        isExplosive: false, // explosive preflight is upstream of dispatch
+        isExplosive: !!item.isExplosive,
         explosiveZonesEnabled: ctx.settings.explosiveZones,
         blastZone1StunDamage: item.blast_radius?.['1']?.stun_damage ?? 0,
     });
@@ -328,7 +332,10 @@ function buildWeaponBucket(input: HandlerInput, ctx: HandlerContext): WeaponBuck
         can_stun: canStun,
         // `stun` is a legacy duplicate of `only_stun` in RollData. Phase 3 cleanup.
         stun: onlyStun,
-        attackerScale: item.scale?.score ?? 0,
+        // Weapon scale of 0 falls back to the actor's scale (matches the
+        // original truthy guard at roll-setup.ts: weapon.system.scale.score is
+        // only assigned when truthy, otherwise actor scale is read elsewhere).
+        attackerScale: item.scale?.score || actorScale(ctx.actor),
         specSkill,
     };
 }
@@ -449,9 +456,9 @@ const actionVehicleRangedWeaponAttackHandler: Handler<'action-vehiclerangedweapo
     const modded = applyWeaponMods(
         { damageScore: baseDamage, miscMod: 0, bonusmod: 0 },
         {
-            damage: item.mods?.dmg?.score ?? 0,
-            difficulty: item.mods?.misc?.score ?? 0,
-            attack: item.mods?.bonus?.score ?? 0,
+            damage: item.mods?.damage ?? 0,
+            attack: item.mods?.attack ?? 0,
+            difficulty: item.mods?.difficulty ?? 0,
         },
     );
     return {
@@ -460,7 +467,8 @@ const actionVehicleRangedWeaponAttackHandler: Handler<'action-vehiclerangedweapo
         source: item.name ?? '',
         range: 'OD6S.RANGE_SHORT_SHORT',
         difficultylevel: defaultDifficultyLabel(ctx.settings),
-        attackerScale: item.scale?.score ?? vehicleScaleForActor(ctx.actor, ctx),
+        // Truthy fallback to vehicle scale — matches the legacy guard.
+        attackerScale: item.scale?.score || vehicleScaleForActor(ctx.actor, ctx),
         vehicle: vehicleUuidForActor(ctx.actor),
     };
 };

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -343,6 +343,128 @@ const vehicleWeaponHandler: Handler<'vehicle-weapon'> = (input, ctx) => ({
     vehicle: vehicleUuidForActor(ctx.actor),
 });
 
+// ---- Action family helpers ----
+
+const characterAttributes = (actor: ActorView): Record<string, { score: number }> =>
+    (actor.type === 'character' || actor.type === 'npc') ? actor.attributes ?? {} : {};
+
+const characterAttributeScore = (actor: ActorView, key: string): number =>
+    characterAttributes(actor)[key]?.score ?? 0;
+
+const actorScale = (actor: ActorView): number => actor.scale?.score ?? 0;
+
+const vehicleScaleForActor = (actor: ActorView, ctx: HandlerContext): number =>
+    (actor.type === 'vehicle' || actor.type === 'starship')
+        ? actor.scale?.score ?? 0
+        : ctx.vehicleStats?.scale?.score ?? 0;
+
+const vehicleRamForActor = (
+    actor: ActorView,
+    ctx: HandlerContext,
+): { ram: number; ramDamage: number } =>
+    (actor.type === 'vehicle' || actor.type === 'starship')
+        ? { ram: actor.ram?.score ?? 0, ramDamage: actor.ram_damage?.score ?? 0 }
+        : {
+            ram: ctx.vehicleStats?.ram?.score ?? 0,
+            ramDamage: ctx.vehicleStats?.ram_damage?.score ?? 0,
+        };
+
+const defaultDifficultyLabel = (settings: RollSettingsView): string =>
+    settings.defaultUnknownDifficulty ? 'OD6S.DIFFICULTY_UNKNOWN' : 'OD6S.DIFFICULTY_EASY';
+
+// ---- Action handlers ----
+
+const actionAttributeHandler: Handler<'action-attribute'> = (input, ctx) => ({
+    score: characterAttributeScore(ctx.actor, input.attribute ?? ''),
+});
+
+const actionOtherHandler: Handler<'action-other'> = () => ({});
+
+const actionRangedAttackHandler: Handler<'action-rangedattack'> = (_input, ctx) => ({
+    score: characterAttributeScore(ctx.actor, 'agi'),
+    range: 'OD6S.RANGE_SHORT_SHORT',
+    difficultylevel: defaultDifficultyLabel(ctx.settings),
+    attackerScale: actorScale(ctx.actor),
+});
+
+const actionVehicleRangedAttackHandler: Handler<'action-vehiclerangedattack'> = (_input, ctx) => ({
+    score: characterAttributeScore(ctx.actor, 'mec'),
+    range: 'OD6S.RANGE_SHORT_SHORT',
+    difficultylevel: defaultDifficultyLabel(ctx.settings),
+    attackerScale: vehicleScaleForActor(ctx.actor, ctx),
+    vehicle: vehicleUuidForActor(ctx.actor),
+});
+
+const actionMeleeAttackHandler: Handler<'action-meleeattack'> = (_input, ctx) => {
+    const resolved = resolveSkillBackedAction({
+        skill: ctx.actionSkill ?? null,
+        attributes: characterAttributes(ctx.actor),
+        flatSkills: ctx.settings.flatSkills,
+        // Melee uses AGI per the rules; not a configurable setting.
+        fallbackAttributeKey: 'agi',
+    });
+    return {
+        score: resolved.score,
+        attackerScale: actorScale(ctx.actor),
+        damagescore: characterStrengthDamage(ctx.actor),
+    };
+};
+
+const actionBrawlAttackHandler: Handler<'action-brawlattack'> = (_input, ctx) => {
+    const resolved = resolveSkillBackedAction({
+        skill: ctx.actionSkill ?? null,
+        attributes: characterAttributes(ctx.actor),
+        flatSkills: ctx.settings.flatSkills,
+        fallbackAttributeKey: ctx.settings.brawlAttribute,
+    });
+    const str = characterStrengthDamage(ctx.actor);
+    return {
+        score: resolved.score,
+        attackerScale: actorScale(ctx.actor),
+        damagetype: 'p',
+        damagescore: str,
+        stundamagetype: 'p',
+        stundamagescore: str,
+        can_stun: true,
+    };
+};
+
+const actionVehicleRamAttackHandler: Handler<'action-vehicleramattack'> = (_input, ctx) => {
+    const { ram, ramDamage } = vehicleRamForActor(ctx.actor, ctx);
+    const contribution = ramAttackContribution(ram, ramDamage);
+    const damagemodifiers: Modifier[] = [];
+    if (contribution.modifier) damagemodifiers.push(contribution.modifier);
+    return {
+        damagetype: 'p',
+        damagemodifiers,
+        source: 'OD6S.COLLISION',
+        attackerScale: vehicleScaleForActor(ctx.actor, ctx),
+        vehicle: vehicleUuidForActor(ctx.actor),
+    };
+};
+
+const actionVehicleRangedWeaponAttackHandler: Handler<'action-vehiclerangedweaponattack'> = (_input, ctx) => {
+    const item = ctx.item ?? {} as ItemView;
+    const baseDamage = item.damage?.score ?? 0;
+    const modded = applyWeaponMods(
+        { damageScore: baseDamage, miscMod: 0, bonusmod: 0 },
+        {
+            damage: item.mods?.dmg?.score ?? 0,
+            difficulty: item.mods?.misc?.score ?? 0,
+            attack: item.mods?.bonus?.score ?? 0,
+        },
+    );
+    return {
+        damagetype: item.damage?.type ?? '',
+        damagescore: modded.damageScore,
+        source: item.name ?? '',
+        range: 'OD6S.RANGE_SHORT_SHORT',
+        difficultylevel: defaultDifficultyLabel(ctx.settings),
+        attackerScale: item.scale?.score ?? vehicleScaleForActor(ctx.actor, ctx),
+        vehicle: vehicleUuidForActor(ctx.actor),
+    };
+};
+
 const resistanceVehicleToughnessHandler: Handler<'resistance-vehicletoughness'> = (input, ctx) => ({
     scaledice: scaleToDice(input, ctx),
     vehicle: vehicleUuidForActor(ctx.actor),
@@ -353,14 +475,14 @@ export const HANDLERS = {
     'starship-weapon': starshipWeaponHandler,
     'vehicle-weapon': vehicleWeaponHandler,
 
-    'action-meleeattack': notImplemented('action-meleeattack'),
-    'action-brawlattack': notImplemented('action-brawlattack'),
-    'action-rangedattack': notImplemented('action-rangedattack'),
-    'action-vehiclerangedattack': notImplemented('action-vehiclerangedattack'),
-    'action-vehiclerangedweaponattack': notImplemented('action-vehiclerangedweaponattack'),
-    'action-vehicleramattack': notImplemented('action-vehicleramattack'),
-    'action-attribute': notImplemented('action-attribute'),
-    'action-other': notImplemented('action-other'),
+    'action-meleeattack': actionMeleeAttackHandler,
+    'action-brawlattack': actionBrawlAttackHandler,
+    'action-rangedattack': actionRangedAttackHandler,
+    'action-vehiclerangedattack': actionVehicleRangedAttackHandler,
+    'action-vehiclerangedweaponattack': actionVehicleRangedWeaponAttackHandler,
+    'action-vehicleramattack': actionVehicleRamAttackHandler,
+    'action-attribute': actionAttributeHandler,
+    'action-other': actionOtherHandler,
 
     'skill': skillHandler,
     'skill-dodge': skillDodgeHandler,

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -147,6 +147,27 @@ const resistanceHandler: Handler<'resistance'> = (input, ctx) => ({
     scaledice: scaleToDice(input, ctx),
 });
 
+const fundsHandler: Handler<'funds'> = () => ({});
+const attributeHandler: Handler<'attribute'> = () => ({});
+
+const purchaseHandler: Handler<'purchase'> = (input) => ({
+    seller: input.seller ?? '',
+});
+
+/**
+ * Top-level `brawlattack` is unreachable in the current code: Actor.rollAction
+ * wraps brawl rolls as `{type: 'action', subtype: 'brawlattack'}`, which the
+ * classifier routes to action-brawlattack. The classifier still accepts a
+ * top-level `brawlattack`, but no caller produces one. Phase 3 removes the
+ * key from RollTypeKey entirely; until then this throws to surface any
+ * caller that resurrects the path.
+ */
+const brawlattackDeadPathHandler: Handler<'brawlattack'> = () => {
+    throw new Error(
+        'brawlattack: unreachable dead path — route brawl rolls through action-brawlattack',
+    );
+};
+
 const resistanceVehicleToughnessHandler: Handler<'resistance-vehicletoughness'> = (input, ctx) => {
     const vehicleUuid =
         ctx.actor.type === 'vehicle' || ctx.actor.type === 'starship'
@@ -183,9 +204,9 @@ export const HANDLERS = {
     'mortally_wounded': mortallyWoundedHandler,
     'incapacitated': incapacitatedHandler,
 
-    'funds': notImplemented('funds'),
-    'purchase': notImplemented('purchase'),
+    'funds': fundsHandler,
+    'purchase': purchaseHandler,
 
-    'brawlattack': notImplemented('brawlattack'),
-    'attribute': notImplemented('attribute'),
+    'brawlattack': brawlattackDeadPathHandler,
+    'attribute': attributeHandler,
 } as const satisfies { [K in RollTypeKey]: Handler<K> };

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -112,6 +112,106 @@ export const ROLL_TYPE_FIELDS = {
     'attribute': [],
 } as const satisfies Record<RollTypeKey, readonly (keyof RollData)[]>;
 
+// ---- Phase 0 (#98): RollTypeKey → governing rule ids ----
+//
+// Maps each handler key to the rule ids in the (gitignored) rules reference
+// that govern its behavior. Rule ids only — no rule text. The mapping is the
+// design spec the upcoming handlers (and their domain tests) are written
+// against; if a handler ends up needing logic not covered by the listed
+// rules, the discrepancy is the signal to either extend this map or remove
+// the unbacked behavior.
+//
+// `?` after an id = best-guess assignment, needs user confirmation before
+// Phase 1 tests rely on it.
+//
+// weapon                            : attacking-and-defending, base-combat-difficulty,
+//                                     combat-difficulty-modifiers-range, step-3-determining-damage,
+//                                     determining-strength-damage
+// starship-weapon                   : scale, step-3-determining-damage, combat-difficulty-modifiers-range,
+//                                     ship-weapons
+// vehicle-weapon                    : scale, step-3-determining-damage, combat-difficulty-modifiers-range,
+//                                     vehicle-damage
+// action-meleeattack                : attacking-and-defending, combat-difficulty-modifiers-range,
+//                                     skill-base-mechanics
+// action-brawlattack                : attacking-and-defending, step-3-determining-damage,
+//                                     determining-strength-damage
+// action-rangedattack               : attacking-and-defending, combat-difficulty-modifiers-range,
+//                                     combat-difficulty-modifiers-cover, base-combat-difficulty
+// action-vehiclerangedattack        : scale, combat-difficulty-modifiers-range, vehicle-damage
+// action-vehiclerangedweaponattack  : scale, step-3-determining-damage, combat-difficulty-modifiers-range
+// action-vehicleramattack           : ramming, scale, vehicle-damage, step-3-determining-damage
+// action-attribute                  : skill-check, base-combat-difficulty
+// action-other                      : skill-check, base-combat-difficulty  ?  fallback bucket — verify
+//                                     no current caller depends on action-other doing anything
+//                                     beyond a generic skill-check
+// skill                             : skill-base-mechanics, skill-check
+// skill-dodge                       : attacking-and-defending, active-defense, skill-base-mechanics
+// specialization                    : specialization-in-skills, skill-check
+// damage                            : step-3-determining-damage, body-points-damage-application
+// resistance                        : damage-resistance-total-body-points,
+//                                     damage-resistance-total-wound-levels
+// resistance-vehicletoughness       : scale, damage-resistance-total-body-points, vehicle-damage
+// mortally_wounded                  : unconsciousness-and-death, wound-level-effects
+// incapacitated                     : wound-level-effects  ?  largely UI/state — confirm whether the
+//                                     roll itself has a rules basis or is purely a status check
+// funds                             : funds-determination, equipment-purchase-mechanics
+// purchase                          : funds-determination, equipment-purchase-mechanics
+// brawlattack                       : attacking-and-defending, step-3-determining-damage,
+//                                     determining-strength-damage  ?  legacy top-level alias of
+//                                     action-brawlattack — candidate for removal if no caller routes here
+// attribute                         : skill-check, attribute-dice-distribution
+//
+// ---- Behaviors in roll-setup.ts with no apparent rules backing ----
+//
+// Each entry is a candidate for removal during the rewrite. `?` = confirm
+// with user before deletion. References use ids defined above.
+//
+// 1. roll-setup.ts:451 — `miscMod += 5` is added when action.subtype is
+//    'meleeattack' AND the localized name matches OD6S.ACTION_MELEE_ATTACK.
+//    Hardcoded +5 with no entry in attacking-and-defending or
+//    combat-difficulty-modifiers-range.  ?  confirm — looks like a fudge
+//    distinguishing "generic action menu melee" from "weapon item melee".
+//
+// 2. roll-setup.ts:434–438 — `actor.getFlag('od6s','fatepointeffect')`
+//    auto-doubles dice+pips when canUseFp. fate-points permits FP spending
+//    for bonuses but doesn't define an "always-on" flag with no cost.  ?
+//    confirm whether the flag represents a deferred-cost UI state or a
+//    rules-unsanctioned freebie.
+//
+// 3. roll-setup.ts:153 (approx) — melee range "fudge" derived from token
+//    widths and grid size. Pure Foundry grid geometry, not a rules concern;
+//    keep as a UI helper but separate from rules math.
+//
+// 4. roll-setup.ts:547–551 — when `dice_for_scale` is on and `scaleMod < 0`,
+//    score is increased by |scaleMod| AND scaleDice is set to a negative
+//    dice count. The scale rule defines modifier application to
+//    difficulty/damage/resistance but not this combined score-bump +
+//    negative-dice substitution.  ?  confirm whether dice_for_scale is a
+//    house-rule setting layered on top of the official scale rule.
+//
+// 5. roll-setup.ts:596–597 — resistance path always converts positive scale
+//    to dice unconditionally; attacks (item 4) branch on sign. Asymmetry
+//    not justified by scale rule.  ?  same disposition as item 4.
+//
+// 6. roll-setup.ts:601–603 — `actor.system.roll_mod` is added to score at
+//    the very end. No rule defines a flat global per-actor modifier.  ?
+//    confirm intent (house-rule slot? debug aid? legacy?).
+//
+// 7. roll-setup.ts:440–442 — appends localized "Parry" to weapon name when
+//    `subtype === 'parry'`, but classifyRoll never produces that subtype.
+//    Likely dead code; remove during rewrite.
+//
+// 8. roll-setup.ts:444 — `canOppose` list includes 'toughness', but no
+//    RollTypeKey produces type='toughness'. Either dead, or the list should
+//    use 'resistance-vehicletoughness' / canonical 'resistance'. Remove or
+//    correct during rewrite.
+//
+// 9. roll-setup.ts:556–569 — `specSkill` populated only when
+//    `OD6S.showSkillSpecialization` setting is true. The specialization
+//    rule doesn't gate skill-link visibility on a setting.  ?  confirm
+//    whether this is a UI display choice (keep, move to view layer) or
+//    rules-relevant (move into the handler input contract).
+//
 // ---- Compile-time partition invariants ----
 //
 // These types resolve to `never` iff the partition is well-formed; if any

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -172,45 +172,72 @@ export const ROLL_TYPE_FIELDS = {
 //    combat-difficulty-modifiers-range.  ?  confirm — looks like a fudge
 //    distinguishing "generic action menu melee" from "weapon item melee".
 //
-// 2. roll-setup.ts:434–438 — `actor.getFlag('od6s','fatepointeffect')`
-//    auto-doubles dice+pips when canUseFp. fate-points permits FP spending
-//    for bonuses but doesn't define an "always-on" flag with no cost.  ?
-//    confirm whether the flag represents a deferred-cost UI state or a
-//    rules-unsanctioned freebie.
+// 2. roll-setup.ts:434–438 — `fatepointeffect` flag doubling.
+//    RECLASSIFIED 2026-05-04 as rules-backed: the FP is paid for in
+//    roll-execute.ts when first spent (`rollData.fatepoint`); the flag
+//    keeps the "FP in effect for the round" state so subsequent rolls in
+//    the round are doubled without re-paying. Cleared on round advance
+//    (combat-hooks). Matches the fate-points rule's full-round duration.
+//    Phase 1 should pin the bonusmod-compounding edge case in a unit test
+//    (execute doubles originaldice/pips, setup doubles dice/pips).
 //
-// 3. roll-setup.ts:153 (approx) — melee range "fudge" derived from token
-//    widths and grid size. Pure Foundry grid geometry, not a rules concern;
-//    keep as a UI helper but separate from rules math.
+// 3. roll-setup.ts:150–160 — melee/brawl out-of-range check (gated on
+//    `OD6S.meleeRange`). Token-width "fudge" is grid-geometry correction
+//    so size-disparate tokens aren't false-positives. RECLASSIFIED: not a
+//    rules concern at all — Foundry-VTT UX validation. Phase 3 should
+//    relocate this to a pre-roll sheet/action listener so the rules
+//    pipeline doesn't carry canvas/UI logic.
 //
-// 4. roll-setup.ts:547–551 — when `dice_for_scale` is on and `scaleMod < 0`,
-//    score is increased by |scaleMod| AND scaleDice is set to a negative
-//    dice count. The scale rule defines modifier application to
-//    difficulty/damage/resistance but not this combined score-bump +
-//    negative-dice substitution.  ?  confirm whether dice_for_scale is a
-//    house-rule setting layered on top of the official scale rule.
+// 4. roll-setup.ts:547–551 — `dice_for_scale` + negative-scale combined
+//    score-bump and negative scaleDice. RECLASSIFIED 2026-05-04 as
+//    rules-backed: the score-bump is the additive scale modifier (scale
+//    rule); the negative scaleDice is fed into otherpenalty in
+//    roll-execute.ts:61 — the dice-pool reduction equivalent. The
+//    `dice_for_scale` setting selects between two equivalent
+//    presentations of the same rule, not an unbacked layer.
 //
-// 5. roll-setup.ts:596–597 — resistance path always converts positive scale
-//    to dice unconditionally; attacks (item 4) branch on sign. Asymmetry
-//    not justified by scale rule.  ?  same disposition as item 4.
+// 5. roll-setup.ts:596–597 — resistance path scaleDice always-positive.
+//    RECLASSIFIED 2026-05-04 as rules-backed: not asymmetric — items 4
+//    and 5 are the attacker-side and defender-side halves of the same
+//    scale rule. Attacker-smaller subtracts from attacker score
+//    (item 4); defender-larger adds to defender dice (item 5). Same
+//    rule, role-split application.
 //
-// 6. roll-setup.ts:601–603 — `actor.system.roll_mod` is added to score at
-//    the very end. No rule defines a flat global per-actor modifier.  ?
-//    confirm intent (house-rule slot? debug aid? legacy?).
+// 6. roll-setup.ts:601–603 — `actor.system.roll_mod` flat additive.
+//    RECLASSIFIED 2026-05-04 as not-a-rules-concern: it's a per-actor
+//    GM/admin override field declared in actor schemas (initial 0), used
+//    in init-roll.ts as well. Keep — but document as a configurable
+//    knob outside the core rule set; the rules pipeline shouldn't
+//    "delete" it. Phase 3 may move the application out of setupRollData
+//    if cleaner, but it's not a deletion candidate.
 //
-// 7. roll-setup.ts:440–442 — appends localized "Parry" to weapon name when
-//    `subtype === 'parry'`, but classifyRoll never produces that subtype.
-//    Likely dead code; remove during rewrite.
+// 7. roll-setup.ts:440–442 — "Parry" weapon-name suffix.
+//    RECLASSIFIED 2026-05-04 as rules-backed (and not dead): item.ts
+//    sets `subtype = 'parry'` directly when a weapon is rolled as parry
+//    defense, bypassing classifyRoll. roll-difficulty.ts and roll-execute
+//    both rely on the value. The label suffix is the user-facing marker
+//    of the defensive use. Keep.
 //
-// 8. roll-setup.ts:444 — `canOppose` list includes 'toughness', but no
-//    RollTypeKey produces type='toughness'. Either dead, or the list should
-//    use 'resistance-vehicletoughness' / canonical 'resistance'. Remove or
-//    correct during rewrite.
+// 8. roll-setup.ts:444 — `'toughness'` in canOppose list. CONFIRMED dead:
+//    no RollTypeKey or canonical type ever produces `type: 'toughness'`
+//    (vehicletoughness is normalized to resistance). Zero-impact deletion
+//    in rewrite — no RFC.
 //
-// 9. roll-setup.ts:556–569 — `specSkill` populated only when
-//    `OD6S.showSkillSpecialization` setting is true. The specialization
-//    rule doesn't gate skill-link visibility on a setting.  ?  confirm
-//    whether this is a UI display choice (keep, move to view layer) or
-//    rules-relevant (move into the handler input contract).
+// 9. roll-setup.ts:556–569 — `specSkill` gated on `showSkillSpecialization`
+//    setting. RECLASSIFIED 2026-05-04 as not-a-rules-concern: the rule
+//    governs *when* a specialization applies, not *whether* the dialog
+//    shows the backing skill link. The setting is a UI presentation
+//    preference. Keep; phase 3 may move the read into the dialog/view
+//    layer instead of the handler contract.
+//
+// ---- Net Phase 0 outcome ----
+// Of 9 originally-flagged behaviors:
+//   - 1 RFC filed (#100) — item 1 (+5 magic constant)
+//   - 1 dead string to delete in rewrite (item 8) — zero impact
+//   - 4 reclassified rules-backed (items 2, 4, 5, 7)
+//   - 3 reclassified not-a-rules-concern, keep / relocate (items 3, 6, 9)
+//
+// Phase 1 (domain tests) can proceed without further user gating.
 //
 // ---- Compile-time partition invariants ----
 //

--- a/tests/domain/roll-handlers-action.test.ts
+++ b/tests/domain/roll-handlers-action.test.ts
@@ -217,13 +217,12 @@ describe('action-meleeattack handler', () => {
         expect(out.attackerScale).toBe(0);
     });
 
-    it('falls back to brawl/melee attribute when no skill item is present', () => {
+    it('falls back to AGI (rules-fixed for melee combat) when no skill item is present', () => {
         const out = HANDLERS['action-meleeattack'](
             makeInput('meleeattack'),
             makeCtx({ actor: characterWithAttrs(), actionSkill: null }),
         );
-        // settings.brawlAttribute = 'str' → fallback to str.score
-        expect(out.score).toBe(9);
+        expect(out.score).toBe(12); // agi
     });
 });
 

--- a/tests/domain/roll-handlers-action.test.ts
+++ b/tests/domain/roll-handlers-action.test.ts
@@ -286,7 +286,7 @@ describe('action-vehiclerangedweaponattack handler', () => {
             name: 'Heavy Cannon',
             damage: { type: 'e', score: 18 },
             scale: { score: 6 },
-            mods: { dmg: { score: 3 }, misc: { score: 0 }, bonus: { score: 0 } },
+            mods: { damage: 3, attack: 0, difficulty: 0 },
         };
         const out = HANDLERS['action-vehiclerangedweaponattack'](
             makeInput('vehiclerangedweaponattack', { itemId: 'Item.weapon-1' }),
@@ -307,7 +307,7 @@ describe('action-vehiclerangedweaponattack handler', () => {
             type: 'vehicle-weapon',
             name: 'Light Cannon',
             damage: { type: 'e', score: 9 },
-            mods: { dmg: { score: 0 }, misc: { score: 0 }, bonus: { score: 0 } },
+            mods: { damage: 0, attack: 0, difficulty: 0 },
         };
         const out = HANDLERS['action-vehiclerangedweaponattack'](
             makeInput('vehiclerangedweaponattack', { itemId: 'Item.weapon-2' }),

--- a/tests/domain/roll-handlers-action.test.ts
+++ b/tests/domain/roll-handlers-action.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Domain tests — action family roll handlers (#98 phase 1).
+ *
+ * Covers the eight action-* RollTypeKeys. Action handlers vary widely in
+ * shape; their bucket-owned outputs split as:
+ *
+ *   action-attribute                 — score from the named attribute
+ *   action-meleeattack               — score (skill-backed), attackerScale,
+ *                                       damagescore (= actor.strengthDamage,
+ *                                       per the unarmed strike rule)
+ *   action-brawlattack               — score (skill-backed), attackerScale,
+ *                                       physical damage + stun damage at
+ *                                       strength score, can_stun true
+ *   action-rangedattack              — score from AGI, attackerScale, default
+ *                                       range/difficulty labels
+ *   action-vehiclerangedattack       — score from MEC, attackerScale, default
+ *                                       range/difficulty labels, vehicle uuid
+ *   action-vehiclerangedweaponattack — vehicle weapon item provides damage,
+ *                                       weapon mods applied; vehicle uuid
+ *   action-vehicleramattack          — physical damage from ramAttackContribution,
+ *                                       attackerScale from vehicle, source label
+ *   action-other                     — empty fallback
+ *
+ * RFC #100 outcome: the +5 magic constant on action-meleeattack is removed.
+ * The rules-correct meleeattack action damage is just actor.strengthDamage
+ * (matching the rule for an unarmed/improvised strike); score comes from
+ * the skill-backed action resolution like other skill-backed actions.
+ *
+ * Rules referenced (ids only):
+ *   action-meleeattack               — attacking-and-defending, skill-base-mechanics
+ *   action-brawlattack               — attacking-and-defending, step-3-determining-damage,
+ *                                       determining-strength-damage
+ *   action-rangedattack              — attacking-and-defending,
+ *                                       combat-difficulty-modifiers-range,
+ *                                       combat-difficulty-modifiers-cover
+ *   action-vehiclerangedattack       — scale, combat-difficulty-modifiers-range,
+ *                                       vehicle-damage
+ *   action-vehiclerangedweaponattack — scale, step-3-determining-damage,
+ *                                       combat-difficulty-modifiers-range
+ *   action-vehicleramattack          — ramming, scale, vehicle-damage,
+ *                                       step-3-determining-damage
+ *   action-attribute                 — skill-check, base-combat-difficulty
+ *   action-other                     — skill-check (fallback bucket)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HANDLERS } from '../../src/module/apps/roll-helpers/roll-handlers';
+import type {
+    ActorView,
+    HandlerContext,
+    HandlerInput,
+    ItemView,
+    RollSettingsView,
+} from '../../src/module/apps/roll-helpers/roll-handlers';
+import type { ActionSkill } from '../../src/module/apps/roll-helpers/action-math';
+import type { RollTypeKey } from '../../src/module/apps/roll-helpers/roll-data';
+
+type ActionSubtype =
+    | 'attribute' | 'meleeattack' | 'brawlattack'
+    | 'rangedattack' | 'vehiclerangedattack' | 'vehiclerangedweaponattack'
+    | 'vehicleramattack' | 'other';
+
+const SUBTYPE_TO_KEY: Record<ActionSubtype, RollTypeKey> = {
+    attribute: 'action-attribute',
+    meleeattack: 'action-meleeattack',
+    brawlattack: 'action-brawlattack',
+    rangedattack: 'action-rangedattack',
+    vehiclerangedattack: 'action-vehiclerangedattack',
+    vehiclerangedweaponattack: 'action-vehiclerangedweaponattack',
+    vehicleramattack: 'action-vehicleramattack',
+    other: 'action-other',
+};
+
+function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
+    return {
+        defaultUnknownDifficulty: false,
+        diceForScale: false,
+        fundsFate: false,
+        hideCombatCards: false,
+        hideSkillCards: false,
+        showSkillSpecialization: true,
+        pipsPerDice: 3,
+        meleeDifficulty: false,
+        explosiveZones: false,
+        weaponDamageTable: {},
+        flatSkills: false,
+        brawlAttribute: 'str',
+        ...overrides,
+    };
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+    return {
+        actor: { type: 'character', uuid: 'Actor.x' },
+        targets: [],
+        settings: makeSettings(),
+        localize: (key: string) => key,
+        ...overrides,
+    };
+}
+
+function makeInput(subtype: ActionSubtype, extras: Partial<HandlerInput> = {}): HandlerInput {
+    return {
+        classified: { type: 'action', subtype, key: SUBTYPE_TO_KEY[subtype] },
+        name: '',
+        score: 0,
+        type: 'action',
+        subtype,
+        ...extras,
+    };
+}
+
+const characterWithAttrs = (overrides: Partial<ActorView & { type: 'character' }> = {}): ActorView => ({
+    type: 'character',
+    uuid: 'Actor.character',
+    attributes: { str: { score: 9 }, agi: { score: 12 }, mec: { score: 6 } },
+    scale: { score: 0 },
+    strengthDamage: 6,
+    ...overrides,
+} as ActorView);
+
+describe('action-attribute handler', () => {
+    it('returns the actor attribute score for the named attribute', () => {
+        const out = HANDLERS['action-attribute'](
+            makeInput('attribute', { attribute: 'agi' }),
+            makeCtx({ actor: characterWithAttrs() }),
+        );
+        expect(out.score).toBe(12);
+    });
+
+    it('returns 0 when the actor has no such attribute', () => {
+        const out = HANDLERS['action-attribute'](
+            makeInput('attribute', { attribute: 'kno' }),
+            makeCtx({ actor: characterWithAttrs() }),
+        );
+        expect(out.score).toBe(0);
+    });
+});
+
+describe('action-other handler', () => {
+    it('returns an empty bucket — fallback for unrecognized action subtypes', () => {
+        const out = HANDLERS['action-other'](
+            makeInput('other'),
+            makeCtx({ actor: characterWithAttrs() }),
+        );
+        expect(out).toEqual({});
+    });
+});
+
+describe('action-rangedattack handler', () => {
+    it('uses agility for score and the rules-default short-range / easy difficulty labels', () => {
+        const out = HANDLERS['action-rangedattack'](
+            makeInput('rangedattack'),
+            makeCtx({ actor: characterWithAttrs({ scale: { score: 3 } }) }),
+        );
+        expect(out.score).toBe(12); // agi
+        expect(out.range).toBe('OD6S.RANGE_SHORT_SHORT');
+        expect(out.difficultylevel).toBe('OD6S.DIFFICULTY_EASY');
+        expect(out.attackerScale).toBe(3);
+    });
+
+    it('honors defaultUnknownDifficulty setting', () => {
+        const out = HANDLERS['action-rangedattack'](
+            makeInput('rangedattack'),
+            makeCtx({
+                actor: characterWithAttrs(),
+                settings: makeSettings({ defaultUnknownDifficulty: true }),
+            }),
+        );
+        expect(out.difficultylevel).toBe('OD6S.DIFFICULTY_UNKNOWN');
+    });
+});
+
+describe('action-vehiclerangedattack handler', () => {
+    it('uses MEC for score and adds the vehicle uuid', () => {
+        const out = HANDLERS['action-vehiclerangedattack'](
+            makeInput('vehiclerangedattack'),
+            makeCtx({
+                actor: { type: 'vehicle', uuid: 'Actor.vehicle-1', scale: { score: 9 } },
+            }),
+        );
+        // score for vehicle-action paths comes from MEC on the (character)
+        // pilot, not the vehicle. When a vehicle actor itself is the actor,
+        // MEC isn't available — orchestrator would resolve via the gunnery
+        // skill-score helper; bare handler returns 0.
+        expect(out.score).toBe(0);
+        expect(out.vehicle).toBe('Actor.vehicle-1');
+        expect(out.attackerScale).toBe(9);
+    });
+
+    it('reads MEC from a character pilot', () => {
+        const pilot = characterWithAttrs({
+            vehicle: { uuid: 'Actor.embedded' },
+        });
+        const out = HANDLERS['action-vehiclerangedattack'](
+            makeInput('vehiclerangedattack'),
+            makeCtx({
+                actor: pilot,
+                vehicleStats: { scale: { score: 6 } },
+            }),
+        );
+        expect(out.score).toBe(6); // mec
+        expect(out.vehicle).toBe('Actor.embedded');
+        expect(out.attackerScale).toBe(6); // from vehicleStats
+    });
+});
+
+describe('action-meleeattack handler', () => {
+    it('uses skill-backed score resolution and sets damagescore to actor strength damage (no +5 — see RFC #100)', () => {
+        const skill: ActionSkill = { score: 6, attributeKey: 'str' };
+        const out = HANDLERS['action-meleeattack'](
+            makeInput('meleeattack', { name: 'OD6S.ACTION_MELEE_ATTACK' }),
+            makeCtx({ actor: characterWithAttrs(), actionSkill: skill }),
+        );
+        expect(out.score).toBe(15); // 6 (skill) + 9 (str)
+        expect(out.damagescore).toBe(6); // actor.strengthDamage
+        expect(out.attackerScale).toBe(0);
+    });
+
+    it('falls back to brawl/melee attribute when no skill item is present', () => {
+        const out = HANDLERS['action-meleeattack'](
+            makeInput('meleeattack'),
+            makeCtx({ actor: characterWithAttrs(), actionSkill: null }),
+        );
+        // settings.brawlAttribute = 'str' → fallback to str.score
+        expect(out.score).toBe(9);
+    });
+});
+
+describe('action-brawlattack handler', () => {
+    it('produces physical damage and stun at strength damage with can_stun true', () => {
+        const skill: ActionSkill = { score: 3, attributeKey: 'str' };
+        const out = HANDLERS['action-brawlattack'](
+            makeInput('brawlattack'),
+            makeCtx({ actor: characterWithAttrs(), actionSkill: skill }),
+        );
+        expect(out.score).toBe(12); // 3 + 9
+        expect(out.damagetype).toBe('p');
+        expect(out.damagescore).toBe(6); // strengthDamage
+        expect(out.stundamagetype).toBe('p');
+        expect(out.stundamagescore).toBe(6);
+        expect(out.can_stun).toBe(true);
+    });
+});
+
+describe('action-vehicleramattack handler', () => {
+    it('produces collision source, physical damage type, vehicle uuid, and a ram damage modifier from vehicle ram_damage score', () => {
+        const out = HANDLERS['action-vehicleramattack'](
+            makeInput('vehicleramattack'),
+            makeCtx({
+                actor: {
+                    type: 'vehicle', uuid: 'Actor.vehicle-1',
+                    scale: { score: 6 }, ram: { score: 3 }, ram_damage: { score: 12 },
+                },
+            }),
+        );
+        expect(out.source).toBe('OD6S.COLLISION');
+        expect(out.damagetype).toBe('p');
+        expect(out.attackerScale).toBe(6);
+        expect(out.vehicle).toBe('Actor.vehicle-1');
+        expect(out.damagemodifiers).toContainEqual(
+            expect.objectContaining({ name: 'OD6S.ACTIVE_EFFECTS', value: 12 }),
+        );
+    });
+
+    it('reads ram from vehicleStats when the actor is a character pilot', () => {
+        const pilot = characterWithAttrs({ vehicle: { uuid: 'Actor.embedded' } });
+        const out = HANDLERS['action-vehicleramattack'](
+            makeInput('vehicleramattack'),
+            makeCtx({
+                actor: pilot,
+                vehicleStats: { scale: { score: 9 }, ram: { score: 0 }, ram_damage: { score: 6 } },
+            }),
+        );
+        expect(out.vehicle).toBe('Actor.embedded');
+        expect(out.attackerScale).toBe(9);
+        expect(out.damagemodifiers).toContainEqual(
+            expect.objectContaining({ name: 'OD6S.ACTIVE_EFFECTS', value: 6 }),
+        );
+    });
+});
+
+describe('action-vehiclerangedweaponattack handler', () => {
+    it('reads damage from the vehicle weapon item, applies weapon mods, and emits the vehicle uuid', () => {
+        const vehicleWeapon: ItemView = {
+            type: 'vehicle-weapon',
+            name: 'Heavy Cannon',
+            damage: { type: 'e', score: 18 },
+            scale: { score: 6 },
+            mods: { dmg: { score: 3 }, misc: { score: 0 }, bonus: { score: 0 } },
+        };
+        const out = HANDLERS['action-vehiclerangedweaponattack'](
+            makeInput('vehiclerangedweaponattack', { itemId: 'Item.weapon-1' }),
+            makeCtx({
+                actor: { type: 'vehicle', uuid: 'Actor.vehicle-1', scale: { score: 3 } },
+                item: vehicleWeapon,
+            }),
+        );
+        expect(out.damagetype).toBe('e');
+        expect(out.damagescore).toBe(21); // 18 + 3 (mod)
+        expect(out.source).toBe('Heavy Cannon');
+        expect(out.attackerScale).toBe(6); // from weapon scale (overrides actor)
+        expect(out.vehicle).toBe('Actor.vehicle-1');
+    });
+
+    it('falls back to actor scale when the vehicle weapon has no scale of its own', () => {
+        const vehicleWeapon: ItemView = {
+            type: 'vehicle-weapon',
+            name: 'Light Cannon',
+            damage: { type: 'e', score: 9 },
+            mods: { dmg: { score: 0 }, misc: { score: 0 }, bonus: { score: 0 } },
+        };
+        const out = HANDLERS['action-vehiclerangedweaponattack'](
+            makeInput('vehiclerangedweaponattack', { itemId: 'Item.weapon-2' }),
+            makeCtx({
+                actor: { type: 'vehicle', uuid: 'Actor.v', scale: { score: 3 } },
+                item: vehicleWeapon,
+            }),
+        );
+        expect(out.attackerScale).toBe(3);
+    });
+});

--- a/tests/domain/roll-handlers-damage-resistance.test.ts
+++ b/tests/domain/roll-handlers-damage-resistance.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Domain tests — damage / resistance family roll handlers (#98 phase 1).
+ *
+ * Covers the five RollTypeKeys whose buckets describe post-attack damage
+ * resolution and follow-up survival rolls: damage, resistance,
+ * resistance-vehicletoughness, mortally_wounded, incapacitated.
+ *
+ * Most buckets are empty — the rules-defined work for these handlers is
+ * mostly carried by the COMMON path (dice/pips assembly, weapon-damaged
+ * penalty fold, opposed-flag derivation). The bucket-owned outputs are:
+ *   resistance / resistance-vehicletoughness — `scaledice` (only when
+ *     diceForScale is on; converts an input scale value to a die count
+ *     using the system pipsPerDice constant)
+ *   resistance-vehicletoughness — `vehicle` (UUID of the vehicle being
+ *     resisted on behalf of: the actor itself for vehicle/starship actors,
+ *     the embedded ref for character actors piloting one)
+ *
+ * Rules referenced (ids only):
+ *   damage                       — step-3-determining-damage,
+ *                                  body-points-damage-application
+ *   resistance                   — damage-resistance-total-body-points,
+ *                                  damage-resistance-total-wound-levels
+ *   resistance-vehicletoughness  — scale, damage-resistance-total-body-points,
+ *                                  vehicle-damage
+ *   mortally_wounded             — unconsciousness-and-death, wound-level-effects
+ *   incapacitated                — wound-level-effects (status check)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HANDLERS } from '../../src/module/apps/roll-helpers/roll-handlers';
+import type {
+    ActorView,
+    HandlerContext,
+    HandlerInput,
+    RollSettingsView,
+} from '../../src/module/apps/roll-helpers/roll-handlers';
+import type { RollTypeKey } from '../../src/module/apps/roll-helpers/roll-data';
+
+type DamageResistanceKey =
+    | 'damage'
+    | 'resistance'
+    | 'resistance-vehicletoughness'
+    | 'mortally_wounded'
+    | 'incapacitated';
+
+function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
+    return {
+        defaultUnknownDifficulty: false,
+        diceForScale: false,
+        fundsFate: false,
+        hideCombatCards: false,
+        hideSkillCards: false,
+        showSkillSpecialization: true,
+        pipsPerDice: 3,
+        ...overrides,
+    };
+}
+
+function makeCtx(actor: ActorView, settings?: Partial<RollSettingsView>): HandlerContext {
+    return {
+        actor,
+        targets: [],
+        settings: makeSettings(settings),
+        localize: (key: string) => key,
+    };
+}
+
+function makeInput(key: DamageResistanceKey, scale?: number | null): HandlerInput {
+    const type =
+        key === 'damage' ? 'damage'
+            : key === 'mortally_wounded' ? 'mortally_wounded'
+                : key === 'incapacitated' ? 'incapacitated'
+                    : 'resistance';
+    const subtype = key === 'resistance-vehicletoughness' ? 'vehicletoughness' : '';
+    return {
+        classified: { type, subtype, key: key as RollTypeKey },
+        name: '',
+        score: 0,
+        type,
+        subtype,
+        scale,
+    };
+}
+
+describe('damage handler', () => {
+    it('returns an empty bucket — damage math is COMMON, not bucket-owned', () => {
+        const out = HANDLERS['damage'](
+            makeInput('damage'),
+            makeCtx({ type: 'character', uuid: 'Actor.x' }),
+        );
+        expect(out).toEqual({});
+    });
+});
+
+describe('resistance handler', () => {
+    it('returns scaledice=0 when diceForScale is off, regardless of input scale', () => {
+        const out = HANDLERS['resistance'](
+            makeInput('resistance', 6),
+            makeCtx({ type: 'character', uuid: 'Actor.x' }, { diceForScale: false }),
+        );
+        expect(out.scaledice).toBe(0);
+    });
+
+    it('converts input scale to dice when diceForScale is on (score 6 → 2 dice at pipsPerDice=3)', () => {
+        const out = HANDLERS['resistance'](
+            makeInput('resistance', 6),
+            makeCtx({ type: 'character', uuid: 'Actor.x' }, { diceForScale: true }),
+        );
+        expect(out.scaledice).toBe(2);
+    });
+
+    it('treats missing scale (null/undefined) as 0', () => {
+        const outA = HANDLERS['resistance'](
+            makeInput('resistance', null),
+            makeCtx({ type: 'character', uuid: 'Actor.x' }, { diceForScale: true }),
+        );
+        const outB = HANDLERS['resistance'](
+            makeInput('resistance'),
+            makeCtx({ type: 'character', uuid: 'Actor.x' }, { diceForScale: true }),
+        );
+        expect(outA.scaledice).toBe(0);
+        expect(outB.scaledice).toBe(0);
+    });
+});
+
+describe('resistance-vehicletoughness handler', () => {
+    it('uses the actor uuid when the actor is a vehicle', () => {
+        const out = HANDLERS['resistance-vehicletoughness'](
+            makeInput('resistance-vehicletoughness', 9),
+            makeCtx({ type: 'vehicle', uuid: 'Actor.vehicle-1' }, { diceForScale: true }),
+        );
+        expect(out.vehicle).toBe('Actor.vehicle-1');
+        expect(out.scaledice).toBe(3);
+    });
+
+    it('uses the actor uuid when the actor is a starship', () => {
+        const out = HANDLERS['resistance-vehicletoughness'](
+            makeInput('resistance-vehicletoughness', 0),
+            makeCtx({ type: 'starship', uuid: 'Actor.starship-1' }),
+        );
+        expect(out.vehicle).toBe('Actor.starship-1');
+    });
+
+    it('uses the embedded vehicle uuid when the actor is a character piloting one', () => {
+        const out = HANDLERS['resistance-vehicletoughness'](
+            makeInput('resistance-vehicletoughness'),
+            makeCtx({
+                type: 'character',
+                uuid: 'Actor.pilot',
+                vehicle: { uuid: 'Actor.embedded-vehicle' },
+            }),
+        );
+        expect(out.vehicle).toBe('Actor.embedded-vehicle');
+    });
+
+    it('returns empty vehicle when the character has no embedded vehicle ref', () => {
+        const out = HANDLERS['resistance-vehicletoughness'](
+            makeInput('resistance-vehicletoughness'),
+            makeCtx({ type: 'character', uuid: 'Actor.pilot' }),
+        );
+        expect(out.vehicle).toBe('');
+    });
+});
+
+describe('mortally_wounded and incapacitated handlers', () => {
+    it.each<DamageResistanceKey>(['mortally_wounded', 'incapacitated'])(
+        '%s returns an empty bucket — survival/state checks have no bucket-owned output',
+        (key) => {
+            const out = HANDLERS[key](
+                makeInput(key),
+                makeCtx({ type: 'character', uuid: 'Actor.x' }),
+            );
+            expect(out).toEqual({});
+        },
+    );
+});

--- a/tests/domain/roll-handlers-resource.test.ts
+++ b/tests/domain/roll-handlers-resource.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Domain tests — resource / legacy family roll handlers (#98 phase 1).
+ *
+ * Covers funds, purchase, attribute (top-level), and brawlattack
+ * (top-level — documented dead). Buckets are minimal:
+ *   funds / attribute        — empty (rules-defined work is on the COMMON
+ *                              path: visibility, fp/cp gating, etc.)
+ *   purchase                 — `seller` only
+ *   brawlattack (top-level)  — UNREACHABLE: classifier accepts it but no
+ *                              caller produces it; brawl rolls always wrap
+ *                              as action-brawlattack via Actor.rollAction.
+ *                              Phase 3 removes the key entirely; for now
+ *                              the handler throws to surface any caller
+ *                              that resurrects the path.
+ *
+ * Rules referenced (ids only):
+ *   funds       — funds-determination, equipment-purchase-mechanics
+ *   purchase    — funds-determination, equipment-purchase-mechanics
+ *   attribute   — skill-check, attribute-dice-distribution
+ *   brawlattack — n/a (dead path)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HANDLERS } from '../../src/module/apps/roll-helpers/roll-handlers';
+import type {
+    HandlerContext,
+    HandlerInput,
+    RollSettingsView,
+} from '../../src/module/apps/roll-helpers/roll-handlers';
+import type { RollTypeKey } from '../../src/module/apps/roll-helpers/roll-data';
+
+function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
+    return {
+        defaultUnknownDifficulty: false,
+        diceForScale: false,
+        fundsFate: false,
+        hideCombatCards: false,
+        hideSkillCards: false,
+        showSkillSpecialization: true,
+        pipsPerDice: 3,
+        ...overrides,
+    };
+}
+
+function makeCtx(settings?: Partial<RollSettingsView>): HandlerContext {
+    return {
+        actor: { type: 'character', uuid: 'Actor.x' },
+        targets: [],
+        settings: makeSettings(settings),
+        localize: (key: string) => key,
+    };
+}
+
+function makeInput(key: 'funds' | 'purchase' | 'attribute' | 'brawlattack', extras: Partial<HandlerInput> = {}): HandlerInput {
+    const type = key === 'purchase' ? 'funds' : key;
+    const subtype = key === 'purchase' ? 'purchase' : '';
+    return {
+        classified: { type, subtype, key: key as RollTypeKey },
+        name: '',
+        score: 0,
+        type,
+        subtype,
+        ...extras,
+    };
+}
+
+describe('funds handler', () => {
+    it('returns an empty bucket — fp/cp gating and visibility live on COMMON', () => {
+        const out = HANDLERS['funds'](makeInput('funds'), makeCtx());
+        expect(out).toEqual({});
+    });
+});
+
+describe('purchase handler', () => {
+    it('returns the seller from input', () => {
+        const out = HANDLERS['purchase'](
+            makeInput('purchase', { seller: 'Joe the Vendor' }),
+            makeCtx(),
+        );
+        expect(out.seller).toBe('Joe the Vendor');
+    });
+
+    it('returns empty seller when not supplied', () => {
+        const out = HANDLERS['purchase'](makeInput('purchase'), makeCtx());
+        expect(out.seller).toBe('');
+    });
+});
+
+describe('attribute handler', () => {
+    it('returns an empty bucket — score comes pre-set on input from the rollAttribute caller', () => {
+        const out = HANDLERS['attribute'](
+            makeInput('attribute', { score: 9, attribute: 'str' }),
+            makeCtx(),
+        );
+        expect(out).toEqual({});
+    });
+});
+
+describe('brawlattack handler (top-level — documented dead)', () => {
+    it('throws — top-level brawlattack is unreachable; rolls go through action-brawlattack', () => {
+        expect(() => HANDLERS['brawlattack'](makeInput('brawlattack'), makeCtx())).toThrow(
+            /unreachable|dead|action-brawlattack/i,
+        );
+    });
+});

--- a/tests/domain/roll-handlers-skill.test.ts
+++ b/tests/domain/roll-handlers-skill.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Domain tests — skill family roll handlers (#98 phase 1).
+ *
+ * Covers the three skill-family RollTypeKeys against the skill mechanics in
+ * the rules reference: skill, skill-dodge, specialization.
+ *
+ * The handlers under test are stubbed (throw notImplemented); these tests
+ * are red on purpose until phase 2 implements them. Each test asserts the
+ * rules-defined input → output projection for one handler — bucket fields
+ * only (per ROLL_TYPE_FIELDS). Cross-cutting concerns (bonusmod from active
+ * effects, flatSkills attribute-as-dice substitution, fp-effect doubling)
+ * belong to finalize and are not under test here.
+ *
+ * Rules referenced (ids only, content lives in gitignored docs/reference/):
+ *   skill, skill-dodge       — skill-base-mechanics, skill-check
+ *   skill-dodge              — + attacking-and-defending, active-defense
+ *   specialization           — specialization-in-skills, skill-check
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HANDLERS } from '../../src/module/apps/roll-helpers/roll-handlers';
+import type {
+    HandlerContext,
+    ItemView,
+    RollSettingsView,
+} from '../../src/module/apps/roll-helpers/roll-handlers';
+import type { ClassifiedRoll } from '../../src/module/apps/roll-helpers/roll-data';
+
+function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
+    return {
+        defaultUnknownDifficulty: false,
+        diceForScale: false,
+        fundsFate: false,
+        hideCombatCards: false,
+        hideSkillCards: false,
+        showSkillSpecialization: true,
+        ...overrides,
+    };
+}
+
+function makeCtx(item: ItemView | undefined, settings?: Partial<RollSettingsView>): HandlerContext {
+    return {
+        actor: { type: 'character' },
+        item,
+        targets: [],
+        settings: makeSettings(settings),
+        localize: (key: string) => key,
+    };
+}
+
+function classified(key: 'skill' | 'skill-dodge' | 'specialization'): ClassifiedRoll {
+    const type = key === 'specialization' ? 'specialization' : 'skill';
+    const subtype = key === 'skill-dodge' ? 'dodge' : '';
+    return { type, subtype, key };
+}
+
+describe('skill handler', () => {
+    it('returns the lowercase parent attribute from the skill item', () => {
+        const item: ItemView = { type: 'skill', attribute: 'AGI' };
+        const out = HANDLERS['skill'](classified('skill'), makeCtx(item));
+        expect(out.attribute).toBe('agi');
+    });
+
+    it('returns null when the skill item is missing', () => {
+        const out = HANDLERS['skill'](classified('skill'), makeCtx(undefined));
+        expect(out.attribute).toBeNull();
+    });
+
+    it('returns null when the skill item has no attribute', () => {
+        const item: ItemView = { type: 'skill' };
+        const out = HANDLERS['skill'](classified('skill'), makeCtx(item));
+        expect(out.attribute).toBeNull();
+    });
+});
+
+describe('skill-dodge handler', () => {
+    it('produces the same shape as skill — only the classification differs', () => {
+        const item: ItemView = { type: 'skill', attribute: 'AGI' };
+        const out = HANDLERS['skill-dodge'](classified('skill-dodge'), makeCtx(item));
+        expect(out.attribute).toBe('agi');
+    });
+});
+
+describe('specialization handler', () => {
+    it('returns attribute and specSkill from the specialization item when the setting is on', () => {
+        const item: ItemView = { type: 'specialization', attribute: 'STR', skill: 'Brawling' };
+        const out = HANDLERS['specialization'](classified('specialization'), makeCtx(item));
+        expect(out.attribute).toBe('str');
+        expect(out.specSkill).toBe('Brawling');
+    });
+
+    it('omits specSkill (empty string) when the showSkillSpecialization setting is off', () => {
+        const item: ItemView = { type: 'specialization', attribute: 'STR', skill: 'Brawling' };
+        const out = HANDLERS['specialization'](
+            classified('specialization'),
+            makeCtx(item, { showSkillSpecialization: false }),
+        );
+        expect(out.attribute).toBe('str');
+        expect(out.specSkill).toBe('');
+    });
+
+    it('returns empty specSkill when the spec item has no parent skill', () => {
+        const item: ItemView = { type: 'specialization', attribute: 'STR' };
+        const out = HANDLERS['specialization'](classified('specialization'), makeCtx(item));
+        expect(out.attribute).toBe('str');
+        expect(out.specSkill).toBe('');
+    });
+});

--- a/tests/domain/roll-handlers-skill.test.ts
+++ b/tests/domain/roll-handlers-skill.test.ts
@@ -34,13 +34,14 @@ function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsVi
         hideCombatCards: false,
         hideSkillCards: false,
         showSkillSpecialization: true,
+        pipsPerDice: 3,
         ...overrides,
     };
 }
 
 function makeCtx(item: ItemView | undefined, settings?: Partial<RollSettingsView>): HandlerContext {
     return {
-        actor: { type: 'character' },
+        actor: { type: 'character', uuid: 'Actor.test-character' },
         item,
         targets: [],
         settings: makeSettings(settings),

--- a/tests/domain/roll-handlers-skill.test.ts
+++ b/tests/domain/roll-handlers-skill.test.ts
@@ -21,10 +21,10 @@ import { describe, expect, it } from 'vitest';
 import { HANDLERS } from '../../src/module/apps/roll-helpers/roll-handlers';
 import type {
     HandlerContext,
+    HandlerInput,
     ItemView,
     RollSettingsView,
 } from '../../src/module/apps/roll-helpers/roll-handlers';
-import type { ClassifiedRoll } from '../../src/module/apps/roll-helpers/roll-data';
 
 function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
     return {
@@ -48,27 +48,33 @@ function makeCtx(item: ItemView | undefined, settings?: Partial<RollSettingsView
     };
 }
 
-function classified(key: 'skill' | 'skill-dodge' | 'specialization'): ClassifiedRoll {
+function makeInput(key: 'skill' | 'skill-dodge' | 'specialization'): HandlerInput {
     const type = key === 'specialization' ? 'specialization' : 'skill';
     const subtype = key === 'skill-dodge' ? 'dodge' : '';
-    return { type, subtype, key };
+    return {
+        classified: { type, subtype, key },
+        name: '',
+        score: 0,
+        type,
+        subtype,
+    };
 }
 
 describe('skill handler', () => {
     it('returns the lowercase parent attribute from the skill item', () => {
         const item: ItemView = { type: 'skill', attribute: 'AGI' };
-        const out = HANDLERS['skill'](classified('skill'), makeCtx(item));
+        const out = HANDLERS['skill'](makeInput('skill'), makeCtx(item));
         expect(out.attribute).toBe('agi');
     });
 
     it('returns null when the skill item is missing', () => {
-        const out = HANDLERS['skill'](classified('skill'), makeCtx(undefined));
+        const out = HANDLERS['skill'](makeInput('skill'), makeCtx(undefined));
         expect(out.attribute).toBeNull();
     });
 
     it('returns null when the skill item has no attribute', () => {
         const item: ItemView = { type: 'skill' };
-        const out = HANDLERS['skill'](classified('skill'), makeCtx(item));
+        const out = HANDLERS['skill'](makeInput('skill'), makeCtx(item));
         expect(out.attribute).toBeNull();
     });
 });
@@ -76,7 +82,7 @@ describe('skill handler', () => {
 describe('skill-dodge handler', () => {
     it('produces the same shape as skill — only the classification differs', () => {
         const item: ItemView = { type: 'skill', attribute: 'AGI' };
-        const out = HANDLERS['skill-dodge'](classified('skill-dodge'), makeCtx(item));
+        const out = HANDLERS['skill-dodge'](makeInput('skill-dodge'), makeCtx(item));
         expect(out.attribute).toBe('agi');
     });
 });
@@ -84,7 +90,7 @@ describe('skill-dodge handler', () => {
 describe('specialization handler', () => {
     it('returns attribute and specSkill from the specialization item when the setting is on', () => {
         const item: ItemView = { type: 'specialization', attribute: 'STR', skill: 'Brawling' };
-        const out = HANDLERS['specialization'](classified('specialization'), makeCtx(item));
+        const out = HANDLERS['specialization'](makeInput('specialization'), makeCtx(item));
         expect(out.attribute).toBe('str');
         expect(out.specSkill).toBe('Brawling');
     });
@@ -92,7 +98,7 @@ describe('specialization handler', () => {
     it('omits specSkill (empty string) when the showSkillSpecialization setting is off', () => {
         const item: ItemView = { type: 'specialization', attribute: 'STR', skill: 'Brawling' };
         const out = HANDLERS['specialization'](
-            classified('specialization'),
+            makeInput('specialization'),
             makeCtx(item, { showSkillSpecialization: false }),
         );
         expect(out.attribute).toBe('str');
@@ -101,7 +107,7 @@ describe('specialization handler', () => {
 
     it('returns empty specSkill when the spec item has no parent skill', () => {
         const item: ItemView = { type: 'specialization', attribute: 'STR' };
-        const out = HANDLERS['specialization'](classified('specialization'), makeCtx(item));
+        const out = HANDLERS['specialization'](makeInput('specialization'), makeCtx(item));
         expect(out.attribute).toBe('str');
         expect(out.specSkill).toBe('');
     });

--- a/tests/domain/roll-handlers-skill.test.ts
+++ b/tests/domain/roll-handlers-skill.test.ts
@@ -4,12 +4,11 @@
  * Covers the three skill-family RollTypeKeys against the skill mechanics in
  * the rules reference: skill, skill-dodge, specialization.
  *
- * The handlers under test are stubbed (throw notImplemented); these tests
- * are red on purpose until phase 2 implements them. Each test asserts the
- * rules-defined input → output projection for one handler — bucket fields
- * only (per ROLL_TYPE_FIELDS). Cross-cutting concerns (bonusmod from active
- * effects, flatSkills attribute-as-dice substitution, fp-effect doubling)
- * belong to finalize and are not under test here.
+ * Each test asserts the rules-defined input → output projection for one
+ * handler — bucket fields only (per ROLL_TYPE_FIELDS). Cross-cutting
+ * concerns (bonusmod from active effects, flatSkills attribute-as-dice
+ * substitution, fp-effect doubling) belong to finalize and are not under
+ * test here.
  *
  * Rules referenced (ids only, content lives in gitignored docs/reference/):
  *   skill, skill-dodge       — skill-base-mechanics, skill-check

--- a/tests/domain/roll-handlers-weapon.test.ts
+++ b/tests/domain/roll-handlers-weapon.test.ts
@@ -36,7 +36,7 @@ import type { RollTypeKey } from '../../src/module/apps/roll-helpers/roll-data';
 
 type WeaponKey = 'weapon' | 'starship-weapon' | 'vehicle-weapon';
 
-const noMods = { dmg: { score: 0 }, misc: { score: 0 }, bonus: { score: 0 } };
+const noMods = { damage: 0, attack: 0, difficulty: 0 };
 
 function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
     return {
@@ -114,13 +114,19 @@ describe('weapon handler — happy path', () => {
         expect(out.range).toBe('OD6S.RANGE_POINT_BLANK_SHORT');
     });
 
-    it('uses weapon scale when set, falling back to actor scale otherwise', () => {
+    it('uses weapon scale when truthy, falling back to actor scale when 0/undefined', () => {
         const withScale = basicRangedWeapon({ scale: { score: 6 } });
-        const withoutScale = basicRangedWeapon();
-        const outA = HANDLERS['weapon'](makeInput('weapon', 'A'), makeCtx(withScale));
-        const outB = HANDLERS['weapon'](makeInput('weapon', 'B'), makeCtx(withoutScale));
-        expect(outA.attackerScale).toBe(6);
-        expect(outB.attackerScale).toBe(0);
+        const noWeaponScale = basicRangedWeapon();
+        const zeroWeaponScale = basicRangedWeapon({ scale: { score: 0 } });
+        const actorWithScale: ActorView = { type: 'character', uuid: 'Actor.x', scale: { score: 3 } };
+
+        expect(HANDLERS['weapon'](makeInput('weapon', 'A'), makeCtx(withScale, actorWithScale)).attackerScale).toBe(6);
+        // Weapon scale missing — fall back to actor.
+        expect(HANDLERS['weapon'](makeInput('weapon', 'B'), makeCtx(noWeaponScale, actorWithScale)).attackerScale).toBe(3);
+        // Weapon scale explicitly 0 — also fall back to actor (truthy guard).
+        expect(HANDLERS['weapon'](makeInput('weapon', 'C'), makeCtx(zeroWeaponScale, actorWithScale)).attackerScale).toBe(3);
+        // Both 0 — expected 0.
+        expect(HANDLERS['weapon'](makeInput('weapon', 'D'), makeCtx(noWeaponScale)).attackerScale).toBe(0);
     });
 });
 
@@ -177,6 +183,24 @@ describe('weapon handler — stun flags', () => {
         const out = HANDLERS['weapon'](makeInput('weapon', 'X'), makeCtx(basicRangedWeapon()));
         expect(out.can_stun).toBe(false);
         expect(out.only_stun).toBe(false);
+    });
+
+    it('explosive weapon: with zones enabled, can_stun reads blast-zone-1 stun_damage (not weapon.stun.score)', () => {
+        const explosiveBlast = basicRangedWeapon({
+            isExplosive: true,
+            stun: undefined,
+            blast_radius: { '1': { stun_damage: 6 } },
+        });
+        const explosiveNoBlast = basicRangedWeapon({
+            isExplosive: true,
+            stun: undefined,
+            blast_radius: { '1': { stun_damage: 0 } },
+        });
+        const ctx = (item: ItemView) =>
+            makeCtx(item, { type: 'character', uuid: 'Actor.x' }, { explosiveZones: true });
+
+        expect(HANDLERS['weapon'](makeInput('weapon', 'A'), ctx(explosiveBlast)).can_stun).toBe(true);
+        expect(HANDLERS['weapon'](makeInput('weapon', 'B'), ctx(explosiveNoBlast)).can_stun).toBe(false);
     });
 });
 

--- a/tests/domain/roll-handlers-weapon.test.ts
+++ b/tests/domain/roll-handlers-weapon.test.ts
@@ -94,7 +94,7 @@ function basicRangedWeapon(overrides: Partial<ItemView> = {}): ItemView {
 }
 
 describe('weapon handler — happy path', () => {
-    it('passes through damage type, score, source, and range from the weapon item', () => {
+    it('passes through damage type, score, source from the weapon item; emits the rules-default range label (resolution to a distance-based bucket happens downstream)', () => {
         const out = HANDLERS['weapon'](
             makeInput('weapon', 'Test Blaster'),
             makeCtx(basicRangedWeapon()),
@@ -102,7 +102,16 @@ describe('weapon handler — happy path', () => {
         expect(out.damagetype).toBe('e');
         expect(out.damagescore).toBe(12);
         expect(out.source).toBe('Test Blaster');
-        expect(out.range).toEqual({ short: 10, medium: 30, long: 60 });
+        expect(out.range).toBe('OD6S.RANGE_SHORT_SHORT');
+    });
+
+    it('emits the point-blank range label for melee subtype', () => {
+        const melee = basicRangedWeapon({ range: false });
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'X', 'meleeattack'),
+            makeCtx(melee),
+        );
+        expect(out.range).toBe('OD6S.RANGE_POINT_BLANK_SHORT');
     });
 
     it('uses weapon scale when set, falling back to actor scale otherwise', () => {

--- a/tests/domain/roll-handlers-weapon.test.ts
+++ b/tests/domain/roll-handlers-weapon.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Domain tests — weapon family roll handlers (#98 phase 1).
+ *
+ * Covers weapon, starship-weapon, vehicle-weapon. The three share the
+ * same bucket logic; vehicle-weapon adds a `vehicle` field for the actor's
+ * vehicle uuid.
+ *
+ * Bucket-owned outputs:
+ *   damagetype, damagescore, stundamagetype, stundamagescore,
+ *   damagemodifiers, source, range, difficultylevel,
+ *   only_stun, can_stun, stun, attackerScale, specSkill
+ *
+ * Cross-cutting math (penalty math, bonusmod accumulation, dice/pips
+ * assembly, fp-effect doubling) lives on COMMON and is not under test here.
+ *
+ * Rules referenced (ids only):
+ *   weapon          — attacking-and-defending, base-combat-difficulty,
+ *                     combat-difficulty-modifiers-range,
+ *                     step-3-determining-damage, determining-strength-damage
+ *   starship-weapon — scale, step-3-determining-damage,
+ *                     combat-difficulty-modifiers-range, ship-weapons
+ *   vehicle-weapon  — scale, step-3-determining-damage,
+ *                     combat-difficulty-modifiers-range, vehicle-damage
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HANDLERS } from '../../src/module/apps/roll-helpers/roll-handlers';
+import type {
+    ActorView,
+    HandlerContext,
+    HandlerInput,
+    ItemView,
+    RollSettingsView,
+} from '../../src/module/apps/roll-helpers/roll-handlers';
+import type { RollTypeKey } from '../../src/module/apps/roll-helpers/roll-data';
+
+type WeaponKey = 'weapon' | 'starship-weapon' | 'vehicle-weapon';
+
+const noMods = { dmg: { score: 0 }, misc: { score: 0 }, bonus: { score: 0 } };
+
+function makeSettings(overrides: Partial<RollSettingsView> = {}): RollSettingsView {
+    return {
+        defaultUnknownDifficulty: false,
+        diceForScale: false,
+        fundsFate: false,
+        hideCombatCards: false,
+        hideSkillCards: false,
+        showSkillSpecialization: true,
+        pipsPerDice: 3,
+        meleeDifficulty: false,
+        explosiveZones: false,
+        weaponDamageTable: {
+            1: { penalty: 3, label: 'OD6S.WEAPON_DAMAGED_LIGHT' },
+            2: { penalty: 6, label: 'OD6S.WEAPON_DAMAGED_HEAVY' },
+        },
+        ...overrides,
+    };
+}
+
+function makeCtx(
+    item: ItemView,
+    actor: ActorView = { type: 'character', uuid: 'Actor.x' },
+    settings?: Partial<RollSettingsView>,
+): HandlerContext {
+    return {
+        actor,
+        item,
+        targets: [],
+        settings: makeSettings(settings),
+        localize: (key: string) => key,
+    };
+}
+
+function makeInput(key: WeaponKey, name: string, subtype = ''): HandlerInput {
+    return {
+        classified: { type: key, subtype, key: key as RollTypeKey },
+        name,
+        score: 0,
+        type: key,
+        subtype,
+        itemId: 'Item.x',
+    };
+}
+
+function basicRangedWeapon(overrides: Partial<ItemView> = {}): ItemView {
+    return {
+        type: 'weapon',
+        name: 'Test Blaster',
+        damage: { type: 'e', score: 12 },
+        range: { short: 10, medium: 30, long: 60 },
+        mods: noMods,
+        ...overrides,
+    };
+}
+
+describe('weapon handler — happy path', () => {
+    it('passes through damage type, score, source, and range from the weapon item', () => {
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'Test Blaster'),
+            makeCtx(basicRangedWeapon()),
+        );
+        expect(out.damagetype).toBe('e');
+        expect(out.damagescore).toBe(12);
+        expect(out.source).toBe('Test Blaster');
+        expect(out.range).toEqual({ short: 10, medium: 30, long: 60 });
+    });
+
+    it('uses weapon scale when set, falling back to actor scale otherwise', () => {
+        const withScale = basicRangedWeapon({ scale: { score: 6 } });
+        const withoutScale = basicRangedWeapon();
+        const outA = HANDLERS['weapon'](makeInput('weapon', 'A'), makeCtx(withScale));
+        const outB = HANDLERS['weapon'](makeInput('weapon', 'B'), makeCtx(withoutScale));
+        expect(outA.attackerScale).toBe(6);
+        expect(outB.attackerScale).toBe(0);
+    });
+});
+
+describe('weapon handler — melee damage with strength', () => {
+    it('adds actor strength damage to weapon damage when weapon.damage.str is true (melee subtype)', () => {
+        const meleeStr = basicRangedWeapon({
+            name: 'Vibroblade',
+            damage: { type: 'p', score: 9, str: true },
+            range: false,
+        });
+        const actor: ActorView = { type: 'character', uuid: 'Actor.x', strengthDamage: 6 };
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'Vibroblade', 'meleeattack'),
+            makeCtx(meleeStr, actor),
+        );
+        expect(out.damagescore).toBe(15);
+    });
+
+    it('does not add strength damage for non-str weapons or non-melee subtypes', () => {
+        const meleeNoStr = basicRangedWeapon({
+            damage: { type: 'p', score: 9 },
+            range: false,
+        });
+        const actor: ActorView = { type: 'character', uuid: 'Actor.x', strengthDamage: 6 };
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'X', 'meleeattack'),
+            makeCtx(meleeNoStr, actor),
+        );
+        expect(out.damagescore).toBe(9);
+    });
+});
+
+describe('weapon handler — stun flags', () => {
+    it('reports can_stun true when weapon has a stun score', () => {
+        const stunCapable = basicRangedWeapon({
+            stun: { type: 's', score: 9 },
+        });
+        const out = HANDLERS['weapon'](makeInput('weapon', 'X'), makeCtx(stunCapable));
+        expect(out.can_stun).toBe(true);
+        expect(out.only_stun).toBe(false);
+        expect(out.stundamagescore).toBe(9);
+    });
+
+    it('reports only_stun true when weapon has stun_only', () => {
+        const stunOnly = basicRangedWeapon({
+            stun: { type: 's', score: 9, stun_only: true },
+        });
+        const out = HANDLERS['weapon'](makeInput('weapon', 'X'), makeCtx(stunOnly));
+        expect(out.only_stun).toBe(true);
+        expect(out.can_stun).toBe(true);
+    });
+
+    it('reports can_stun false when weapon has no stun', () => {
+        const out = HANDLERS['weapon'](makeInput('weapon', 'X'), makeCtx(basicRangedWeapon()));
+        expect(out.can_stun).toBe(false);
+        expect(out.only_stun).toBe(false);
+    });
+});
+
+describe('weapon handler — damage modifiers from weapon state', () => {
+    it('emits a WEAPON_DAMAGED entry when the weapon is damaged', () => {
+        const damaged = basicRangedWeapon({ damaged: 1 });
+        const out = HANDLERS['weapon'](makeInput('weapon', 'X'), makeCtx(damaged));
+        expect(out.damagemodifiers).toContainEqual(
+            expect.objectContaining({ name: 'OD6S.WEAPON_DAMAGED', value: -3 }),
+        );
+    });
+
+    it('emits a STRENGTH_DAMAGE_BONUS entry when weapon.damage.muscle is set', () => {
+        const muscle = basicRangedWeapon({
+            damage: { type: 'p', score: 9, muscle: true },
+        });
+        const actor: ActorView = { type: 'character', uuid: 'Actor.x', strengthDamage: 6 };
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'X'),
+            makeCtx(muscle, actor),
+        );
+        expect(out.damagemodifiers).toContainEqual(
+            expect.objectContaining({ name: 'OD6S.STRENGTH_DAMAGE_BONUS', value: 6 }),
+        );
+    });
+
+    it('emits no damage modifiers when weapon is pristine and not muscle-powered', () => {
+        const out = HANDLERS['weapon'](makeInput('weapon', 'X'), makeCtx(basicRangedWeapon()));
+        expect(out.damagemodifiers).toEqual([]);
+    });
+});
+
+describe('weapon handler — difficulty', () => {
+    it('uses weapon-authored difficulty when meleeDifficulty setting is on', () => {
+        const item = basicRangedWeapon({ difficulty: 'OD6S.DIFFICULTY_MODERATE' });
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'X'),
+            makeCtx(item, { type: 'character', uuid: 'Actor.x' }, { meleeDifficulty: true }),
+        );
+        expect(out.difficultylevel).toBe('OD6S.DIFFICULTY_MODERATE');
+    });
+
+    it('falls back to easy when weapon has no authored difficulty (and meleeDifficulty on)', () => {
+        const out = HANDLERS['weapon'](
+            makeInput('weapon', 'X'),
+            makeCtx(basicRangedWeapon(), { type: 'character', uuid: 'Actor.x' }, { meleeDifficulty: true }),
+        );
+        expect(out.difficultylevel).toBe('OD6S.DIFFICULTY_EASY');
+    });
+});
+
+describe('vehicle-weapon handler — adds vehicle uuid', () => {
+    it('uses the actor uuid when the actor is a vehicle', () => {
+        const out = HANDLERS['vehicle-weapon'](
+            makeInput('vehicle-weapon', 'Turret'),
+            makeCtx(basicRangedWeapon(), { type: 'vehicle', uuid: 'Actor.vehicle-1' }),
+        );
+        expect(out.vehicle).toBe('Actor.vehicle-1');
+    });
+
+    it('uses the embedded vehicle uuid when the actor is a character', () => {
+        const out = HANDLERS['vehicle-weapon'](
+            makeInput('vehicle-weapon', 'Turret'),
+            makeCtx(basicRangedWeapon(), {
+                type: 'character',
+                uuid: 'Actor.pilot',
+                vehicle: { uuid: 'Actor.embedded-vehicle' },
+            }),
+        );
+        expect(out.vehicle).toBe('Actor.embedded-vehicle');
+    });
+});
+
+describe('starship-weapon handler — same shape as weapon', () => {
+    it('produces the same bucket as weapon (no vehicle field)', () => {
+        const out = HANDLERS['starship-weapon'](
+            makeInput('starship-weapon', 'Cannon'),
+            makeCtx(basicRangedWeapon(), { type: 'starship', uuid: 'Actor.starship' }),
+        );
+        expect(out.damagescore).toBe(12);
+        expect(out.source).toBe('Test Blaster');
+        expect('vehicle' in out).toBe(false);
+    });
+});

--- a/tests/smoke/helpers/foundry-page.ts
+++ b/tests/smoke/helpers/foundry-page.ts
@@ -103,16 +103,29 @@ export async function loginAndWaitReady(page: Page): Promise<void> {
 
 /**
  * Run an arbitrary async function inside the world's page context. The
- * function receives no arguments and must return a JSON-serializable
- * result. Errors thrown inside propagate out to the test.
+ * function and arg must be JSON-serializable; the result must be too.
+ * Errors thrown inside propagate out to the test.
  *
  * Use this to run the same probe scripts the test runbook documents.
  */
 export async function evalInWorld<T>(
     page: Page,
     fn: () => Promise<T> | T,
+): Promise<T>;
+export async function evalInWorld<T, A>(
+    page: Page,
+    fn: (arg: A) => Promise<T> | T,
+    arg: A,
+): Promise<T>;
+export async function evalInWorld<T, A>(
+    page: Page,
+    fn: ((arg: A) => Promise<T> | T) | (() => Promise<T> | T),
+    arg?: A,
 ): Promise<T> {
-    return await page.evaluate(fn);
+    if (arguments.length >= 3) {
+        return await page.evaluate(fn as (arg: A) => Promise<T> | T, arg as A);
+    }
+    return await page.evaluate(fn as () => Promise<T> | T);
 }
 
 /**


### PR DESCRIPTION
## Summary
Foundation for the #98 setupRollData rewrite. Lands the per-roll-type handler contract, all 25 pure handlers (covered by 302 domain tests), and the Foundry → handler-view boundary adapter. **Production code is untouched** — the new machinery is dormant; the existing setupRollData runs unmodified.

The cutover (replacing setupRollData's body) is the follow-up PR.

## What's in scope

**Phase 0 — rule-driven audit** (`roll-type-fields.ts`)
- Inline RollTypeKey ↔ governing-rule-id mapping (ids only — rules content stays out of the repo).
- Reclassification of behaviors flagged as "no rules backing." Of the original 9, after wider-graph tracing: 1 RFC filed (#100, +5 magic constant on melee action), 1 zero-impact dead string, 4 rules-backed after all, 3 not-a-rules-concern (UI/admin plumbing).

**Phase 1 — handler contract** (`roll-handlers.ts`)
- `Handler<K>` typed so output is `Pick<RollData, ROLL_TYPE_FIELDS[K]>` — bucket discipline enforced at compile time.
- `HandlerInput` (request data) and `HandlerContext` (narrowed Foundry-free views: `ActorView` discriminated union, `ItemView`, `TargetView`, `RollSettingsView`).
- `HANDLERS` registry with `as const satisfies { [K in RollTypeKey]: Handler<K> }` for compile-time totality.

**Phase 2 — handlers**, organized into 5 family pairs (test red → handler green):
- skill / skill-dodge / specialization
- damage / resistance / resistance-vehicletoughness / mortally_wounded / incapacitated
- funds / purchase / attribute / brawlattack (top-level — documented dead)
- weapon / starship-weapon / vehicle-weapon
- 8 action-* handlers

302 domain tests cover the rules-defined input → bucket projections. Cross-cutting concerns (penalties, dice/pips, fp doubling, label assembly) stay on the COMMON path — finalize lands in the cutover PR.

**Phase 3a — boundary adapter** (`roll-context-adapter.ts`)
- Atomic projectors: `adaptActor`, `adaptItem`, `adaptTargets`, `adaptSettings`.
- `adaptContext` composes them. The single Foundry-touching file in the rules pipeline; everything else is pure. 14 unit tests.

**Pre-rewrite bundled** (per maintainer-confirmed bundling preference):
- `fix(roll-action)` — real bug: duplicated `'starship'` typo at `roll-action.ts:6` made every vehicle-action path on a vehicle actor crash with "Cannot read properties of undefined (reading 'specialization')". Surfaced by the new tier-3-action-rolls smoke probe added in #99.
- `test(smoke)` — overload `evalInWorld` to forward a serializable arg (the new probe needed it).

## What's NOT in scope (cutover PR)

- Replace `setupRollData`'s 638-line body with `preflight + classify + adaptContext + HANDLERS[key] + finalize`.
- `runFinalize` (COMMON-side assembly).
- `runPreflight` (extract explosive dialog + range UI check).
- Dead-code removal: `brawlattack` top-level RollTypeKey, `'toughness'` in canOppose, +5 magic constant (per RFC #100), parry suffix relocation.
- Smoke verification of cutover.

## Verification

- `pnpm run check` clean (lint, typecheck, 289 unit + 302 domain tests).
- Tier-3-action-rolls smoke probes (the 3 added in #99) pass after the roll-action fix.
- Production code unchanged — `setupRollData` runs the old path; no user-visible behavior change in this PR.

## Test plan
- [ ] `pnpm run check` passes
- [ ] `pnpm run test:smoke -- tier-3-action-rolls` passes
- [ ] Diff review: handler contract + 5 family pairs + adapter

Tracking: #98
Refs: #99 (prep), #100 (RFC for +5 magic constant)