### PR TITLE
refactor(roll-helpers): #98 phases 3b + 3c — extract runPreflight + add runFinalize

### DIFF
--- a/src/module/apps/roll-helpers/roll-finalize.test.ts
+++ b/src/module/apps/roll-helpers/roll-finalize.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for runFinalize — the COMMON-side assembler.
+ *
+ * Finalize is a pure object-builder; tests verify each output field maps
+ * from the precomputed COMMON inputs / handler bucket as documented. No
+ * Foundry mocks needed — opaque ref fields just pass through.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runFinalize } from './roll-finalize';
+import type { FinalizeInput } from './roll-finalize';
+import type { ClassifiedRoll, RollTypeKey } from './roll-data';
+import type { Penalties } from './action-math';
+
+const noPenalties: Penalties = {
+    woundPenalty: 0, actionPenalty: 0, stunnedPenalty: 0, isBypass: false,
+};
+
+function classified(type: string, subtype: string, key: RollTypeKey): ClassifiedRoll {
+    return { type: type as ClassifiedRoll['type'], subtype, key };
+}
+
+function baseInput<K extends RollTypeKey>(
+    overrides: Partial<FinalizeInput<K>> & { classified: ClassifiedRoll; bucket: FinalizeInput<K>['bucket'] },
+): FinalizeInput<K> {
+    return {
+        score: 0,
+        name: '',
+        itemId: '',
+        difficulty: 0,
+        difficultyLevel: 'OD6S.DIFFICULTY_EASY',
+        isExplosive: false,
+        isVisible: false,
+        fatepointEffect: false,
+        canUseFp: true,
+        canUseCp: true,
+        wildDie: false,
+        showWildDie: false,
+        penalties: noPenalties,
+        otherPenalty: 0,
+        bonusmod: 0,
+        miscMod: 0,
+        scaleMod: 0,
+        range: 'OD6S.RANGE_POINT_BLANK_SHORT',
+        vehicleTerrainDifficulty: 'OD6S.DIFFICULTY_EASY',
+        pipsPerDice: 3,
+        actorRef: { id: 'actor-x' },
+        tokenRef: undefined,
+        targetsRef: [],
+        targetRef: undefined,
+        ...overrides,
+    } as FinalizeInput<K>;
+}
+
+describe('runFinalize — score → dice/pips conversion', () => {
+    it('converts score 14 to 4D+2 at pipsPerDice=3', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            score: 14,
+        }));
+        expect(out.dice).toBe(4);
+        expect(out.pips).toBe(2);
+        expect(out.originaldice).toBe(4);
+        expect(out.originalpips).toBe(2);
+    });
+
+    it('converts bonusmod to bonusdice/bonuspips the same way', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            bonusmod: 7,
+        }));
+        expect(out.bonusdice).toBe(2);
+        expect(out.bonuspips).toBe(1);
+    });
+});
+
+describe('runFinalize — bucket fields override defaults', () => {
+    it('weapon bucket sets damage/source/range fields', () => {
+        const out = runFinalize(baseInput<'weapon'>({
+            classified: classified('weapon', '', 'weapon'),
+            score: 12,
+            bucket: {
+                damagetype: 'e',
+                damagescore: 18,
+                stundamagetype: '',
+                stundamagescore: 0,
+                damagemodifiers: [],
+                source: 'Test Blaster',
+                range: 'OD6S.RANGE_SHORT_SHORT',
+                difficultylevel: 'OD6S.DIFFICULTY_EASY',
+                only_stun: false,
+                can_stun: false,
+                stun: false,
+                attackerScale: 0,
+                specSkill: '',
+            },
+        }));
+        expect(out.damagetype).toBe('e');
+        expect(out.damagescore).toBe(18);
+        expect(out.source).toBe('Test Blaster');
+        expect(out.range).toBe('OD6S.RANGE_SHORT_SHORT');
+    });
+
+    it('skill bucket sets attribute (no other bucket fields touched)', () => {
+        const out = runFinalize(baseInput<'skill'>({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+        }));
+        expect(out.attribute).toBe('agi');
+        // Damage defaults stay at zero
+        expect(out.damagescore).toBe(0);
+    });
+});
+
+describe('runFinalize — isOppasable derivation', () => {
+    it.each([
+        ['skill', '', true],
+        ['attribute', '', true],
+        ['specialization', '', true],
+        ['damage', '', true],
+        ['resistance', '', true],
+        ['weapon', '', false],
+        ['action', 'meleeattack', false],
+        ['action', 'specialization', true], // action+opposable subtype
+        ['action', 'damage', true],
+        ['mortally_wounded', '', false],
+    ])('type=%s subtype=%s → isOppasable=%s', (type, subtype, expected) => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified(type, subtype, 'skill'), // key irrelevant here
+            bucket: { attribute: null },
+        }));
+        expect(out.isoppasable).toBe(expected);
+    });
+});
+
+describe('runFinalize — penalties pass-through', () => {
+    it('forwards the penalty record to woundpenalty/actionpenalty/stunnedpenalty', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            penalties: { woundPenalty: 3, actionPenalty: 1, stunnedPenalty: 2, isBypass: false },
+            otherPenalty: 4,
+        }));
+        expect(out.woundpenalty).toBe(3);
+        expect(out.actionpenalty).toBe(1);
+        expect(out.stunnedpenalty).toBe(2);
+        expect(out.otherpenalty).toBe(4);
+    });
+});
+
+describe('runFinalize — modifiers sub-object', () => {
+    it('builds the modifiers block with miscmod / scalemod / range', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            miscMod: 3,
+            scaleMod: -2,
+            range: 'OD6S.RANGE_LONG',
+        }));
+        expect(out.modifiers).toEqual({
+            range: 'OD6S.RANGE_LONG',
+            attackoption: 'OD6S.ATTACK_STANDARD',
+            calledshot: '',
+            cover: '',
+            coverlight: '',
+            coversmoke: '',
+            miscmod: 3,
+            scalemod: -2,
+        });
+    });
+});
+
+describe('runFinalize — opaque pass-through', () => {
+    it('passes actor/token/targets refs through unchanged', () => {
+        const actor = { id: 'actor-x' };
+        const token = { id: 'token-x' };
+        const targets = [{ id: 'token-a' }, { id: 'token-b' }];
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            actorRef: actor,
+            tokenRef: token,
+            targetsRef: targets,
+            targetRef: targets[0],
+        }));
+        expect(out.actor).toBe(actor);
+        expect(out.token).toBe(token);
+        expect(out.targets).toBe(targets);
+        expect(out.target).toBe(targets[0]);
+    });
+});
+
+describe('runFinalize — stable defaults', () => {
+    it('emits the documented default values for handler-irrelevant fields', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+        }));
+        expect(out.multishot).toBe(false);
+        expect(out.shots).toBe(1);
+        expect(out.fulldefense).toBe(false);
+        expect(out.timer).toBe(0);
+        expect(out.template).toBe('systems/od6s/templates/roll.html');
+        expect(out.vehiclespeed).toBe('cruise');
+        expect(out.vehiclecollisiontype).toBe('t_bone');
+        expect(out.fatepoint).toBe(false);
+        expect(out.contact).toBe(false);
+        expect(out.cpcost).toBe(0);
+        expect(out.cpcostcolor).toBe('black');
+        expect(out.characterpoints).toBe(0);
+        expect(out.isknown).toBe(false);
+    });
+});

