### PR TITLE
refactor(roll-setup): #98 phase 3d/3e — cutover to handler dispatch

### DIFF
--- a/src/module/apps/roll-helpers/roll-data.test.ts
+++ b/src/module/apps/roll-helpers/roll-data.test.ts
@@ -91,7 +91,6 @@ describe('classifyRoll', () => {
             ['mortally_wounded', 'mortally_wounded'],
             ['incapacitated', 'incapacitated'],
             ['funds', 'funds'],
-            ['brawlattack', 'brawlattack'],
             // Top-level attribute roll (Actor.rollAttribute) — distinct from
             // action+attribute, which is dispatched via the action handler.
             ['attribute', 'attribute'],

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -249,7 +249,6 @@ export type RollTypeKey =
     | 'incapacitated'
     | 'funds'
     | 'purchase'
-    | 'brawlattack'
     | 'attribute';
 
 /** Canonical post-normalization roll types. Output of classifyRoll. */
@@ -258,7 +257,7 @@ export type CanonicalRollType =
     | 'action' | 'skill' | 'specialization'
     | 'damage' | 'resistance'
     | 'mortally_wounded' | 'incapacitated'
-    | 'funds' | 'brawlattack' | 'attribute';
+    | 'funds' | 'attribute';
 
 export interface ClassifiedRoll {
     type: CanonicalRollType;
@@ -343,7 +342,7 @@ function isCanonicalType(type: string): type is CanonicalRollType {
         case 'action': case 'skill': case 'specialization':
         case 'damage': case 'resistance':
         case 'mortally_wounded': case 'incapacitated':
-        case 'funds': case 'brawlattack': case 'attribute':
+        case 'funds': case 'attribute':
             return true;
         default:
             return false;
@@ -363,7 +362,6 @@ function deriveRollTypeKey(type: CanonicalRollType, subtype: string): RollTypeKe
         case 'mortally_wounded': return 'mortally_wounded';
         case 'incapacitated': return 'incapacitated';
         case 'funds': return subtype === 'purchase' ? 'purchase' : 'funds';
-        case 'brawlattack': return 'brawlattack';
         case 'attribute': return 'attribute';
         case 'action':
             switch (subtype) {

--- a/src/module/apps/roll-helpers/roll-finalize.test.ts
+++ b/src/module/apps/roll-helpers/roll-finalize.test.ts
@@ -38,7 +38,8 @@ function baseInput<K extends RollTypeKey>(
         showWildDie: false,
         penalties: noPenalties,
         otherPenalty: 0,
-        bonusmod: 0,
+        bonusDice: 0,
+        bonusPips: 0,
         miscMod: 0,
         scaleMod: 0,
         range: 'OD6S.RANGE_POINT_BLANK_SHORT',
@@ -65,11 +66,35 @@ describe('runFinalize — score → dice/pips conversion', () => {
         expect(out.originalpips).toBe(2);
     });
 
-    it('converts bonusmod to bonusdice/bonuspips the same way', () => {
+    it('applies diceMultiplier=2 (FP-in-effect) to dice/pips and originaldice/originalpips', () => {
         const out = runFinalize(baseInput<"skill">({
             classified: classified('skill', '', 'skill'),
             bucket: { attribute: 'agi' },
-            bonusmod: 7,
+            score: 14, // → 4D+2
+            diceMultiplier: 2,
+        }));
+        expect(out.dice).toBe(8);
+        expect(out.pips).toBe(4);
+        expect(out.originaldice).toBe(8);
+        expect(out.originalpips).toBe(4);
+    });
+
+    it('treats missing diceMultiplier as 1 (no doubling)', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            score: 14,
+        }));
+        expect(out.dice).toBe(4);
+        expect(out.pips).toBe(2);
+    });
+
+    it('forwards precomputed bonusDice/bonusPips unchanged', () => {
+        const out = runFinalize(baseInput<"skill">({
+            classified: classified('skill', '', 'skill'),
+            bucket: { attribute: 'agi' },
+            bonusDice: 2,
+            bonusPips: 1,
         }));
         expect(out.bonusdice).toBe(2);
         expect(out.bonuspips).toBe(1);

--- a/src/module/apps/roll-helpers/roll-finalize.ts
+++ b/src/module/apps/roll-helpers/roll-finalize.ts
@@ -67,8 +67,14 @@ export interface FinalizeInput<K extends RollTypeKey> {
     penalties: Penalties;
     /** Extra penalty (from negative scaleMod under dice_for_scale, etc.). */
     otherPenalty: number;
-    /** Accumulated bonusmod (active effects + handler-side contributions). */
-    bonusmod: number;
+    /**
+     * Pre-split bonus dice / pips. Orchestrator computes via
+     * `splitBonusForPenalty` (negative bonus folds into `otherPenalty`) and
+     * augments `bonusPips` with `flatSkillBonusPips` in flat-skills mode.
+     * Finalize is a passive forwarder for these.
+     */
+    bonusDice: number;
+    bonusPips: number;
     /** Misc modifier (weapon mods difficulty, +5 magic constants if any, etc.). */
     miscMod: number;
     /** Scale modifier between attacker and defender (post-resolution). */
@@ -79,6 +85,18 @@ export interface FinalizeInput<K extends RollTypeKey> {
     vehicleTerrainDifficulty: string;
     /** Pips per die (3 in standard OpenD6). */
     pipsPerDice: number;
+    /**
+     * Post-conversion dice multiplier (default 1). When the FP-in-effect flag
+     * doubles the roll, orchestrator passes `2`; finalize multiplies BOTH
+     * `dice` and `pips` AND the matching `originaldice`/`originalpips` after
+     * `score → dice/pips` conversion. This keeps `originaldice` aligned with
+     * the doubled values execute also re-doubles from on its FP path.
+     *
+     * Splitting score-derived dice from the multiplier closes the Audit-A
+     * timeline bug where damaged-weapon penalties / `roll_mod` re-derives
+     * could overwrite an earlier doubling.
+     */
+    diceMultiplier?: number;
     /** Opaque Foundry actor/token/targets refs — passed through unchanged. */
     actorRef: unknown;
     tokenRef: unknown;
@@ -89,8 +107,12 @@ export interface FinalizeInput<K extends RollTypeKey> {
 }
 
 export function runFinalize<K extends RollTypeKey>(input: FinalizeInput<K>): RollData {
-    const dicePips = getDiceFromScore(input.score, input.pipsPerDice);
-    const bonusDicePips = getDiceFromScore(input.bonusmod, input.pipsPerDice);
+    const baseDice = getDiceFromScore(input.score, input.pipsPerDice);
+    const multiplier = input.diceMultiplier ?? 1;
+    const dicePips = {
+        dice: baseDice.dice * multiplier,
+        pips: baseDice.pips * multiplier,
+    };
 
     const isOppasable =
         OPPOSABLE_TYPES.has(input.classified.type)
@@ -106,8 +128,8 @@ export function runFinalize<K extends RollTypeKey>(input: FinalizeInput<K>): Rol
         pips: dicePips.pips,
         originaldice: dicePips.dice,
         originalpips: dicePips.pips,
-        bonusdice: bonusDicePips.dice,
-        bonuspips: bonusDicePips.pips,
+        bonusdice: input.bonusDice,
+        bonuspips: input.bonusPips,
         score: input.score,
 
         // Wild die / FP / CP flags

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -29,8 +29,7 @@ import {
     computeStunFlags,
     ramAttackContribution,
 } from './weapon-context-math';
-import type { ActionSkill } from './action-math';
-import { resolveSkillBackedAction } from './action-math';
+import type { ActionResolution } from './action-math';
 
 export type HandlerOutput<K extends RollTypeKey> =
     Pick<RollData, (typeof ROLL_TYPE_FIELDS)[K][number]>;
@@ -174,12 +173,18 @@ export interface HandlerContext {
     settings: RollSettingsView;
     localize: Localize;
     /**
-     * Pre-resolved skill backing for skill-backed action handlers
-     * (action-meleeattack / action-brawlattack). The orchestrator looks up the
-     * actor's skill item by the action's configured skill name and projects it
-     * here; null when no matching skill item exists.
+     * Pre-resolved skill-backed action result for action-meleeattack /
+     * action-brawlattack. The orchestrator runs `resolveSkillBackedAction`
+     * once at the boundary (Audit E: deduplicates the call so `flatPips` can
+     * be reused for the COMMON-side bonusdice computation) and stashes the
+     * result here. Handlers read `score` (and optionally `flatPips`) without
+     * reaching for skill / attribute fields themselves.
+     *
+     * Null/undefined when the actor isn't a character or no resolution is
+     * applicable; handlers default to score 0 in that case (the action-* keys
+     * that need this only fire for character-piloted paths).
      */
-    actionSkill?: ActionSkill | null;
+    actionSkillResolved?: ActionResolution | null;
     /**
      * Vehicle stats for vehicle-action handlers when the actor is a character
      * piloting a vehicle (the orchestrator dereferences `actor.system.vehicle`
@@ -233,20 +238,6 @@ const attributeHandler: Handler<'attribute'> = () => ({});
 const purchaseHandler: Handler<'purchase'> = (input) => ({
     seller: input.seller ?? '',
 });
-
-/**
- * Top-level `brawlattack` is unreachable in the current code: Actor.rollAction
- * wraps brawl rolls as `{type: 'action', subtype: 'brawlattack'}`, which the
- * classifier routes to action-brawlattack. The classifier still accepts a
- * top-level `brawlattack`, but no caller produces one. Phase 3 removes the
- * key from RollTypeKey entirely; until then this throws to surface any
- * caller that resurrects the path.
- */
-const brawlattackDeadPathHandler: Handler<'brawlattack'> = () => {
-    throw new Error(
-        'brawlattack: unreachable dead path — route brawl rolls through action-brawlattack',
-    );
-};
 
 const vehicleUuidForActor = (actor: ActorView): string =>
     actor.type === 'vehicle' || actor.type === 'starship'
@@ -402,31 +393,16 @@ const actionVehicleRangedAttackHandler: Handler<'action-vehiclerangedattack'> = 
     vehicle: vehicleUuidForActor(ctx.actor),
 });
 
-const actionMeleeAttackHandler: Handler<'action-meleeattack'> = (_input, ctx) => {
-    const resolved = resolveSkillBackedAction({
-        skill: ctx.actionSkill ?? null,
-        attributes: characterAttributes(ctx.actor),
-        flatSkills: ctx.settings.flatSkills,
-        // Melee uses AGI per the rules; not a configurable setting.
-        fallbackAttributeKey: 'agi',
-    });
-    return {
-        score: resolved.score,
-        attackerScale: actorScale(ctx.actor),
-        damagescore: characterStrengthDamage(ctx.actor),
-    };
-};
+const actionMeleeAttackHandler: Handler<'action-meleeattack'> = (_input, ctx) => ({
+    score: ctx.actionSkillResolved?.score ?? 0,
+    attackerScale: actorScale(ctx.actor),
+    damagescore: characterStrengthDamage(ctx.actor),
+});
 
 const actionBrawlAttackHandler: Handler<'action-brawlattack'> = (_input, ctx) => {
-    const resolved = resolveSkillBackedAction({
-        skill: ctx.actionSkill ?? null,
-        attributes: characterAttributes(ctx.actor),
-        flatSkills: ctx.settings.flatSkills,
-        fallbackAttributeKey: ctx.settings.brawlAttribute,
-    });
     const str = characterStrengthDamage(ctx.actor);
     return {
-        score: resolved.score,
+        score: ctx.actionSkillResolved?.score ?? 0,
         attackerScale: actorScale(ctx.actor),
         damagetype: 'p',
         damagescore: str,
@@ -450,8 +426,25 @@ const actionVehicleRamAttackHandler: Handler<'action-vehicleramattack'> = (_inpu
     };
 };
 
-const actionVehicleRangedWeaponAttackHandler: Handler<'action-vehiclerangedweaponattack'> = (_input, ctx) => {
-    const item = ctx.item ?? {} as ItemView;
+const actionVehicleRangedWeaponAttackHandler: Handler<'action-vehiclerangedweaponattack'> = (input, ctx) => {
+    // B2: character-fallback path. crew-vehicle.ts (rolling a vehicle weapon
+    // from a character pilot's sheet) passes the weapon's damage/damage_type/
+    // name on IncomingRollData when the embedded vehicle weapon item can't be
+    // resolved on the character actor. The adapter doesn't see an item; the
+    // handler reads from `input` instead. Vehicle scale comes from
+    // ctx.vehicleStats (orchestrator pre-resolved at the boundary).
+    if (!ctx.item) {
+        return {
+            damagetype: input.damage_type ?? '',
+            damagescore: input.damage ?? 0,
+            source: input.name ?? '',
+            range: 'OD6S.RANGE_SHORT_SHORT',
+            difficultylevel: defaultDifficultyLabel(ctx.settings),
+            attackerScale: vehicleScaleForActor(ctx.actor, ctx),
+            vehicle: vehicleUuidForActor(ctx.actor),
+        };
+    }
+    const item = ctx.item;
     const baseDamage = item.damage?.score ?? 0;
     const modded = applyWeaponMods(
         { damageScore: baseDamage, miscMod: 0, bonusmod: 0 },
@@ -506,6 +499,5 @@ export const HANDLERS = {
     'funds': fundsHandler,
     'purchase': purchaseHandler,
 
-    'brawlattack': brawlattackDeadPathHandler,
     'attribute': attributeHandler,
 } as const satisfies { [K in RollTypeKey]: Handler<K> };

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -190,6 +190,13 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     const localize = game.i18n.localize.bind(game.i18n);
     const settings = readSettings();
     const classified = classifyRoll(data, localize);
+    // `classifyRoll` does NOT mutate `data` — for weapon-item rolls coming
+    // through with a localized subtype alias (e.g. "Melee" / "Ranged"),
+    // `data.subtype` stays localized while `classified.subtype` is canonical.
+    // Always read `subtype` (canonical) downstream of the classifier; reading
+    // `data.subtype` would silently skip melee/ranged mod accumulation, range
+    // bucketing, and any branch keyed on the canonical attack subtype.
+    const subtype = classified.subtype;
 
     const item = resolveItemForDispatch(data);
     const isExplosive = !!item
@@ -200,12 +207,10 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     // range table and may cancel via false (e.g., out-of-ammo dialog).
     let weaponRangeTable: { short: number; medium: number; long: number } | undefined;
     if (item && (data.type === 'weapon' || data.type === 'starship-weapon' || data.type === 'vehicle-weapon')) {
-        const isRangedAlias = data.subtype === 'rangedattack'
-            || data.subtype === game.i18n.localize('OD6S.RANGED')
-            || data.subtype === game.i18n.localize('OD6S.THROWN')
-            || data.subtype === game.i18n.localize('OD6S.MISSILE')
-            || data.subtype === game.i18n.localize('OD6S.EXPLOSIVE');
-        if (isRangedAlias) {
+        // Classifier collapses every localized weapon-type alias (RANGED /
+        // THROWN / MISSILE / EXPLOSIVE) into canonical 'rangedattack', so a
+        // single check covers the whole alias set.
+        if (subtype === 'rangedattack') {
             const r = await od6sutilities.getWeaponRange(data.actor, item);
             if (r === false) return false;
             weaponRangeTable = r as typeof weaponRangeTable;
@@ -295,20 +300,20 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     if (isCharacterActor(data.actor)) {
         const c = data.actor.system;
-        if (data.subtype === 'meleeattack') bonusmod += c.melee.mod;
-        if (data.subtype === 'brawlattack') bonusmod += c.brawl.mod;
-        if (data.subtype === 'dodge') bonusmod += c.dodge.mod;
-        if (data.subtype === 'parry') bonusmod += c.parry.mod;
-        if (data.subtype === 'block') bonusmod += c.block.mod;
+        if (subtype === 'meleeattack') bonusmod += c.melee.mod;
+        if (subtype === 'brawlattack') bonusmod += c.brawl.mod;
+        if (subtype === 'dodge') bonusmod += c.dodge.mod;
+        if (subtype === 'parry') bonusmod += c.parry.mod;
+        if (subtype === 'block') bonusmod += c.block.mod;
     }
 
     // Ranged-attack bonus: vehicle's ranged.score for vehicle-piloted paths,
     // actor.system.ranged.mod for personal ranged.
-    const isRangedSubtype = data.subtype === 'rangedattack'
-        || data.subtype === 'vehiclerangedattack'
-        || data.subtype === 'vehiclerangedweaponattack';
+    const isRangedSubtype = subtype === 'rangedattack'
+        || subtype === 'vehiclerangedattack'
+        || subtype === 'vehiclerangedweaponattack';
     if (isRangedSubtype) {
-        if (data.subtype && data.subtype.startsWith('vehicle')) {
+        if (subtype.startsWith('vehicle')) {
             const vehSys = data.actor.system as OD6SVehicleSystem;
             const charSys = data.actor.system as OD6SCharacterSystem & {
                 vehicle: { ranged?: { score?: number } };
@@ -348,7 +353,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if (typeof bucketAny.attackerScale === 'number' && bucketAny.attackerScale !== 0) {
         attackerScale = bucketAny.attackerScale;
     } else if (isAttackRoll) {
-        const isVehicleSubtype = data.subtype !== undefined && data.subtype.includes('vehicle');
+        const isVehicleSubtype = subtype.includes('vehicle');
         if (isVehicleSubtype) {
             attackerScale = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
                 ? +((data.actor.system as { scale?: { score?: number } }).scale?.score ?? 0)
@@ -375,7 +380,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         ?? data.difficultyLevel
         ?? (settings.defaultUnknownDifficulty ? 'OD6S.DIFFICULTY_UNKNOWN' : 'OD6S.DIFFICULTY_EASY');
 
-    if (RANGED_BUCKETING_SUBTYPES.has(data.subtype ?? '')) {
+    if (RANGED_BUCKETING_SUBTYPES.has(subtype)) {
         rangeLabel = 'OD6S.RANGE_SHORT_SHORT';
         const rangeDifficulty = !!game.settings.get('od6s', 'map_range_to_difficulty');
         const autoExplosive = !!game.settings.get('od6s', 'auto_explosive');
@@ -489,7 +494,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     // ---- Misc COMMON inputs ----
     let name = data.name;
-    if (data.subtype === 'parry' && classified.type === 'weapon') {
+    if (subtype === 'parry' && classified.type === 'weapon') {
         name = `${data.name} ${game.i18n.localize('OD6S.PARRY')}`;
     }
     const vehicleTerrainDifficulty = OD6S.vehicleDifficulty
@@ -505,7 +510,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if ((bucketAny.attackerScale !== undefined) || isAttackRoll) {
         (bucketWithOverrides as Partial<RollData>).attackerScale = attackerScale;
     }
-    if (RANGED_BUCKETING_SUBTYPES.has(data.subtype ?? '') || bucketAny.range !== undefined) {
+    if (RANGED_BUCKETING_SUBTYPES.has(subtype) || bucketAny.range !== undefined) {
         (bucketWithOverrides as Partial<RollData>).range = rangeLabel;
     }
     if (bucketAny.difficultylevel !== undefined) {

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -1,654 +1,551 @@
 /**
- * Roll setup: assembles the rollData object from event/actor/item data and opens the dialog.
+ * Roll setup orchestrator (#98 phase 3d cutover).
+ *
+ * Replaces the legacy 650-line `setupRollData` with a thin coordinator over
+ * the rules pipeline:
+ *
+ *   1. preflight                — Foundry-coupled cancellation gates
+ *   2. classifyRoll             — type/subtype → RollTypeKey
+ *   3. adaptContext + pre-resolve actionSkill / vehicleStats
+ *   4. HANDLERS[key]            — pure typed bucket
+ *   5. score gate (with explosive cleanup)
+ *   6. orchestrator-side accumulation: bonusmod (14 sites), miscMod, scaleMod
+ *   7. range bucketing for ranged subtypes (with explosive cleanup on out-of-range)
+ *   8. roll_mod, damaged-weapon penalty, flatSkills attribute swap, fatepointeffect
+ *   9. runFinalize              — typed bucket + COMMON inputs → RollData
+ *
+ * RFC fixes applied during cutover:
+ *   - #100: +5 magic constant on action-meleeattack removed (no rules backing).
+ *   - #103: vehicleramattack `ram.score` added once (legacy added it twice).
+ *   - #104: attackerScale derives unconditionally from actor for attack rolls
+ *           with no targets (legacy left attackerScale=0).
+ *   - Audit A: fatepointeffect doubling routed through FinalizeInput.diceMultiplier
+ *              so damaged / roll_mod re-derives can't overwrite it.
+ *   - Phase 0 cleanup: legacy `'toughness'` in canOppose was already gone in
+ *     finalize; legacy top-level `brawlattack` RollTypeKey removed (no
+ *     caller produces type='brawlattack'; Actor.rollAction wraps brawl as
+ *     `{type:'action', subtype:'brawlattack'}` which routes to action-brawlattack).
  */
+
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {cancelAction, getEffectMod} from "./roll-effects";
-import {isCharacterActor, isVehicleActor, isSkillItem} from "../../system/type-guards";
+import {isCharacterActor} from "../../system/type-guards";
 import {bucketRangeFromDistance, flatSkillBonusPips, splitBonusForPenalty} from "./difficulty-math";
-import type {Modifier} from "./difficulty-math";
-import type {IncomingRollData, RollData, DiceValue} from "./roll-data";
-import {
-    applyWeaponMods,
-    buildDamagedWeaponModifier,
-    buildStrengthDamageModifier,
-    computeStunFlags,
-    ramAttackContribution,
-} from "./weapon-context-math";
+import type {IncomingRollData, RollData, ClassifiedRoll, RollTypeKey} from "./roll-data";
+import {classifyRoll} from "./roll-data";
+import {applyWeaponMods} from "./weapon-context-math";
 import {computePenalties, isPenaltyBypassType, resolveSkillBackedAction} from "./action-math";
+import type {ActionResolution} from "./action-math";
 import {runPreflight} from "./roll-preflight";
+import {adaptContext} from "./roll-context-adapter";
+import type {RollSettingsRaw} from "./roll-context-adapter";
+import {HANDLERS} from "./roll-handlers";
+import type {HandlerContext, HandlerInput} from "./roll-handlers";
+import {runFinalize} from "./roll-finalize";
 
 /**
- * Returns the "vehicle data" carried by an actor regardless of host type:
- * for vehicle/starship actors it's `system` itself; for character actors
- * it's the embedded `system.vehicle` field. The shape is loosely typed
- * because the two sources only partially overlap at runtime.
+ * Roll-type keys whose rolls get the `dice_for_scale` negative-scaleMod dice
+ * adjustment (Audit D enumeration).
  */
-function selectVehicleData(actor: Actor): {
-    uuid?: string;
-    scale?: { score: number };
-    ram?: { score: number };
-    ram_damage?: { score: number };
-    ranged?: { score?: number };
-    vehicle_weapons?: Item[];
-} {
-    if (actor.type === 'vehicle' || actor.type === 'starship') {
-        return actor.system as never;
+const ATTACK_KEYS: ReadonlySet<RollTypeKey> = new Set<RollTypeKey>([
+    'weapon', 'starship-weapon', 'vehicle-weapon',
+    'action-brawlattack',
+    'action-vehicleramattack',
+    'action-vehiclerangedweaponattack',
+]);
+
+const RANGED_BUCKETING_SUBTYPES = new Set([
+    'rangedattack', 'vehiclerangedattack', 'vehiclerangedweaponattack',
+]);
+
+function readSettings(): RollSettingsRaw {
+    return {
+        defaultUnknownDifficulty: !!game.settings.get('od6s', 'default_unknown_difficulty'),
+        diceForScale: !!game.settings.get('od6s', 'dice_for_scale'),
+        fundsFate: !!OD6S.fundsFate,
+        hideCombatCards: !!game.settings.get('od6s', 'hide-combat-cards'),
+        hideSkillCards: !!game.settings.get('od6s', 'hide-skill-cards'),
+        showSkillSpecialization: !!OD6S.showSkillSpecialization,
+        pipsPerDice: OD6S.pipsPerDice,
+        meleeDifficulty: !!OD6S.meleeDifficulty,
+        explosiveZones: !!game.settings.get('od6s', 'explosive_zones'),
+        weaponDamageTable: OD6S.weaponDamage,
+        flatSkills: !!OD6S.flatSkills,
+        brawlAttribute: game.settings.get('od6s', 'brawl_attribute') as string,
+    };
+}
+
+/**
+ * Resolve the source item for handler dispatch. Mirrors the legacy boundary
+ * resolver: standard items.get on the actor; for character-piloted vehicle
+ * weapon attacks, fall back to the embedded `vehicle.vehicle_weapons` array.
+ */
+function resolveItemForDispatch(data: IncomingRollData): Item | undefined {
+    if (!data.itemId) return undefined;
+    let item = data.actor.items.get(data.itemId);
+    if (!item
+        && data.type === 'action'
+        && data.subtype === 'vehiclerangedweaponattack'
+        && isCharacterActor(data.actor)) {
+        item = data.actor.system.vehicle.vehicle_weapons
+            ?.find((i: { id?: string }) => i.id === data.itemId);
     }
-    return (actor.system as OD6SCharacterSystem).vehicle as never;
+    return item;
+}
+
+function resolveVehicleStatsForCharacter(actor: Actor): HandlerContext['vehicleStats'] {
+    if (!isCharacterActor(actor)) return undefined;
+    const v = actor.system.vehicle as {
+        scale?: { score: number };
+        ram?: { score: number };
+        ram_damage?: { score: number };
+    } | undefined;
+    if (!v) return undefined;
+    return {
+        scale: v.scale ? { score: +v.scale.score } : undefined,
+        ram: v.ram ? { score: +v.ram.score } : undefined,
+        ram_damage: v.ram_damage ? { score: +v.ram_damage.score } : undefined,
+    };
+}
+
+/**
+ * Build the `actionSkillResolved` bucket for action-meleeattack /
+ * action-brawlattack at the boundary. Audit E: pre-resolving here means
+ * `flatPips` is available for COMMON-side bonusdice without re-running
+ * `resolveSkillBackedAction` inside the handler.
+ */
+function preResolveActionSkill(
+    data: IncomingRollData,
+    classified: ClassifiedRoll,
+    settings: RollSettingsRaw,
+): ActionResolution | undefined {
+    if (classified.key !== 'action-meleeattack' && classified.key !== 'action-brawlattack') {
+        return undefined;
+    }
+    if (!isCharacterActor(data.actor)) return { score: 0 };
+
+    const skillName = classified.key === 'action-meleeattack'
+        ? game.i18n.localize('OD6S.MELEE_COMBAT')
+        : game.i18n.localize('OD6S.BRAWL');
+    const fallback = classified.key === 'action-meleeattack'
+        ? 'agi'
+        : (game.settings.get('od6s', 'brawl_attribute') as string);
+
+    const skillItem = data.actor.items.find(
+        (i: Item) => i.type === 'skill' && i.name === skillName,
+    );
+    const sysAttrs: Record<string, { score: number }> = {};
+    const rawAttrs = (data.actor.system as { attributes?: Record<string, { score: number }> }).attributes ?? {};
+    for (const [k, v] of Object.entries(rawAttrs)) {
+        sysAttrs[k] = { score: +v.score };
+    }
+
+    const skillSys = skillItem ? (skillItem.system as OD6SSkillItemSystem) : null;
+    return resolveSkillBackedAction({
+        skill: skillSys
+            ? { score: skillSys.score, attributeKey: skillSys.attribute.toLowerCase() }
+            : null,
+        attributes: sysAttrs,
+        flatSkills: settings.flatSkills,
+        fallbackAttributeKey: fallback,
+    });
+}
+
+function deriveVisibility(
+    key: RollTypeKey,
+    settings: RollSettingsRaw,
+    isBypass: boolean,
+): boolean {
+    if (isBypass) return true;
+    switch (key) {
+        case 'skill': case 'skill-dodge': case 'specialization':
+        case 'funds': case 'purchase': case 'action-attribute':
+            return !settings.hideSkillCards;
+        case 'weapon': case 'starship-weapon': case 'vehicle-weapon':
+        case 'action-meleeattack': case 'action-brawlattack':
+        case 'action-rangedattack': case 'action-vehiclerangedattack':
+        case 'action-vehiclerangedweaponattack': case 'action-vehicleramattack':
+        case 'action-other':
+            return !settings.hideCombatCards;
+        default:
+            return false;
+    }
+}
+
+function deriveCanUseFpCp(
+    key: RollTypeKey,
+    settings: RollSettingsRaw,
+): { canUseFp: boolean; canUseCp: boolean } {
+    if (key === 'resistance-vehicletoughness') return { canUseFp: false, canUseCp: false };
+    if ((key === 'funds' || key === 'purchase') && !settings.fundsFate) {
+        return { canUseFp: false, canUseCp: false };
+    }
+    return { canUseFp: true, canUseCp: true };
 }
 
 export async function setupRollData(data: IncomingRollData): Promise<RollData | false> {
-    let attribute;
-    let range = "OD6S.RANGE_POINT_BLANK_SHORT";
-    let woundPenalty;
-    let damageType = '';
-    let damageScore = 0;
-    let stunDamageType = '';
-    let stunDamageScore = 0;
-    const damageModifiers: Modifier[] = [];
-    const targets: Token[] = [];
-    let difficulty = 0;
-    let isAttack = false;
-    let isVisible = false;
-    let isOpposable = false;
-    let difficultyLevel = game.settings.get('od6s','default_unknown_difficulty') ? 'OD6S.DIFFICULTY_UNKNOWN' : 'OD6S.DIFFICULTY_EASY';
-    let bonusmod = 0;
-    let bonusdice: DiceValue = { dice: 0, pips: 0 };
-    let penaltydice = 0;
-    let miscMod = 0;
-    let scaleMod = 0;
-    let scaleDice = 0;
-    let canUseCp = true;
-    let canUseFp = true;
-    let vehicle = '';
-    let vehicleTerrainDifficulty = 'OD6S.DIFFICULTY_EASY';
-    let damageSource = '';
-    let attackerScale = 0;
-    let defenderScale;
-    let flatPips = 0;
-    let specSkill = '';
-    let isExplosive = false;
-    let canStun = false;
-    let onlyStun = false;
-    const actorToken = data.actor.isToken ? data.actor.token.object : data.actor.getActiveTokens()[0];
-
     if (!(await runPreflight(data))) return false;
 
-    // isExplosive flag flows into RollData. The explosive-dialog gate inside
-    // runPreflight cancels (returns false) when the dialog is opened, so by
-    // the time we read here, either the item is set up OR it isn't explosive.
-    if (typeof(data.itemId) !== 'undefined' && data.itemId !== '') {
-        let item = data.actor.items.get(data.itemId);
-        if (typeof(item) === 'undefined'
-            && data.type === 'action' && data.subtype === 'vehiclerangedweaponattack') {
-            item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!
-                .find((i: any) => i.id === data.itemId);
-        }
-        if ((item?.system as OD6SWeaponItemSystem | undefined)?.subtype?.toLowerCase() === 'explosive') {
-            isExplosive = true;
-        }
-    }
+    const localize = game.i18n.localize.bind(game.i18n);
+    const settings = readSettings();
+    const classified = classifyRoll(data, localize);
 
-    if (typeof (data.flatpips) !== 'undefined' && data.flatpips > 0) {
-        flatPips = data.flatpips;
-    }
+    const item = resolveItemForDispatch(data);
+    const isExplosive = !!item
+        && (item.system as OD6SWeaponItemSystem | undefined)?.subtype?.toLowerCase() === 'explosive';
 
-    if ((data.type === 'funds' || data.type === 'purchase') && !OD6S.fundsFate) {
-        canUseCp = false;
-        canUseFp = false;
-    }
-
-    if (OD6S.vehicleDifficulty) {
-        vehicleTerrainDifficulty = 'OD6S.TERRAIN_EASY';
-    }
-
-    if ((typeof (data.subtype) !== 'undefined' && data.subtype.includes('vehicle'))
-        || data.type.includes('vehicle')) {
-        if (data.actor.type === 'vehicle' || data.actor.type === 'starship') {
-            vehicle = data.actor.uuid;
+    // For weapon-typed rolls with a localized ranged subtype alias (RANGED /
+    // THROWN / MISSILE / EXPLOSIVE), getWeaponRange resolves the per-roll
+    // range table and may cancel via false (e.g., out-of-ammo dialog).
+    let weaponRangeTable: { short: number; medium: number; long: number } | undefined;
+    if (item && (data.type === 'weapon' || data.type === 'starship-weapon' || data.type === 'vehicle-weapon')) {
+        const isRangedAlias = data.subtype === 'rangedattack'
+            || data.subtype === game.i18n.localize('OD6S.RANGED')
+            || data.subtype === game.i18n.localize('OD6S.THROWN')
+            || data.subtype === game.i18n.localize('OD6S.MISSILE')
+            || data.subtype === game.i18n.localize('OD6S.EXPLOSIVE');
+        if (isRangedAlias) {
+            const r = await od6sutilities.getWeaponRange(data.actor, item);
+            if (r === false) return false;
+            weaponRangeTable = r as typeof weaponRangeTable;
         } else {
-            vehicle = (data.actor.system as OD6SCharacterSystem).vehicle.uuid;
+            weaponRangeTable = (item.system as OD6SWeaponItemSystem).range as unknown as typeof weaponRangeTable;
         }
+    } else if (item && classified.key === 'action-vehiclerangedweaponattack') {
+        const sys = item.system as { range?: typeof weaponRangeTable };
+        weaponRangeTable = sys.range;
     }
 
-    if (typeof (data.difficulty) !== 'undefined') {
-        difficulty = data.difficulty;
-    }
-
-    if (typeof (data.difficultyLevel) !== 'undefined') {
-        difficultyLevel = data.difficultyLevel;
-    }
-
-    if (data.subtype === game.i18n.localize('OD6S.RANGED') ||
-        data.subtype === game.i18n.localize('OD6S.THROWN') ||
-        data.subtype === game.i18n.localize('OD6S.MISSILE') ||
-        data.subtype === game.i18n.localize('OD6S.EXPLOSIVE')) {
-        data.subtype = "rangedattack";
-        isAttack = true;
-    }
-
-    if (data.subtype === game.i18n.localize('OD6S.MELEE')) {
-        data.subtype = "meleeattack"
-        isAttack = true;
-    }
-
+    const actorToken = data.actor.isToken ? data.actor.token.object : data.actor.getActiveTokens()[0];
+    const targets: Token[] = [];
     game.user?.targets?.forEach((t: Token) => targets.push(t));
 
-    // See if this is a weapon attack
-    if (data.type === 'weapon' || data.type === 'starship-weapon' || data.type === 'vehicle-weapon') {
-        const weapon = data.actor.getEmbeddedDocument('Item', data.itemId ?? '');
-        damageSource = weapon.name;
-        damageType = weapon.system.damage.type;
-        damageScore = weapon.system.damage.score;
-        stunDamageType = weapon.system?.stun?.type;
-        stunDamageScore = weapon.system?.stun?.score;
-        isAttack = true;
-        if (data.subtype === 'meleeattack') {
-            damageScore = od6sutilities.getMeleeDamage(data.actor, weapon);
-            if (stunDamageScore > 0) {
-                stunDamageScore = weapon.system.damage.str ? stunDamageScore + (data.actor.system as OD6SCharacterSystem).strengthdamage.score : stunDamageScore;
-            }
+    // Boundary projection (sets `actor`, `item`, `targets`, `settings`, `localize`).
+    const ctxBase = adaptContext(
+        { type: data.actor.type, uuid: data.actor.uuid, system: data.actor.system },
+        item ? { type: item.type, name: item.name, system: item.system } : undefined,
+        { settings, localize, canvasTargets: targets },
+    );
+    const ctx: HandlerContext = {
+        ...ctxBase,
+        actionSkillResolved: preResolveActionSkill(data, classified, settings),
+        vehicleStats: resolveVehicleStatsForCharacter(data.actor),
+    };
+
+    const { actor: _omitActor, ...dataNoActor } = data;
+    void _omitActor;
+    const handlerInput: HandlerInput = { ...dataNoActor, classified };
+
+    const bucket = HANDLERS[classified.key](handlerInput, ctx);
+
+    // ---- Score resolution ----
+    const bucketAny = bucket as Partial<RollData>;
+    const workingScore = bucketAny.score ?? data.score;
+
+    const flatSkillsBypass = settings.flatSkills
+        && (classified.type === 'skill' || classified.type === 'specialization');
+    if (workingScore < settings.pipsPerDice && !flatSkillsBypass) {
+        ui.notifications.warn(game.i18n.localize("OD6S.SCORE_TOO_LOW"));
+        if (isExplosive) {
+            await cancelAction({ ...data, isExplosive, itemid: data.itemId } as unknown as RollData);
         }
-        if (weapon.system.scale.score) attackerScale = weapon.system.scale.score;
-        ({damageScore, miscMod, bonusmod} = applyWeaponMods(
-            {damageScore, miscMod, bonusmod},
-            weapon.system.mods,
-        ));
+        return false;
+    }
 
-        if (OD6S.meleeDifficulty) {
-            weapon.system.difficulty ? difficultyLevel = weapon.system.difficulty : difficultyLevel = 'OD6S.DIFFICULTY_EASY';
-        }
+    // ---- bonusmod / miscMod accumulation (orchestrator-side) ----
+    let bonusmod = 0;
+    let miscMod = 0;
 
-        ({onlyStun, canStun} = computeStunFlags({
-            stunOnly: weapon.system.stun?.stun_only,
-            weaponStunScore: weapon.system.stun?.score ?? 0,
-            isExplosive,
-            explosiveZonesEnabled: Boolean(game.settings.get('od6s', 'explosive_zones')),
-            blastZone1StunDamage: weapon.system.blast_radius?.["1"]?.stun_damage ?? 0,
-        }));
+    // Weapon family: weapon mod difficulty / attack land on miscMod / bonusmod
+    // (handler already folded `damage` into bucket.damagescore via the same
+    // helper — applyWeaponMods is run twice but discarded outputs differ, so no
+    // double-fold happens).
+    if (item && (classified.type === 'weapon' || classified.type === 'starship-weapon' || classified.type === 'vehicle-weapon')) {
+        const wsys = item.system as OD6SWeaponItemSystem;
+        const folded = applyWeaponMods({ damageScore: 0, miscMod, bonusmod }, wsys.mods);
+        miscMod = folded.miscMod;
+        bonusmod = folded.bonusmod;
 
-        if(data.subtype === 'rangedattack') {
-            data.range = await od6sutilities.getWeaponRange(data.actor, weapon) as typeof data.range;
-            if (data.range === false) return false;
-        } else {
-            data.range = weapon.system.range as typeof data.range;
-        }
-
-        const damagedMod = buildDamagedWeaponModifier(weapon.system.damaged, OD6S.weaponDamage);
-        if (damagedMod) damageModifiers.push(damagedMod);
-
-        if (weapon.system.damage.muscle) {
-            damageModifiers.push(buildStrengthDamageModifier(
-                (data.actor.system as OD6SCharacterSystem).strengthdamage.score,
-            ));
-        }
-
-        // Check for effect modifiers — prefer specialization over skill when
-        // the actor owns the matching item.
-        const stats = weapon.system.stats;
-        const ownsSpec = !!stats.specialization
+        const stats = wsys.stats;
+        const ownsSpec = !!stats?.specialization
             && data.actor.items.some((i: Item) => i.type === 'specialization' && i.name === stats.specialization);
-        const ownsSkill = !!stats.skill
+        const ownsSkill = !!stats?.skill
             && data.actor.items.some((i: Item) => i.type === 'skill' && i.name === stats.skill);
         if (ownsSpec) {
-            bonusmod += (+getEffectMod('specialization', stats.specialization, data.actor));
+            bonusmod += +getEffectMod('specialization', stats.specialization!, data.actor);
         } else if (ownsSkill) {
-            bonusmod += (+getEffectMod('skill', stats.skill, data.actor));
+            bonusmod += +getEffectMod('skill', stats.skill!, data.actor);
         }
     }
 
-    if (data.subtype === 'vehiclerangedweaponattack') {
-        let vehicleWeapon: Item | undefined;
-        if (isVehicleActor(data.actor)) {
-            if (data.actor.system.embedded_pilot?.value) {
-                vehicleWeapon = data.actor.items.filter((i: Item) => i._id === data.itemId)[0];
-            } else if (data.actor.type === 'vehicle') {
-                vehicleWeapon = (data.actor as any).vehicle_weapons.filter((i: Item) => i._id === data.itemId)[0];
-            } else {
-                vehicleWeapon = (data.actor as any).starship_weapons.filter((i: Item) => i._id === data.itemId)[0];
+    if (item && classified.key === 'action-vehiclerangedweaponattack') {
+        const wsys = item.system as OD6SVehicleWeaponItemSystem;
+        const folded = applyWeaponMods({ damageScore: 0, miscMod, bonusmod }, wsys.mods);
+        miscMod = folded.miscMod;
+        bonusmod = folded.bonusmod;
+    }
+
+    if (classified.type === 'skill' && item) {
+        bonusmod += +getEffectMod('skill', item.name ?? '', data.actor);
+    }
+    if (classified.type === 'specialization' && item) {
+        bonusmod += +getEffectMod('specialization', item.name ?? '', data.actor);
+    }
+
+    if (isCharacterActor(data.actor)) {
+        const c = data.actor.system;
+        if (data.subtype === 'meleeattack') bonusmod += c.melee.mod;
+        if (data.subtype === 'brawlattack') bonusmod += c.brawl.mod;
+        if (data.subtype === 'dodge') bonusmod += c.dodge.mod;
+        if (data.subtype === 'parry') bonusmod += c.parry.mod;
+        if (data.subtype === 'block') bonusmod += c.block.mod;
+    }
+
+    // Ranged-attack bonus: vehicle's ranged.score for vehicle-piloted paths,
+    // actor.system.ranged.mod for personal ranged.
+    const isRangedSubtype = data.subtype === 'rangedattack'
+        || data.subtype === 'vehiclerangedattack'
+        || data.subtype === 'vehiclerangedweaponattack';
+    if (isRangedSubtype) {
+        if (data.subtype && data.subtype.startsWith('vehicle')) {
+            const vehSys = data.actor.system as OD6SVehicleSystem;
+            const charSys = data.actor.system as OD6SCharacterSystem & {
+                vehicle: { ranged?: { score?: number } };
+            };
+            if (vehSys?.embedded_pilot?.value && typeof ((vehSys?.ranged as OD6SScoreField)?.score) !== 'undefined') {
+                bonusmod += +(vehSys.ranged as OD6SScoreField).score;
+            } else if (typeof (charSys?.vehicle?.ranged?.score) !== 'undefined') {
+                bonusmod += +charSys.vehicle.ranged.score;
             }
-        } else if (isCharacterActor(data.actor)) {
-            vehicleWeapon = data.actor.system.vehicle.vehicle_weapons?.filter((i: Item) => i.id === data.itemId)[0];
-        }
-
-        isAttack = true;
-        if (typeof (vehicleWeapon) !== 'undefined') {
-            const vwSys = vehicleWeapon.system as OD6SVehicleWeaponItemSystem;
-            damageScore = vwSys.damage.score;
-            damageType = vwSys.damage.type;
-            ({damageScore, miscMod, bonusmod} = applyWeaponMods(
-                {damageScore, miscMod, bonusmod},
-                vwSys.mods,
-            ));
-            attackerScale = vwSys.scale.score
-                ? vwSys.scale.score
-                : selectVehicleData(data.actor).scale?.score ?? 0;
-        } else if (isCharacterActor(data.actor)) {
-            damageScore = data.damage ?? 0;
-            damageType = data.damage_type ?? '';
-            attackerScale = data.actor.system.vehicle.scale!.score;
-        }
-        damageSource = data.name;
-    }
-
-    if (data.subtype === 'vehicleramattack') {
-        damageType = 'p';
-        damageSource = 'OD6S.COLLISION';
-        isAttack = true;
-        const vehicleData = selectVehicleData(data.actor);
-        const ram = ramAttackContribution(
-            vehicleData.ram?.score ?? 0,
-            vehicleData.ram_damage?.score ?? 0,
-        );
-        if (ram.modifier) damageModifiers.push(ram.modifier);
-        bonusmod += ram.bonusModIncrement;
-    }
-
-    if ((data.type === 'brawlattack' || data.subtype === 'brawlattack') && isCharacterActor(data.actor)) {
-        damageType = 'p';
-        damageScore = data.actor.system.strengthdamage.score;
-        isAttack = true;
-        canStun = true;
-        stunDamageScore = damageScore;
-        stunDamageType = 'p';
-    }
-
-    if (data.type === 'vehicletoughness') {
-        canUseCp = canUseFp = false;
-        data.subtype = data.type;
-        data.type = 'resistance';
-    }
-
-    if (targets.length === 1) {
-        if (!attackerScale && isAttack) {
-            if (data.subtype !== undefined && data.subtype.includes('vehicle')) {
-                attackerScale = selectVehicleData(data.actor).scale?.score ?? 0;
-            } else {
-                attackerScale = data.actor.system.scale.score ?? 0;
-            }
-        }
-
-        if (typeof (targets[0].actor.system.scale.score) === 'undefined') {
-            defenderScale = 0;
         } else {
-            defenderScale = targets[0].actor.system.scale.score;
+            bonusmod += +(data.actor.system.ranged as OD6SModField).mod;
         }
+    }
+
+    // RFC #103: vehicleramattack adds ram.score ONCE (legacy added at lines
+    // 245 and 487 — same condition twice).
+    if (classified.key === 'action-vehicleramattack') {
+        const vehicleData = isCharacterActor(data.actor)
+            ? (data.actor.system.vehicle as { ram?: { score?: number } })
+            : (data.actor.system as { ram?: { score?: number } });
+        if (typeof vehicleData?.ram?.score === 'number') {
+            bonusmod += vehicleData.ram.score;
+        }
+    }
+
+    // ---- attackerScale / scaleMod ----
+    // RFC #104: derive attackerScale from the actor unconditionally for attack
+    // rolls (legacy gated on `targets.length === 1 && isAttack`, leaving
+    // attackerScale=0 for no-target attacks).
+    const isAttackRoll = ATTACK_KEYS.has(classified.key)
+        || (isRangedSubtype && (classified.type === 'weapon' || classified.type === 'starship-weapon' || classified.type === 'vehicle-weapon'))
+        || classified.key === 'action-rangedattack'
+        || classified.key === 'action-vehiclerangedattack'
+        || classified.key === 'action-meleeattack';
+
+    let attackerScale: number;
+    if (typeof bucketAny.attackerScale === 'number' && bucketAny.attackerScale !== 0) {
+        attackerScale = bucketAny.attackerScale;
+    } else if (isAttackRoll) {
+        const isVehicleSubtype = data.subtype !== undefined && data.subtype.includes('vehicle');
+        if (isVehicleSubtype) {
+            attackerScale = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
+                ? +((data.actor.system as { scale?: { score?: number } }).scale?.score ?? 0)
+                : +(((data.actor.system as OD6SCharacterSystem).vehicle?.scale as { score?: number } | undefined)?.score ?? 0);
+        } else {
+            attackerScale = +(((data.actor.system as { scale?: { score?: number } }).scale?.score) ?? 0);
+        }
+    } else {
+        attackerScale = bucketAny.attackerScale ?? 0;
+    }
+
+    let scaleMod = 0;
+    if (targets.length === 1) {
+        const defenderScale = +((targets[0].actor.system as { scale?: { score?: number } }).scale?.score ?? 0);
         if (attackerScale !== defenderScale) {
             scaleMod = attackerScale - defenderScale;
         }
     }
 
-    if (data.type === 'action') {
-        let skill: Item | undefined;
-        switch (data.subtype) {
-            case 'vehicletoughness':
-                canUseCp = canUseFp = false;
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                data.type = 'resistance';
-                break;
-            case 'attribute':
-                data.score = data.actor.system.attributes[data.attribute!].score;
-                isVisible = !game.settings.get('od6s', 'hide-skill-cards');
-                break;
-            case 'vehiclerangedattack':
-                data.score = data.actor.system.attributes.mec.score;
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                break;
-            case 'vehiclerangedweaponattack':
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                break;
-            case 'vehicleramattack':
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                break;
-            case 'rangedattack':
-                data.score = data.actor.system.attributes.agi.score;
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                break;
-            case 'meleeattack': {
-                skill = data.actor.items.find((i: Item) => i.type === 'skill'
-                    && i.name === game.i18n.localize('OD6S.MELEE_COMBAT'));
-                const resolved = resolveSkillBackedAction({
-                    skill: (skill !== undefined && isSkillItem(skill) && isCharacterActor(data.actor))
-                        ? {score: skill.system.score, attributeKey: skill.system.attribute.toLowerCase()}
-                        : null,
-                    attributes: data.actor.system.attributes,
-                    flatSkills: OD6S.flatSkills,
-                    fallbackAttributeKey: 'agi',
-                });
-                data.score = resolved.score;
-                if (resolved.flatPips !== undefined) flatPips = resolved.flatPips;
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                break;
+    // ---- Range bucketing (orchestrator-side) ----
+    let rangeLabel: string = (typeof bucketAny.range === 'string' ? bucketAny.range : undefined)
+        ?? 'OD6S.RANGE_POINT_BLANK_SHORT';
+    let difficultyLevel: string = bucketAny.difficultylevel
+        ?? data.difficultyLevel
+        ?? (settings.defaultUnknownDifficulty ? 'OD6S.DIFFICULTY_UNKNOWN' : 'OD6S.DIFFICULTY_EASY');
+
+    if (RANGED_BUCKETING_SUBTYPES.has(data.subtype ?? '')) {
+        rangeLabel = 'OD6S.RANGE_SHORT_SHORT';
+        const rangeDifficulty = !!game.settings.get('od6s', 'map_range_to_difficulty');
+        const autoExplosive = !!game.settings.get('od6s', 'auto_explosive');
+        const wantsBucket = (targets.length === 1 || (isExplosive && autoExplosive))
+            && !!data.itemId
+            && typeof data.token !== 'undefined' && data.token !== ''
+            && !!weaponRangeTable;
+        if (wantsBucket) {
+            let distance: number | undefined;
+            if (isExplosive) {
+                distance = item?.getFlag('od6s', 'explosiveRange') as number | undefined;
+            } else {
+                distance = Math.floor(canvas.grid.measurePath([(actorToken as Token).center, targets[0].center]).distance);
             }
-            case 'brawlattack': {
-                skill = data.actor.items.find((i: Item) => i.type === 'skill'
-                    && i.name === game.i18n.localize('OD6S.BRAWL'));
-                const resolved = resolveSkillBackedAction({
-                    skill: (skill !== undefined && isSkillItem(skill) && isCharacterActor(data.actor))
-                        ? {score: skill.system.score, attributeKey: skill.system.attribute.toLowerCase()}
-                        : null,
-                    attributes: data.actor.system.attributes,
-                    flatSkills: OD6S.flatSkills,
-                    fallbackAttributeKey: game.settings.get('od6s', 'brawl_attribute'),
-                });
-                data.score = resolved.score;
-                if (resolved.flatPips !== undefined) flatPips = resolved.flatPips;
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-                break;
-            }
-            case '':
-                if (data.name === game.i18n.localize('OD6S.ENERGY_RESISTANCE') ||
-                    data.name === game.i18n.localize('OD6S.PHYSICAL_RESISTANCE') ||
-                    data.name === game.i18n.localize('OD6S.RESISTANCE_NO_ARMOR')) {
-                    data.type = 'resistance';
-                }
-                isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-        }
-    }
-
-    let rollValues = od6sutilities.getDiceFromScore(data.score);
-
-    const penalties = computePenalties({
-        rollType: data.type,
-        actionItemCount: data.actor.itemTypes.action.length,
-        stunsCurrent: isCharacterActor(data.actor) ? (data.actor.system.stuns.current ?? 0) : 0,
-        woundPenalty: isPenaltyBypassType(data.type) ? 0 : od6sutilities.getWoundPenalty(data.actor),
-    });
-    woundPenalty = penalties.woundPenalty;
-    const actionPenalty = penalties.actionPenalty;
-    const stunnedPenalty = penalties.stunnedPenalty;
-    if (penalties.isBypass) isVisible = true;
-
-    if (data.type === 'funds') {
-        isVisible = !game.settings.get('od6s', 'hide-skill-cards');
-    }
-
-    if (data.score < OD6S.pipsPerDice && !(OD6S.flatSkills && (data.type === 'skill' || data.type === 'specialization'))) {
-        ui.notifications.warn(game.i18n.localize("OD6S.SCORE_TOO_LOW"));
-        if (isExplosive) await cancelAction({ ...data, isExplosive, itemid: data.itemId } as unknown as RollData);
-        return false;
-    }
-
-    if (data.type === 'skill' && data.name === 'Dodge') {
-        data.subtype = 'dodge';
-    }
-
-    if ((data.type === 'skill') || (data.type === 'specialization')) {
-        isVisible = !game.settings.get('od6s', 'hide-skill-cards');
-        attribute = (data.actor.items.filter((i: Item) => i.id === data.itemId)[0].system as OD6SSkillItemSystem).attribute.toLowerCase();
-        if (typeof (attribute) === 'undefined') {
-            attribute = null;
-        } else {
-            if (OD6S.flatSkills) {
-                const attributeValues = od6sutilities.getDiceFromScore(data.actor.system.attributes[attribute].score);
-                if (attributeValues.dice === 0) {
-                    ui.notifications.warn(game.i18n.localize("OD6S.SCORE_TOO_LOW"));
+            if (typeof distance === 'number') {
+                const bucketRange = bucketRangeFromDistance(distance, weaponRangeTable!, rangeDifficulty);
+                if (bucketRange === null) {
+                    if (isExplosive && item) {
+                        const regionId = item.getFlag('od6s', 'explosiveTemplate') as string | undefined;
+                        if (regionId) {
+                            try { await canvas.scene.deleteEmbeddedDocuments('Region', [regionId]); } catch {/* region already gone */}
+                            await item.unsetFlag('od6s', 'explosiveSet');
+                            await item.unsetFlag('od6s', 'explosiveTemplate');
+                            await item.unsetFlag('od6s', 'explosiveRange');
+                        }
+                    }
+                    ui.notifications.warn(game.i18n.localize('OD6S.OUT_OF_RANGE'));
                     return false;
                 }
-                rollValues.dice = (+attributeValues.dice);
-                rollValues.pips = (+attributeValues.pips);
-            }
-        }
-    } else {
-        attribute = null;
-    }
-
-    // See if there are any effects that should add a bonus to a skill roll
-    if (data.type === 'skill') {
-        const skillName = data.actor.items.filter((i: Item) => i.id === data.itemId)[0].name;
-        bonusmod += (+getEffectMod('skill', skillName, data.actor));
-    }
-
-    if (data.type === 'specialization') {
-        const specName = data.actor.items.filter((i: Item) => i.id === data.itemId)[0].name;
-        bonusmod += (+getEffectMod('specialization', specName, data.actor));
-    }
-
-    let fatepointeffect = false;
-
-    if (data.actor.getFlag('od6s', 'fatepointeffect') && canUseFp) {
-        rollValues.dice = (+rollValues.dice) * 2;
-        rollValues.pips = (+rollValues.pips) * 2;
-        fatepointeffect = true;
-    }
-
-    if (data.subtype === 'parry' && data.type === 'weapon') {
-        data.name = data.name + " " + game.i18n.localize('OD6S.PARRY');
-    }
-
-    const canOppose =  ['skill', 'attribute', 'specialization', 'damage', 'resistance', 'toughness'];
-    if (canOppose.includes(data.type)) isOpposable = true;
-    if (data.type === 'action' && canOppose.includes(data.subtype ?? '')) isOpposable = true;
-
-    if (data.type === 'action' &&
-        data.subtype === "meleeattack" &&
-        data.name === game.i18n.localize('OD6S.ACTION_MELEE_ATTACK')) {
-        miscMod += 5;
-        damageScore = (data.actor.system as OD6SCharacterSystem).strengthdamage.score;
-    }
-
-    if (data.subtype === 'rangedattack' ||
-        data.subtype === 'vehiclerangedattack' ||
-        data.subtype === 'vehiclerangedweaponattack') {
-        range = "OD6S.RANGE_SHORT_SHORT";
-
-        const rangeDifficulty = game.settings.get('od6s', 'map_range_to_difficulty');
-        if (targets.length === 1 || (isExplosive && game.settings.get('od6s','auto_explosive'))) {
-            if (data.itemId) {
-                const item = data.actor.items.get(data.itemId);
-                if (typeof (data.token) !== 'undefined' && data.token !== '') {
-                    let distance;
-                    if (isExplosive) {
-                        distance = item?.getFlag('od6s', 'explosiveRange');
-                    } else {
-                        distance = Math.floor(canvas.grid.measurePath([(actorToken as Token).center, targets[0].center]).distance);
-                    }
-                    const rangeConfig = data.range as { short: number; medium: number; long: number };
-                    const bucket = bucketRangeFromDistance(distance, rangeConfig, rangeDifficulty);
-                    if (bucket === null) {
-                        if (isExplosive) {
-                            const regionId = item?.getFlag('od6s', 'explosiveTemplate');
-                            if (regionId) {
-                                const region = canvas.scene.getEmbeddedDocument('Region', regionId);
-                                if (region) {
-                                    await canvas.scene.deleteEmbeddedDocuments('Region', [regionId]);
-                                }
-                                await item?.unsetFlag('od6s', 'explosiveSet');
-                                await item?.unsetFlag('od6s', 'explosiveTemplate');
-                                await item?.unsetFlag('od6s', 'explosiveRange');
-                            }
-                        }
-                        ui.notifications.warn(game.i18n.localize('OD6S.OUT_OF_RANGE'));
-                        return false;
-                    }
-                    range = bucket.range;
-                    if (bucket.difficultyLevel !== null) difficultyLevel = bucket.difficultyLevel;
-                }
-            }
-        }
-
-        if (data.subtype.startsWith('vehicle')) {
-            const vehSys = data.actor.system as OD6SVehicleSystem;
-            const charSys = data.actor.system as OD6SCharacterSystem & { vehicle: { ranged?: { score?: number } } };
-            if (vehSys?.embedded_pilot?.value && typeof ((vehSys?.ranged as OD6SScoreField)?.score) !== 'undefined') {
-                bonusmod += (+(vehSys.ranged as OD6SScoreField).score);
-            } else if (typeof (charSys?.vehicle?.ranged?.score) !== 'undefined') {
-                bonusmod += (+charSys.vehicle.ranged.score);
-            }
-        } else {
-            bonusmod += (+(data.actor.system.ranged as OD6SModField).mod);
-        }
-    }
-
-    if (data.subtype === 'vehicleramattack') {
-        const vehicleData = selectVehicleData(data.actor);
-        if (vehicleData.ram?.score !== undefined) {
-            bonusmod += vehicleData.ram.score;
-        }
-    }
-
-    if (isCharacterActor(data.actor)) {
-        const charSys = data.actor.system;
-        if (data.subtype === 'meleeattack') {
-            bonusmod += charSys.melee.mod;
-        }
-        if (data.subtype === 'brawlattack') {
-            bonusmod += charSys.brawl.mod;
-            canStun = true;
-            damageScore = charSys.strengthdamage.score;
-            stunDamageScore = damageScore;
-            stunDamageType = 'p';
-        }
-        if (data.subtype === 'dodge') bonusmod += charSys.dodge.mod;
-        if (data.subtype === 'parry') bonusmod += charSys.parry.mod;
-        if (data.subtype === 'block') bonusmod += charSys.block.mod;
-    }
-
-    if (OD6S.flatSkills) {
-        bonusdice = { dice: 0, pips: bonusmod };
-    } else {
-        bonusdice = od6sutilities.getDiceFromScore(bonusmod);
-    }
-    const split = splitBonusForPenalty(bonusdice.dice, bonusdice.pips, OD6S.pipsPerDice);
-    bonusdice = { dice: split.bonusDice, pips: split.bonusPips };
-    penaltydice = split.penaltyDice;
-
-    if (OD6S.flatSkills) {
-        bonusdice.pips += flatSkillBonusPips(flatPips, data.score, data.type);
-    }
-
-    if (isAttack) {
-        isVisible = !game.settings.get('od6s', 'hide-combat-cards');
-        if (game.settings.get('od6s', 'dice_for_scale')) {
-            if (scaleMod < 0) {
-                data.score = data.score + (scaleMod * -1);
-                scaleDice = od6sutilities.getDiceFromScore(scaleMod).dice * -1;
-                rollValues.dice = (+rollValues.dice) + (+scaleDice);
+                rangeLabel = bucketRange.range;
+                if (bucketRange.difficultyLevel !== null) difficultyLevel = bucketRange.difficultyLevel;
             }
         }
     }
 
-    if (data.type === 'specialization' || data.type === 'weapon') {
-        if (OD6S.showSkillSpecialization) {
-            const item = data.actor.items.get(data.itemId!);
-            if (typeof (item) !== 'undefined') {
-                if (item.type === 'specialization') {
-                    specSkill = (item.system as OD6SSpecializationItemSystem).skill;
-                } else {
-                    const wsys = item.system as OD6SWeaponItemSystem;
-                    if (data.name === wsys.stats.specialization) {
-                        specSkill = wsys.stats.skill;
-                    }
-                }
-            }
+    // ---- Score adjustments after dispatch: scale / roll_mod / damaged ----
+    let scaleDice = 0;
+    let workingScoreForFinalize = workingScore;
+
+    if (classified.type === 'resistance' && settings.diceForScale) {
+        const sc = data.scale ?? 0;
+        scaleMod = sc;
+        scaleDice = od6sutilities.getDiceFromScore(sc).dice;
+    } else if (isAttackRoll && settings.diceForScale && scaleMod < 0) {
+        // Attacker-smaller: bump score, negative scaleDice flows into otherpenalty.
+        workingScoreForFinalize = workingScore + (scaleMod * -1);
+        scaleDice = od6sutilities.getDiceFromScore(scaleMod).dice * -1;
+    }
+
+    if (data.actor.system.roll_mod !== 0) {
+        workingScoreForFinalize = workingScoreForFinalize + (+data.actor.system.roll_mod);
+    }
+
+    if (classified.type === 'damage' && item) {
+        const wsys = item.system as OD6SWeaponItemSystem | undefined;
+        if (wsys && wsys.damaged > 0) {
+            workingScoreForFinalize -= OD6S.weaponDamage[wsys.damaged].penalty;
         }
     }
 
-    if (data.type === 'damage') {
-        if (data.itemId) {
-            const item = data.actor.items.get(data.itemId);
-            const wsys = item?.system as OD6SWeaponItemSystem | undefined;
-            if (wsys && wsys.damaged > 0) {
-                const score = od6sutilities.getScoreFromDice(rollValues.dice, rollValues.pips) - OD6S.weaponDamage[wsys.damaged].penalty;
-                rollValues.dice = od6sutilities.getDiceFromScore(score).dice;
-                rollValues.pips = od6sutilities.getDiceFromScore(score).pips;
-            }
+    // Flat-skills attribute swap-in for skill / specialization rolls: dice
+    // come from the parent attribute, not the skill score.
+    let flatPips = 0;
+    if (typeof data.flatpips !== 'undefined' && data.flatpips > 0) flatPips = data.flatpips;
+    if (ctx.actionSkillResolved?.flatPips !== undefined) flatPips = ctx.actionSkillResolved.flatPips;
+
+    if ((classified.type === 'skill' || classified.type === 'specialization')
+        && settings.flatSkills
+        && bucketAny.attribute) {
+        const attrKey = bucketAny.attribute as string;
+        const attrScore = +((data.actor.system as { attributes?: Record<string, { score?: number }> })
+            .attributes?.[attrKey]?.score ?? 0);
+        const attrValues = od6sutilities.getDiceFromScore(attrScore);
+        if (attrValues.dice === 0) {
+            ui.notifications.warn(game.i18n.localize("OD6S.SCORE_TOO_LOW"));
+            return false;
         }
+        // Score for finalize becomes attribute score (+ roll_mod once).
+        workingScoreForFinalize = attrScore
+            + (data.actor.system.roll_mod !== 0 ? +data.actor.system.roll_mod : 0);
     }
 
-    let seller = '';
-    if (data.type === 'purchase') {
-        seller = data.seller ?? '';
-        data.type = 'funds';
-        data.subtype = 'purchase';
+    // ---- Penalties ----
+    const penalties = computePenalties({
+        rollType: classified.type,
+        actionItemCount: data.actor.itemTypes.action.length,
+        stunsCurrent: isCharacterActor(data.actor) ? (data.actor.system.stuns?.current ?? 0) : 0,
+        woundPenalty: isPenaltyBypassType(classified.type)
+            ? 0
+            : od6sutilities.getWoundPenalty(data.actor),
+    });
+
+    // ---- bonusdice / bonuspips / otherPenalty ----
+    const bonusBase = settings.flatSkills
+        ? { dice: 0, pips: bonusmod }
+        : od6sutilities.getDiceFromScore(bonusmod);
+    const split = splitBonusForPenalty(bonusBase.dice, bonusBase.pips, settings.pipsPerDice);
+    const bonusDice = split.bonusDice;
+    let bonusPips = split.bonusPips;
+    const otherPenalty = split.penaltyDice;
+
+    if (settings.flatSkills) {
+        bonusPips += flatSkillBonusPips(flatPips, workingScore, classified.type);
     }
 
-    if(data.type === 'resistance') {
-        if (game.settings.get('od6s', 'dice_for_scale')) {
-            if (typeof(data.scale) === 'undefined' || data.scale === null) {
-                data.scale = 0;
-            }
-            scaleMod = data.scale;
-            scaleDice = od6sutilities.getDiceFromScore(data.scale).dice;
-        }
+    // ---- Visibility / FP-CP gating / wild die ----
+    const isVisible = deriveVisibility(classified.key, settings, penalties.isBypass);
+    const { canUseFp, canUseCp } = deriveCanUseFpCp(classified.key, settings);
+    const fatepointEffect = !!data.actor.getFlag('od6s', 'fatepointeffect') && canUseFp;
+    const diceMultiplier = fatepointEffect ? 2 : 1;
+
+    // ---- Misc COMMON inputs ----
+    let name = data.name;
+    if (data.subtype === 'parry' && classified.type === 'weapon') {
+        name = `${data.name} ${game.i18n.localize('OD6S.PARRY')}`;
+    }
+    const vehicleTerrainDifficulty = OD6S.vehicleDifficulty
+        ? 'OD6S.TERRAIN_EASY'
+        : 'OD6S.DIFFICULTY_EASY';
+
+    const wildDie = !!game.settings.get('od6s', 'use_wild_die')
+        && !!(data.actor.system as { use_wild_die?: boolean }).use_wild_die;
+    const showWildDie = !!game.settings.get('od6s', 'use_wild_die');
+
+    // ---- Final bucket overrides for orchestrator-derived fields ----
+    const bucketWithOverrides: typeof bucket = { ...bucket };
+    if ((bucketAny.attackerScale !== undefined) || isAttackRoll) {
+        (bucketWithOverrides as Partial<RollData>).attackerScale = attackerScale;
+    }
+    if (RANGED_BUCKETING_SUBTYPES.has(data.subtype ?? '') || bucketAny.range !== undefined) {
+        (bucketWithOverrides as Partial<RollData>).range = rangeLabel;
+    }
+    if (bucketAny.difficultylevel !== undefined) {
+        (bucketWithOverrides as Partial<RollData>).difficultylevel = difficultyLevel;
+    }
+    if (bucketAny.scaledice !== undefined || classified.type === 'resistance' || isAttackRoll) {
+        (bucketWithOverrides as Partial<RollData>).scaledice = scaleDice;
+    }
+    if (classified.key === 'purchase') {
+        (bucketWithOverrides as Partial<RollData>).seller = data.seller ?? '';
     }
 
-    if(data.actor.system.roll_mod !== 0) {
-        data.score = (+data.score) + (+data.actor.system.roll_mod);
-        rollValues = od6sutilities.getDiceFromScore(data.score);
-    }
-
-    return {
-        label: data.name,
-        title: data.name,
-        dice: rollValues.dice,
-        pips: rollValues.pips,
-        specSkill: specSkill,
-        originaldice: rollValues.dice,
-        originalpips: rollValues.pips,
-        score: data.score,
-        wilddie: game.settings.get('od6s', 'use_wild_die') && data.actor.system.use_wild_die,
-        showWildDie: game.settings.get('od6s', 'use_wild_die'),
-        canusefp: canUseFp,
-        fatepoint: Boolean(false),
-        fatepointeffect: fatepointeffect,
-        characterpoints: 0,
-        canusecp: canUseCp,
-        contact: false,
-        cpcost: 0,
-        cpcostcolor: "black",
-        bonusdice: bonusdice.dice,
-        bonuspips: bonusdice.pips,
-        isvisible: isVisible,
-        isknown: false,
-        isExplosive: isExplosive,
-        type: data.type,
-        subtype: data.subtype ?? '',
-        attribute: attribute,
-        actor: data.actor,
-        token: actorToken as Token | undefined,
-        actionpenalty: actionPenalty,
-        woundpenalty: woundPenalty,
-        stunnedpenalty: stunnedPenalty,
-        otherpenalty: penaltydice,
-        multishot: false,
-        shots: 1,
-        fulldefense: false,
-        itemid: data.itemId ?? '',
-        targets: targets,
-        target: targets[0],
-        timer: 0,
-        damagetype: damageType,
-        damagescore: damageScore,
-        stundamagetype: stunDamageType,
-        stundamagescore: stunDamageScore,
-        damagemodifiers: damageModifiers,
-        difficultylevel: difficultyLevel,
-        isoppasable: isOpposable,
-        difficulty: difficulty,
-        scaledice: scaleDice,
-        seller: seller,
-        vehicle: vehicle,
-        vehiclespeed: 'cruise',
-        vehiclecollisiontype: 't_bone',
-        vehicleterraindifficulty: vehicleTerrainDifficulty,
-        source: damageSource,
-        range: range,
-        template: "systems/od6s/templates/roll.html",
-        only_stun: onlyStun,
-        can_stun: canStun,
-        stun: onlyStun,
-        attackerScale: attackerScale,
-        modifiers: {
-            range: range,
-            attackoption: 'OD6S.ATTACK_STANDARD',
-            calledshot: '',
-            cover: '',
-            coverlight: '',
-            coversmoke: '',
-            miscmod: miscMod,
-            scalemod: scaleMod
-        }
-    };
+    return runFinalize({
+        classified,
+        score: workingScoreForFinalize,
+        name,
+        itemId: data.itemId ?? '',
+        difficulty: data.difficulty ?? 0,
+        difficultyLevel,
+        isExplosive,
+        isVisible,
+        fatepointEffect,
+        canUseFp,
+        canUseCp,
+        wildDie,
+        showWildDie,
+        penalties,
+        otherPenalty,
+        bonusDice,
+        bonusPips,
+        miscMod,
+        scaleMod,
+        range: rangeLabel,
+        vehicleTerrainDifficulty,
+        pipsPerDice: settings.pipsPerDice,
+        diceMultiplier,
+        actorRef: data.actor,
+        tokenRef: actorToken,
+        targetsRef: targets,
+        targetRef: targets[0],
+        bucket: bucketWithOverrides,
+    });
 }

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -102,11 +102,6 @@ export const ROLL_TYPE_FIELDS = {
     'funds': [],
     'purchase': ['seller'],
 
-    'brawlattack': [
-        'damagetype', 'damagescore', 'stundamagetype', 'stundamagescore',
-        'can_stun', 'attackerScale',
-    ],
-
     // Top-level attribute roll (Actor.rollAttribute). Flows through
     // setupRollData with no type-specific writes; score/dice come from input.
     'attribute': [],
@@ -156,9 +151,6 @@ export const ROLL_TYPE_FIELDS = {
 //                                     roll itself has a rules basis or is purely a status check
 // funds                             : funds-determination, equipment-purchase-mechanics
 // purchase                          : funds-determination, equipment-purchase-mechanics
-// brawlattack                       : attacking-and-defending, step-3-determining-damage,
-//                                     determining-strength-damage  ?  legacy top-level alias of
-//                                     action-brawlattack — candidate for removal if no caller routes here
 // attribute                         : skill-check, attribute-dice-distribution
 //
 // ---- Behaviors in roll-setup.ts with no apparent rules backing ----

--- a/tests/domain/roll-handlers-action.test.ts
+++ b/tests/domain/roll-handlers-action.test.ts
@@ -52,7 +52,7 @@ import type {
     ItemView,
     RollSettingsView,
 } from '../../src/module/apps/roll-helpers/roll-handlers';
-import type { ActionSkill } from '../../src/module/apps/roll-helpers/action-math';
+import type { ActionResolution } from '../../src/module/apps/roll-helpers/action-math';
 import type { RollTypeKey } from '../../src/module/apps/roll-helpers/roll-data';
 
 type ActionSubtype =
@@ -206,34 +206,34 @@ describe('action-vehiclerangedattack handler', () => {
 });
 
 describe('action-meleeattack handler', () => {
-    it('uses skill-backed score resolution and sets damagescore to actor strength damage (no +5 — see RFC #100)', () => {
-        const skill: ActionSkill = { score: 6, attributeKey: 'str' };
+    it('reads pre-resolved score from ctx.actionSkillResolved and sets damagescore to actor strength damage (no +5 — see RFC #100)', () => {
+        const resolved: ActionResolution = { score: 15 }; // 6 (skill) + 9 (str)
         const out = HANDLERS['action-meleeattack'](
             makeInput('meleeattack', { name: 'OD6S.ACTION_MELEE_ATTACK' }),
-            makeCtx({ actor: characterWithAttrs(), actionSkill: skill }),
+            makeCtx({ actor: characterWithAttrs(), actionSkillResolved: resolved }),
         );
-        expect(out.score).toBe(15); // 6 (skill) + 9 (str)
+        expect(out.score).toBe(15);
         expect(out.damagescore).toBe(6); // actor.strengthDamage
         expect(out.attackerScale).toBe(0);
     });
 
-    it('falls back to AGI (rules-fixed for melee combat) when no skill item is present', () => {
+    it('defaults score to 0 when no resolution is supplied (orchestrator owns the AGI fallback)', () => {
         const out = HANDLERS['action-meleeattack'](
             makeInput('meleeattack'),
-            makeCtx({ actor: characterWithAttrs(), actionSkill: null }),
+            makeCtx({ actor: characterWithAttrs(), actionSkillResolved: null }),
         );
-        expect(out.score).toBe(12); // agi
+        expect(out.score).toBe(0);
     });
 });
 
 describe('action-brawlattack handler', () => {
     it('produces physical damage and stun at strength damage with can_stun true', () => {
-        const skill: ActionSkill = { score: 3, attributeKey: 'str' };
+        const resolved: ActionResolution = { score: 12 }; // 3 + 9
         const out = HANDLERS['action-brawlattack'](
             makeInput('brawlattack'),
-            makeCtx({ actor: characterWithAttrs(), actionSkill: skill }),
+            makeCtx({ actor: characterWithAttrs(), actionSkillResolved: resolved }),
         );
-        expect(out.score).toBe(12); // 3 + 9
+        expect(out.score).toBe(12);
         expect(out.damagetype).toBe('p');
         expect(out.damagescore).toBe(6); // strengthDamage
         expect(out.stundamagetype).toBe('p');
@@ -317,5 +317,27 @@ describe('action-vehiclerangedweaponattack handler', () => {
             }),
         );
         expect(out.attackerScale).toBe(3);
+    });
+
+    it('B2: when ctx.item is missing (character-pilot fallback), reads damage/damage_type/name from input and vehicle scale from ctx.vehicleStats', () => {
+        const pilot = characterWithAttrs({ vehicle: { uuid: 'Actor.embedded' } });
+        const out = HANDLERS['action-vehiclerangedweaponattack'](
+            makeInput('vehiclerangedweaponattack', {
+                itemId: 'Item.unresolvable',
+                damage: 15,
+                damage_type: 'e',
+                name: 'Pilot Vehicle Weapon',
+            }),
+            makeCtx({
+                actor: pilot,
+                vehicleStats: { scale: { score: 6 } },
+                // intentionally no item — exercises the fallback branch
+            }),
+        );
+        expect(out.damagetype).toBe('e');
+        expect(out.damagescore).toBe(15);
+        expect(out.source).toBe('Pilot Vehicle Weapon');
+        expect(out.attackerScale).toBe(6);
+        expect(out.vehicle).toBe('Actor.embedded');
     });
 });

--- a/tests/domain/roll-handlers-resource.test.ts
+++ b/tests/domain/roll-handlers-resource.test.ts
@@ -1,23 +1,15 @@
 /**
  * Domain tests — resource / legacy family roll handlers (#98 phase 1).
  *
- * Covers funds, purchase, attribute (top-level), and brawlattack
- * (top-level — documented dead). Buckets are minimal:
- *   funds / attribute        — empty (rules-defined work is on the COMMON
- *                              path: visibility, fp/cp gating, etc.)
- *   purchase                 — `seller` only
- *   brawlattack (top-level)  — UNREACHABLE: classifier accepts it but no
- *                              caller produces it; brawl rolls always wrap
- *                              as action-brawlattack via Actor.rollAction.
- *                              Phase 3 removes the key entirely; for now
- *                              the handler throws to surface any caller
- *                              that resurrects the path.
+ * Covers funds, purchase, and top-level attribute. Buckets are minimal:
+ *   funds / attribute  — empty (rules-defined work is on the COMMON path:
+ *                        visibility, fp/cp gating, etc.)
+ *   purchase           — `seller` only
  *
  * Rules referenced (ids only):
  *   funds       — funds-determination, equipment-purchase-mechanics
  *   purchase    — funds-determination, equipment-purchase-mechanics
  *   attribute   — skill-check, attribute-dice-distribution
- *   brawlattack — n/a (dead path)
  */
 
 import { describe, expect, it } from 'vitest';
@@ -51,7 +43,7 @@ function makeCtx(settings?: Partial<RollSettingsView>): HandlerContext {
     };
 }
 
-function makeInput(key: 'funds' | 'purchase' | 'attribute' | 'brawlattack', extras: Partial<HandlerInput> = {}): HandlerInput {
+function makeInput(key: 'funds' | 'purchase' | 'attribute', extras: Partial<HandlerInput> = {}): HandlerInput {
     const type = key === 'purchase' ? 'funds' : key;
     const subtype = key === 'purchase' ? 'purchase' : '';
     return {
@@ -96,10 +88,3 @@ describe('attribute handler', () => {
     });
 });
 
-describe('brawlattack handler (top-level — documented dead)', () => {
-    it('throws — top-level brawlattack is unreachable; rolls go through action-brawlattack', () => {
-        expect(() => HANDLERS['brawlattack'](makeInput('brawlattack'), makeCtx())).toThrow(
-            /unreachable|dead|action-brawlattack/i,
-        );
-    });
-});


### PR DESCRIPTION
## Summary

- Cuts over `setupRollData` from the legacy 650-line monolith to the handler-dispatch pipeline that's been on main dormant since #101 + #102.
- Folds in RFCs #100, #103, #104 + the Audit-A fatepointeffect timeline fix + the Audit-E `actionSkillResolved` deduplication.
- Removes the top-level `brawlattack` `RollTypeKey` (no caller produces it; classifier accepted it via the dead path the throwing handler guarded).

## Pipeline

\`\`\`
preflight → classifyRoll → adaptContext + pre-resolve(actionSkill, vehicleStats)
         → HANDLERS[key]   → score gate (with explosive cleanup)
         → bonusmod (14 sites) / miscMod / scaleMod
         → range bucketing for ranged subtypes (with explosive cleanup on out-of-range)
         → roll_mod / damaged-weapon penalty / flat-skills attribute swap / fatepointeffect
         → runFinalize
\`\`\`

`setupRollData` drops 654 → 552 lines. Rules math lives in the typed handler buckets and the COMMON assembler; the orchestrator coordinates the boundary work.

## Behavioral changes (intentional)

| Issue | Before | After |
| --- | --- | --- |
| RFC #100 | +5 melee magic constant on `action.subtype='meleeattack'` + `name=OD6S.ACTION_MELEE_ATTACK` | Constant deleted (no rules backing; community + author confirmed). |
| RFC #103 | `vehicleramattack` added `ram.score` to bonusmod twice (lines 245 + 487 of legacy) | Added once. |
| RFC #104 | `attackerScale` derived from actor only when `targets.length === 1 && isAttack` — left at 0 for no-target attacks | Derived from actor unconditionally on attack rolls. |
| Audit A | fatepointeffect doubled rollValues post-conversion; `roll_mod` and damaged-weapon re-derives could overwrite the doubling | Doubling routed via `FinalizeInput.diceMultiplier`; finalize multiplies AFTER the `score → dice` conversion so adjustments compose. |
| flat-skills + roll_mod | Latent: legacy applied roll_mod after the flat-skills attribute swap, silently overwriting it | New code applies roll_mod within the swapped score so both effects compose. |

## Refactors

- `FinalizeInput`: replaces `bonusmod` with precomputed `bonusDice` / `bonusPips`. Orchestrator owns `splitBonusForPenalty` + `flatSkillBonusPips`; finalize is a passive forwarder for these.
- `HandlerContext.actionSkill` → `actionSkillResolved` (`ActionResolution | null`). Orchestrator runs `resolveSkillBackedAction` once at the boundary so `flatPips` is reusable for COMMON-side bonusdice without a second call inside the handler.
- `actionVehicleRangedWeaponAttackHandler`: B2 fallback — reads `input.damage` / `damage_type` / `name` when `ctx.item` is missing, preserving the `crew-vehicle.ts` character-pilot path.
- 3e dead-code: top-level `brawlattack` `RollTypeKey` + throwing dead-path handler + ROLL_TYPE_FIELDS bucket + 2 referencing tests removed. `Actor.rollAction` wraps brawl as `{type:'action', subtype:'brawlattack'}` which routes to `action-brawlattack`.

## Test plan

- [x] `pnpm run check` — typecheck + 314 unit + 303 domain tests + lint (0 errors / 711 warnings, under 720 cap)
- [x] `pnpm run build` — esbuild bundle + CSS + packs + translations + icons all green
- [ ] Smoke (`pnpm run test:smoke`) against a live Foundry world — local before merge:
  - [ ] Melee weapon attack from character sheet (parry suffix, in-range / out-of-range)
  - [ ] Ranged weapon attack with auto-explosive on out-of-range (region cleanup)
  - [ ] Brawl attack with FP-in-effect (verify diceMultiplier doubling holds through roll_mod / damaged)
  - [ ] Vehicle ram attack (single ram.score increment — RFC #103)
  - [ ] No-target ranged attack (attackerScale set, not 0 — RFC #104)
  - [ ] Vehicle weapon attack from character pilot (B2 fallback path)
  - [ ] Skill / specialization in flat-skills mode + roll_mod (latent fix)

Closes #98. Closes #100. Closes #103. Closes #104.