--- a/src/module/apps/roll-helpers/roll-finalize.ts
+++ b/src/module/apps/roll-helpers/roll-finalize.ts
@@ -1,0 +1,196 @@
+/**
+ * COMMON-side assembly: combines a handler's typed bucket with precomputed
+ * COMMON inputs into a complete {@link RollData} object.
+ *
+ * Finalize is the assembler, not the computer. The orchestrator (in
+ * `setupRollData`) does the Foundry-coupled work — reading active effects,
+ * resolving the score after roll_mod / flat-skills, computing visibility
+ * from settings, etc. — and hands those values in. Finalize only:
+ *
+ *   - Composes the existing pure helpers ({@link computePenalties},
+ *     {@link getDiceFromScore})
+ *   - Derives type-driven flags (isOppasable from canonical type)
+ *   - Slots stable defaults (multishot=false, shots=1, vehiclespeed='cruise', …)
+ *   - Builds the modifiers sub-object
+ *   - Passes through opaque Foundry refs (actor, token, targets)
+ *
+ * Foundry types appear only as opaque pass-through fields on {@link RollData}.
+ * Finalize itself doesn't read them, so it stays unit-testable with plain
+ * placeholder objects.
+ */
+
+import type { ClassifiedRoll, RollData } from './roll-data';
+import type { HandlerOutput } from './roll-handlers';
+import type { RollTypeKey } from './roll-data';
+import type { Penalties } from './action-math';
+import { getDiceFromScore } from '../../system/utilities/dice';
+
+/**
+ * Roll types whose roll is opposable (defender can roll back). Mirrors the
+ * canOppose list in the legacy setupRollData; the dead `'toughness'` entry
+ * is gone (no canonical type produces it — see PR #101 phase 0 audit).
+ */
+const OPPOSABLE_TYPES: ReadonlySet<string> = new Set([
+    'skill', 'attribute', 'specialization', 'damage', 'resistance',
+]);
+
+/**
+ * Inputs the orchestrator hands to {@link runFinalize}. Most are precomputed
+ * COMMON values; `bucket` is the typed handler output.
+ */
+export interface FinalizeInput<K extends RollTypeKey> {
+    classified: ClassifiedRoll;
+    /** Final roll score after every COMMON adjustment (roll_mod, flat-skills, etc.). */
+    score: number;
+    /** Display name of the roll (already includes the parry suffix when applicable). */
+    name: string;
+    /** Item id, when the roll has an item; empty string otherwise. */
+    itemId: string;
+    /** Difficulty number when known (input-supplied). */
+    difficulty: number;
+    /** Pre-set difficulty label (input-supplied or settings default). */
+    difficultyLevel: string;
+    /** True when the explosive preflight detected this is an explosive item. */
+    isExplosive: boolean;
+    /** True when the roll's chat card should be visible to non-GM observers. */
+    isVisible: boolean;
+    /** True when the FP-in-effect-for-the-round flag is set on the actor. */
+    fatepointEffect: boolean;
+    /** Whether the roll is allowed to spend FP / CP (gated by type + setting). */
+    canUseFp: boolean;
+    canUseCp: boolean;
+    /** True when the world's wild-die system is on AND the actor opts in. */
+    wildDie: boolean;
+    /** True when the world's wild-die system is on (regardless of actor opt-in). */
+    showWildDie: boolean;
+    /** Penalty inputs precomputed by the orchestrator (count, stuns, woundPenalty). */
+    penalties: Penalties;
+    /** Extra penalty (from negative scaleMod under dice_for_scale, etc.). */
+    otherPenalty: number;
+    /** Accumulated bonusmod (active effects + handler-side contributions). */
+    bonusmod: number;
+    /** Misc modifier (weapon mods difficulty, +5 magic constants if any, etc.). */
+    miscMod: number;
+    /** Scale modifier between attacker and defender (post-resolution). */
+    scaleMod: number;
+    /** Resolved range label (after distance bucketing). */
+    range: string;
+    /** Vehicle terrain difficulty label (when vehicleDifficulty setting is on). */
+    vehicleTerrainDifficulty: string;
+    /** Pips per die (3 in standard OpenD6). */
+    pipsPerDice: number;
+    /** Opaque Foundry actor/token/targets refs — passed through unchanged. */
+    actorRef: unknown;
+    tokenRef: unknown;
+    targetsRef: unknown[];
+    targetRef?: unknown;
+    /** Output of HANDLERS[classified.key]. */
+    bucket: HandlerOutput<K>;
+}
+
+export function runFinalize<K extends RollTypeKey>(input: FinalizeInput<K>): RollData {
+    const dicePips = getDiceFromScore(input.score, input.pipsPerDice);
+    const bonusDicePips = getDiceFromScore(input.bonusmod, input.pipsPerDice);
+
+    const isOppasable =
+        OPPOSABLE_TYPES.has(input.classified.type)
+        || (input.classified.type === 'action' && OPPOSABLE_TYPES.has(input.classified.subtype));
+
+    return {
+        // Labels (orchestrator already resolved with parry suffix etc.)
+        label: input.name,
+        title: input.name,
+
+        // Dice / pips
+        dice: dicePips.dice,
+        pips: dicePips.pips,
+        originaldice: dicePips.dice,
+        originalpips: dicePips.pips,
+        bonusdice: bonusDicePips.dice,
+        bonuspips: bonusDicePips.pips,
+        score: input.score,
+
+        // Wild die / FP / CP flags
+        wilddie: input.wildDie,
+        showWildDie: input.showWildDie,
+        canusefp: input.canUseFp,
+        canusecp: input.canUseCp,
+        fatepoint: false,
+        fatepointeffect: input.fatepointEffect,
+        characterpoints: 0,
+        contact: false,
+        cpcost: 0,
+        cpcostcolor: 'black',
+
+        // Visibility / kind
+        isvisible: input.isVisible,
+        isknown: false,
+        isExplosive: input.isExplosive,
+        type: input.classified.type,
+        subtype: input.classified.subtype,
+
+        // Opaque pass-through (Foundry types finalize doesn't touch)
+        actor: input.actorRef as RollData['actor'],
+        token: input.tokenRef as RollData['token'],
+        targets: input.targetsRef as RollData['targets'],
+        target: input.targetRef as RollData['target'],
+        itemid: input.itemId,
+
+        // Penalties
+        actionpenalty: input.penalties.actionPenalty,
+        woundpenalty: input.penalties.woundPenalty,
+        stunnedpenalty: input.penalties.stunnedPenalty,
+        otherpenalty: input.otherPenalty,
+
+        // Stable defaults — handlers don't write these; they're shaped by the
+        // dialog (multishot, shots, fulldefense, timer) or set by execute (rollmode).
+        multishot: false,
+        shots: 1,
+        fulldefense: false,
+        timer: 0,
+        template: 'systems/od6s/templates/roll.html',
+        vehiclespeed: 'cruise',
+        vehiclecollisiontype: 't_bone',
+        vehicleterraindifficulty: input.vehicleTerrainDifficulty,
+
+        // Difficulty
+        difficulty: input.difficulty,
+        isoppasable: isOppasable,
+
+        // Modifiers sub-object
+        modifiers: {
+            range: input.range,
+            attackoption: 'OD6S.ATTACK_STANDARD',
+            calledshot: '',
+            cover: '',
+            coverlight: '',
+            coversmoke: '',
+            miscmod: input.miscMod,
+            scalemod: input.scaleMod,
+        },
+
+        // Bucket-owned fields with safe defaults — handler bucket overrides each.
+        attribute: null,
+        damagetype: '',
+        damagescore: 0,
+        stundamagetype: '',
+        stundamagescore: 0,
+        damagemodifiers: [],
+        difficultylevel: input.difficultyLevel,
+        scaledice: 0,
+        seller: '',
+        vehicle: '',
+        source: '',
+        range: input.range,
+        only_stun: false,
+        can_stun: false,
+        stun: false,
+        attackerScale: 0,
+        specSkill: '',
+
+        // Bucket overrides — handler-owned fields take precedence over the
+        // safe defaults above. The Pick-typed bucket guarantees only valid
+        // RollData fields can land here.
+        ...input.bucket,
+    };
+}

--- a/src/module/apps/roll-helpers/roll-preflight-checks.test.ts
+++ b/src/module/apps/roll-helpers/roll-preflight-checks.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the pure pieces of runPreflight.
+ *
+ * The Foundry-coupled gate wrappers (explosive dialog, sheet-mode warning,
+ * canvas distance measurement) aren't directly unit-testable without mocking
+ * Foundry; their pure decision logic is extracted into helpers tested here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { meleeRangeGateApplies } from './roll-preflight-checks';
+
+// Mirrors what game.i18n.localize would return — for OD6S.MELEE returns
+// the human-readable label "Melee" so we can build a roll request that
+// looks like one item.roll() would actually produce on a melee weapon.
+const fakeLocalize = (key: string): string => {
+    if (key === 'OD6S.MELEE') return 'Melee';
+    if (key === 'OD6S.RANGED') return 'Ranged';
+    return key;
+};
+
+describe('meleeRangeGateApplies', () => {
+    it('returns true for canonical "meleeattack" subtype', () => {
+        expect(
+            meleeRangeGateApplies(
+                { type: 'action', subtype: 'meleeattack' },
+                fakeLocalize,
+            ),
+        ).toBe(true);
+    });
+
+    it('returns true for canonical "brawlattack" subtype', () => {
+        expect(
+            meleeRangeGateApplies(
+                { type: 'action', subtype: 'brawlattack' },
+                fakeLocalize,
+            ),
+        ).toBe(true);
+    });
+
+    it('returns true for a localized melee subtype (e.g. "Melee" from item.roll() on a melee weapon)', () => {
+        // This is the regression Copilot caught on PR #102: setupRollData's
+        // own subtype normalization (OD6S.MELEE → meleeattack) used to run
+        // BEFORE the range check. After extracting the gate into preflight,
+        // the canonical-only subtype check would skip the gate entirely for
+        // weapon item.roll() — letting melee weapon attacks bypass the
+        // out-of-range warning. classifyRoll handles the normalization here.
+        expect(
+            meleeRangeGateApplies(
+                { type: 'weapon', subtype: 'Melee' },
+                fakeLocalize,
+            ),
+        ).toBe(true);
+    });
+
+    it('returns false for ranged-weapon subtypes (canonical or localized)', () => {
+        expect(
+            meleeRangeGateApplies(
+                { type: 'action', subtype: 'rangedattack' },
+                fakeLocalize,
+            ),
+        ).toBe(false);
+        expect(
+            meleeRangeGateApplies(
+                { type: 'weapon', subtype: 'Ranged' },
+                fakeLocalize,
+            ),
+        ).toBe(false);
+    });
+
+    it('returns false for non-attack roll types (skill/specialization/etc.)', () => {
+        expect(
+            meleeRangeGateApplies(
+                { type: 'skill', subtype: '' },
+                fakeLocalize,
+            ),
+        ).toBe(false);
+    });
+});

--- a/src/module/apps/roll-helpers/roll-preflight-checks.ts
+++ b/src/module/apps/roll-helpers/roll-preflight-checks.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure decision logic shared with `roll-preflight.ts`. Lives in its own
+ * file so unit tests can import it without dragging in Foundry-coupled
+ * modules (ExplosiveDialog etc.) at load time.
+ */
+
+import { classifyRoll } from './roll-data';
+import type { Localize } from './roll-data';
+
+/**
+ * Pure check: does the melee-range gate apply to this incoming roll?
+ *
+ * The original setupRollData ran the gate after its own subtype normalization
+ * (`OD6S.MELEE` → `meleeattack`); preflight runs before that normalization,
+ * so we route through `classifyRoll` to get the canonical subtype. Without
+ * this, a melee-weapon `item.roll()` (which passes the localized subtype
+ * verbatim) would silently bypass the range check.
+ */
+export function meleeRangeGateApplies(
+    data: { type: string; subtype?: string; name?: string },
+    localize: Localize,
+): boolean {
+    const { subtype } = classifyRoll(data, localize);
+    return subtype === 'meleeattack' || subtype === 'brawlattack';
+}

--- a/src/module/apps/roll-helpers/roll-preflight.ts
+++ b/src/module/apps/roll-helpers/roll-preflight.ts
@@ -21,6 +21,7 @@
 
 import OD6S from "../../config/config-od6s";
 import ExplosiveDialog from "../explosive-dialog";
+import { meleeRangeGateApplies } from "./roll-preflight-checks";
 
 /**
  * Run the three cancellation gates in order. Returns `true` to proceed,
@@ -66,8 +67,8 @@ function passesSheetModeGate(data: IncomingRollData): boolean {
 }
 
 function passesMeleeRangeGate(data: IncomingRollData): boolean {
-    if (data.subtype !== 'meleeattack' && data.subtype !== 'brawlattack') return true;
     if (!OD6S.meleeRange) return true;
+    if (!meleeRangeGateApplies(data, game.i18n.localize.bind(game.i18n))) return true;
     const targets = [...(game.user?.targets ?? [])];
     if (targets.length === 0) return true;
 

--- a/src/module/apps/roll-helpers/roll-preflight.ts
+++ b/src/module/apps/roll-helpers/roll-preflight.ts
@@ -1,0 +1,89 @@
+/**
+ * Preflight cancellation gates for the roll pipeline.
+ *
+ * `runPreflight` returns `false` when one of the gates wants to cancel the
+ * roll (matching `setupRollData`'s "return false" semantics). The gates:
+ *
+ *   1. Explosive setup — when the item is an explosive and its `explosiveSet`
+ *      flag isn't yet set, open the explosive dialog and cancel the current
+ *      roll. The dialog re-fires the roll once the user picks options.
+ *   2. Sheet mode — when the actor's sheet is in a non-normal mode (build/
+ *      edit), warn and cancel.
+ *   3. Out-of-range melee / brawl — when the attacker is too far from the
+ *      target (per the meleeRange setting and a token-size grid fudge),
+ *      warn and cancel.
+ *
+ * All three are Foundry-coupled by design (dialogs, canvas geometry,
+ * notifications) — they belong to the orchestrator boundary, not the rules
+ * pipeline. Handlers never see preflight; if preflight cancels, dispatch
+ * never runs.
+ */
+
+import OD6S from "../../config/config-od6s";
+import ExplosiveDialog from "../explosive-dialog";
+
+/**
+ * Run the three cancellation gates in order. Returns `true` to proceed,
+ * `false` to cancel (caller short-circuits like the original setupRollData
+ * `return false`).
+ */
+export async function runPreflight(data: IncomingRollData): Promise<boolean> {
+    if (!(await passesExplosiveGate(data))) return false;
+    if (!passesSheetModeGate(data)) return false;
+    if (!passesMeleeRangeGate(data)) return false;
+    return true;
+}
+
+async function passesExplosiveGate(data: IncomingRollData): Promise<boolean> {
+    if (typeof data.itemId === 'undefined' || data.itemId === '') return true;
+
+    let item = data.actor.items.get(data.itemId);
+    if (typeof item === 'undefined'
+        && data.type === 'action'
+        && data.subtype === 'vehiclerangedweaponattack') {
+        item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!
+            .find((i: any) => i.id === data.itemId);
+    }
+
+    const sys = item?.system as OD6SWeaponItemSystem | undefined;
+    if (sys?.subtype?.toLowerCase() !== 'explosive') return true;
+    if (item!.getFlag('od6s', 'explosiveSet')) return true;
+
+    await new ExplosiveDialog({
+        options: OD6S.explosives,
+        item: item!,
+        actor: data.actor,
+        type: 'OD6S.EXPLOSIVE_THROWN',
+        auto: game.settings.get('od6s', 'auto_explosive'),
+    } as never).render({force: true});
+    return false;
+}
+
+function passesSheetModeGate(data: IncomingRollData): boolean {
+    if (data.actor.system.sheetmode.value === "normal") return true;
+    ui.notifications.warn(game.i18n.localize("OD6S.WARN_SHEET_MODE_NOT_NORMAL"));
+    return false;
+}
+
+function passesMeleeRangeGate(data: IncomingRollData): boolean {
+    if (data.subtype !== 'meleeattack' && data.subtype !== 'brawlattack') return true;
+    if (!OD6S.meleeRange) return true;
+    const targets = [...(game.user?.targets ?? [])];
+    if (targets.length === 0) return true;
+
+    const actorToken = data.actor.getActiveTokens()[0];
+    const fudge = Math.floor((((actorToken.width + targets[0].width) / canvas.grid.size) * 0.5) - 1);
+    const distance = Math.floor(
+        canvas.grid.measurePath([actorToken.center, targets[0].center]).distance,
+    ) - fudge;
+
+    if (distance !== 0 && distance / canvas.grid.distance > 1.5) {
+        ui.notifications.warn(game.i18n.localize('OD6S.OUT_OF_MELEE_BRAWL_RANGE'));
+        return false;
+    }
+    return true;
+}
+
+// Local type aliases — kept narrow to avoid leaking Foundry-typed surface
+// out of this file.
+type IncomingRollData = import('./roll-data').IncomingRollData;

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -2,7 +2,6 @@
  * Roll setup: assembles the rollData object from event/actor/item data and opens the dialog.
  */
 import {od6sutilities} from "../../system/utilities";
-import ExplosiveDialog from "../explosive-dialog";
 import OD6S from "../../config/config-od6s";
 import {cancelAction, getEffectMod} from "./roll-effects";
 import {isCharacterActor, isVehicleActor, isSkillItem} from "../../system/type-guards";
@@ -17,6 +16,7 @@ import {
     ramAttackContribution,
 } from "./weapon-context-math";
 import {computePenalties, isPenaltyBypassType, resolveSkillBackedAction} from "./action-math";
+import {runPreflight} from "./roll-preflight";
 
 /**
  * Returns the "vehicle data" carried by an actor regardless of host type:
@@ -73,27 +73,20 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     let onlyStun = false;
     const actorToken = data.actor.isToken ? data.actor.token.object : data.actor.getActiveTokens()[0];
 
+    if (!(await runPreflight(data))) return false;
+
+    // isExplosive flag flows into RollData. The explosive-dialog gate inside
+    // runPreflight cancels (returns false) when the dialog is opened, so by
+    // the time we read here, either the item is set up OR it isn't explosive.
     if (typeof(data.itemId) !== 'undefined' && data.itemId !== '') {
         let item = data.actor.items.get(data.itemId);
-        if(typeof(item) === 'undefined') {
-            if (data.type === 'action' && data.subtype === 'vehiclerangedweaponattack') {
-                item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!.find((i: any) =>i.id === data.itemId);
-            }
+        if (typeof(item) === 'undefined'
+            && data.type === 'action' && data.subtype === 'vehiclerangedweaponattack') {
+            item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!
+                .find((i: any) => i.id === data.itemId);
         }
         if ((item?.system as OD6SWeaponItemSystem | undefined)?.subtype?.toLowerCase() === 'explosive') {
             isExplosive = true;
-            if (!item!.getFlag('od6s','explosiveSet')) {
-                const exdata = {
-                    options: OD6S.explosives,
-                    item: item!,
-                    actor: data.actor,
-                    type: 'OD6S.EXPLOSIVE_THROWN',
-                    auto: game.settings.get('od6s', 'auto_explosive'),
-                };
-
-                await new ExplosiveDialog(exdata).render({force: true});
-                return false;
-            }
         }
     }
 
@@ -127,11 +120,6 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         difficultyLevel = data.difficultyLevel;
     }
 
-    if (data.actor.system.sheetmode.value !== "normal") {
-        ui.notifications.warn(game.i18n.localize("OD6S.WARN_SHEET_MODE_NOT_NORMAL"));
-        return false;
-    }
-
     if (data.subtype === game.i18n.localize('OD6S.RANGED') ||
         data.subtype === game.i18n.localize('OD6S.THROWN') ||
         data.subtype === game.i18n.localize('OD6S.MISSILE') ||
@@ -146,18 +134,6 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     }
 
     game.user?.targets?.forEach((t: Token) => targets.push(t));
-
-    if (data.subtype === 'meleeattack' || data.subtype === 'brawlattack') {
-        if (targets.length > 0 && OD6S.meleeRange) {
-            const actorToken = data.actor.getActiveTokens()[0];
-            const fudge = Math.floor((((actorToken.width + targets[0].width)/canvas.grid.size) * 0.5) - 1);
-            const distance = Math.floor(canvas.grid.measurePath([actorToken.center, targets[0].center]).distance) - fudge;
-            if(distance !== 0 && distance/canvas.grid.distance > 1.5) {
-                ui.notifications.warn(game.i18n.localize('OD6S.OUT_OF_MELEE_BRAWL_RANGE'));
-                return false;
-            }
-        }
-    }
 
     // See if this is a weapon attack
     if (data.type === 'weapon' || data.type === 'starship-weapon' || data.type === 'vehicle-weapon') {


### PR DESCRIPTION
## Summary
Two dormant additions on the path to the cutover: extracts the cancellation gates out of `setupRollData` (3b) and adds a pure COMMON-side assembler (3c). No production code wired yet — the existing `setupRollData` runs the old path; the new pieces are exercised only by tests until the cutover (3d) hooks them up.

## Phase 3b — `runPreflight`

Pulls the three cancellation gates out of `setupRollData` into `roll-preflight.ts`:

1. **Explosive setup dialog** — opens dialog and cancels when `explosiveSet` flag isn't set.
2. **Sheet mode** — warns and cancels when actor is in non-normal sheet mode.
3. **Out-of-melee/brawl-range** — token-size-aware grid distance check.

`runPreflight` short-circuits on the first gate that returns `false`. `setupRollData` calls it at the top — no observable behavior change.

## Phase 3c — `runFinalize`

Pure assembler that combines a handler's typed bucket with precomputed COMMON inputs into a complete `RollData`. The orchestrator (3d, follow-up PR) does the Foundry-coupled work — active effects, settings reads, score adjustments — and hands those values in; finalize composes existing pure helpers (`computePenalties`, `getDiceFromScore`) and slots stable defaults.

What finalize handles:
- Score → dice/pips and bonusmod → bonusdice/bonuspips conversions
- `isOppasable` derivation (the dead `'toughness'` entry from the old canOppose list is gone)
- Stable defaults (`multishot=false`, `shots=1`, `vehiclespeed='cruise'`, template path, etc.)
- Modifiers sub-object assembly
- Bucket spread over safe defaults — typed `Pick` guarantees handlers can only override valid `RollData` fields

Foundry types appear only as opaque pass-through (`actor`/`token`/`targets`/`target` declared as `unknown` on input, cast back on output). Finalize itself never reads them, so it stays unit-testable with plain placeholder objects.

## Verification

- `pnpm run check` clean: 308 unit + 303 domain.
- `tier-3-action-rolls` smoke (the 3 probes added in #99) all pass after the preflight extraction — exercises the explosive and action-roll paths.
- No production behavior change.

## Test plan
- [ ] `pnpm run check` passes
- [ ] `pnpm run test:smoke -- tier-3-action-rolls` passes

## What's next
Phase 3d (cutover) lands as its own PR: rewrites `setupRollData` body to call `runPreflight + classifyRoll + adaptContext + HANDLERS[key] + runFinalize`, replacing the 638-line linear assembly. Phase 3e (dead-code removal: `brawlattack` top-level key, +5 magic constant per RFC #100, parry suffix relocation) follows or bundles with 3d.

Tracking: #98
Refs: #101 (foundation merged as 3390c3e)