### PR TITLE
refactor(actor-sheet): #83 phase 2 — extract roll + inventory-transfer helpers

### DIFF
--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const foundry: any;
-import {od6sroll} from "../apps/roll";
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import OD6SCreateCharacter from "../apps/character-creation";
@@ -27,6 +26,11 @@ import {
     prepareCharacterItems, prepareVehicleItems,
     prepareStarshipItems, prepareContainerItems,
 } from "./sheet-helpers/prepare-items";
+import {
+    rollAvailableAction, rollAvailableVehicleAction,
+    rollBodyPoints, rollPurchase as rollPurchaseHelper,
+} from "./sheet-helpers/rolls";
+import {onPurchase, onTransfer} from "./sheet-helpers/inventory-transfer";
 
 
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
@@ -384,109 +388,15 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
 
     /* -------------------------------------------- */
-    /*  Roll Methods                                 */
+    /*  Roll Methods (delegates)                     */
     /* -------------------------------------------- */
 
     async _rollAvailableVehicleAction(ev: any) {
-        const rollData: any = {score: 0, scale: 0};
-        const data = ev.currentTarget.dataset;
-        const actorData = this.document.system;
-
-        if (data.rollable !== "true") return;
-
-        if (["vehicleramattack", "vehiclemaneuver", "vehicledodge"].includes(data.type)) {
-            rollData.score = od6sutilities.getScoreFromSkill(this.document,
-                    actorData.vehicle.specialization.value,
-                    actorData.vehicle.skill.value, OD6S.vehicle_actions[data.id].base)
-                + actorData.vehicle.maneuverability.score;
-        } else if (data.type === "vehiclesensors") {
-            rollData.score = +(od6sutilities.getScoreFromSkill(this.document, "",
-                actorData.vehicle.sensors.skill, OD6S.vehicle_actions[data.id].base)) + (+data.score);
-        } else if (data.type === "vehicleshields") {
-            rollData.score = od6sutilities.getScoreFromSkill(this.document, "",
-                actorData.vehicle.shields.skill.value, OD6S.vehicle_actions[data.id].base);
-        } else {
-            const item = actorData.vehicle.vehicle_weapons.find((i: any) => i.id === data.id);
-            if (item !== null && typeof item !== "undefined") {
-                rollData.score = od6sutilities.getScoreFromSkill(this.document, item.system.specialization.value,
-                    game.i18n.localize(item.system.skill.value), item.system.attribute.value);
-                rollData.score += item.system.fire_control.score;
-                rollData.scale = item.system.scale.score;
-                rollData.damage = item.system.damage.score;
-                rollData.damage_type = item.system.damage.type;
-            }
-        }
-
-        if (!rollData.scale) rollData.scale = actorData.vehicle.scale.score;
-        rollData.name = game.i18n.localize(data.name);
-        rollData.type = "action";
-        rollData.actor = this.document;
-        rollData.subtype = data.type;
-        await od6sroll._onRollDialog(rollData);
+        return rollAvailableVehicleAction(this, ev);
     }
 
     async _rollAvailableAction(ev: any) {
-        const rollData: any = {token: this.token};
-        const data = ev.currentTarget.dataset;
-        let name = game.i18n.localize(data.name);
-        let flatPips = 0;
-
-        if (data.rollable !== "true") return;
-        if (data.id !== "") {
-            const item = this.document.items.find((i: any) => i.id === data.id);
-            if (item !== null && typeof item !== "undefined") {
-                return await item.roll(data.type === "parry");
-            }
-        }
-
-        if (["dodge", "parry", "block"].includes(data.type)) {
-            switch (data.type) {
-                case "dodge": name = OD6S.actions.dodge.skill; break;
-                case "parry": name = OD6S.actions.parry.skill; break;
-                case "block": name = OD6S.actions.block.skill; break;
-            }
-            name = game.i18n.localize(name);
-        }
-
-        if (data.type === "attribute") {
-            name = data.name;
-            rollData.attribute = data.id;
-        } else {
-            let skill = this.document.items.find((i: any) => i.type === "skill" && i.name === name);
-            if (skill !== null && typeof skill !== "undefined") {
-                if (OD6S.flatSkills) {
-                    rollData.score = (+this.document.system.attributes[skill.system.attribute.toLowerCase()].score);
-                    flatPips = (+skill.system.score);
-                } else {
-                    rollData.score = (+skill.system.score)
-                        + (+this.document.system.attributes[skill.system.attribute.toLowerCase()].score);
-                }
-            } else {
-                skill = await od6sutilities._getItemFromWorld(name);
-                if (skill !== null && typeof skill !== "undefined") {
-                    rollData.score = (+this.document.system.attributes[skill.system.attribute.toLowerCase()].score);
-                } else {
-                    skill = await od6sutilities._getItemFromCompendium(name);
-                    if (skill !== null && typeof skill !== "undefined") {
-                        rollData.score = (+this.document.system.attributes[skill.system.attribute.toLowerCase()].score);
-                    } else {
-                        for (const a in OD6S.actions) {
-                            if (OD6S.actions[a].type === ev.currentTarget.dataset.type) {
-                                rollData.score = (+this.document.system.attributes[OD6S.actions[a].base].score);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (flatPips > 0) rollData.flatpips = flatPips;
-        rollData.name = name;
-        rollData.type = "action";
-        rollData.actor = this.document;
-        rollData.subtype = data.type;
-        await od6sroll._onRollDialog(rollData);
+        return rollAvailableAction(this, ev);
     }
 
     async _editEffect(ev: any) {
@@ -542,110 +452,22 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
 
     /* -------------------------------------------- */
-    /*  Rolling                                      */
+    /*  Rolling & Inventory (delegates)              */
     /* -------------------------------------------- */
 
     async _rollBodyPoints() {
-        const strDice = od6sutilities.getDiceFromScore(this.document.system.attributes.str.score
-            + this.document.system.attributes.str.mod);
-        let rollString;
-        if (game.settings.get("od6s", "use_wild_die")) {
-            if (strDice.dice < 2) rollString = "1dw";
-            else rollString = (+strDice.dice - 1) + "d6+1dw";
-        } else {
-            rollString = strDice.dice + "d6";
-        }
-        rollString += "+" + (+strDice.pips + 20);
-
-        const label = game.i18n.localize("OD6S.ROLLING") + " " + game.i18n.localize(OD6S.bodyPointsName);
-
-        let rollMode: any = CONST.DICE_ROLL_MODES.PUBLIC;
-        if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
-            rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
-        }
-        const roll = await new Roll(rollString).evaluate();
-        await roll.toMessage({
-            speaker: ChatMessage.getSpeaker(),
-            flavor: label,
-        }, {rollMode, create: true});
-
-        await this.document.update({"system.wounds.body_points.max": roll.total});
+        return rollBodyPoints(this);
     }
 
     async rollPurchase(ev: any, buyerId: any) {
-        const item = this.document.items.get(ev.currentTarget.dataset.itemId);
-        if (typeof item === "undefined") return ui.notifications.warn(game.i18n.localize("OD6S.ITEM_NOT_FOUND"));
-        const data: any = {
-            name: game.i18n.localize("OD6S.PURCHASE") + " " + item.name,
-            itemId: item.id,
-            actor: (game as any).actors.get(buyerId),
-            seller: this.document.id,
-            type: "purchase",
-            difficultyLevel: OD6S.difficultyShort[item.system.price],
-        };
-        data.score = data.actor.system.funds.score;
-        await od6sroll._onRollDialog(data);
+        return rollPurchaseHelper(this, ev, buyerId);
     }
 
     async _onPurchase(itemId: any, buyerId: any) {
-        const seller = this.document;
-        const buyer = (game as any).actors.get(buyerId);
-        const item = seller.items.get(itemId);
-
-        if (OD6S.cost === "1") {
-            if ((+buyer!.system.credits.value) < (+item!.system.cost)) {
-                ui.notifications.warn(game.i18n.localize("OD6S.WARN_NOT_ENOUGH_CURRENCY"));
-                return;
-            }
-            await buyer!.update({"system.credits.value": (+buyer!.system.credits.value) - (+item!.system.cost)});
-        }
-
-        const boughtItem = JSON.parse(JSON.stringify(item));
-        boughtItem.system.quantity = 1;
-        if (item!.type === "gear") {
-            const hasItem = buyer!.items.filter((i: any) => i.name === item!.name);
-            if (hasItem.length > 0) {
-                await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
-            } else {
-                await buyer!.createEmbeddedDocuments("Item", [boughtItem]);
-            }
-        } else {
-            await buyer!.createEmbeddedDocuments("Item", [boughtItem]);
-        }
-
-        const sellerUpdate: any = {};
-        if (item!.system.quantity > 0) sellerUpdate["system.quantity"] = (+item!.system.quantity) - 1;
-        await item!.update(sellerUpdate);
+        return onPurchase(this, itemId, buyerId);
     }
 
     async _onTransfer(itemId: any, senderId: any, recId: any) {
-        const sender = (game as any).actors.get(senderId);
-        const receiver = (game as any).actors.get(recId);
-        const item = sender!.items.get(itemId);
-
-        const recItem = JSON.parse(JSON.stringify(item));
-        recItem.quantity = 1;
-        if (item!.type === "gear") {
-            const hasItem = receiver!.items.filter((i: any) => i.name === item!.name);
-            if (hasItem.length > 0) {
-                await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
-            } else {
-                await receiver!.createEmbeddedDocuments("Item", [recItem]);
-            }
-
-            const senderUpdate: any = {};
-            if (item!.system.quantity > 0) senderUpdate["system.quantity"] = (+item!.system.quantity) - 1;
-            await item!.update(senderUpdate);
-
-            if ((sender!.type === "character" || sender!.type === "container")
-                && item!.system.quantity === 0) {
-                await sender!.deleteEmbeddedDocuments("Item", [item!.id]);
-            }
-        } else {
-            await receiver!.createEmbeddedDocuments("Item", [recItem]);
-            await sender!.deleteEmbeddedDocuments("Item", [item!.id]);
-        }
-
-        await this.render();
+        return onTransfer(this, itemId, senderId, recId);
     }
 }

--- a/src/module/actor/sheet-helpers/inventory-transfer.ts
+++ b/src/module/actor/sheet-helpers/inventory-transfer.ts
@@ -1,0 +1,82 @@
+/**
+ * Cross-actor item moves invoked from the actor sheet:
+ *
+ *   - `onPurchase` — fires after a purchase roll succeeds (called from
+ *     `roll-execute`, `chat-log-listeners`, `handle-wild-die`, and the
+ *     inventory listener for the cost=0 / `OD6S.cost === '0'` shortcut).
+ *     Deducts credits when the credit-check setting is on, then copies the
+ *     item from seller to buyer (stacking gear by name) and decrements the
+ *     seller's quantity.
+ *
+ *   - `onTransfer` — straight item move between two actors. Same gear-
+ *     stacking rule as `onPurchase`; for non-gear types the source doc
+ *     is deleted after the receiver is given a copy. Also auto-cleans
+ *     zero-quantity gear off character/container sources.
+ */
+
+import OD6S from "../../config/config-od6s";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sheet = any;
+
+export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promise<void> {
+    const seller = sheet.document;
+    const buyer = (game as any).actors.get(buyerId);
+    const item = seller.items.get(itemId);
+
+    if (OD6S.cost === "1") {
+        if ((+buyer!.system.credits.value) < (+item!.system.cost)) {
+            ui.notifications.warn(game.i18n.localize("OD6S.WARN_NOT_ENOUGH_CURRENCY"));
+            return;
+        }
+        await buyer!.update({"system.credits.value": (+buyer!.system.credits.value) - (+item!.system.cost)});
+    }
+
+    const boughtItem = JSON.parse(JSON.stringify(item));
+    boughtItem.system.quantity = 1;
+    if (item!.type === "gear") {
+        const hasItem = buyer!.items.filter((i: any) => i.name === item!.name);
+        if (hasItem.length > 0) {
+            await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
+        } else {
+            await buyer!.createEmbeddedDocuments("Item", [boughtItem]);
+        }
+    } else {
+        await buyer!.createEmbeddedDocuments("Item", [boughtItem]);
+    }
+
+    const sellerUpdate: any = {};
+    if (item!.system.quantity > 0) sellerUpdate["system.quantity"] = (+item!.system.quantity) - 1;
+    await item!.update(sellerUpdate);
+}
+
+export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId: any): Promise<void> {
+    const sender = (game as any).actors.get(senderId);
+    const receiver = (game as any).actors.get(recId);
+    const item = sender!.items.get(itemId);
+
+    const recItem = JSON.parse(JSON.stringify(item));
+    recItem.quantity = 1;
+    if (item!.type === "gear") {
+        const hasItem = receiver!.items.filter((i: any) => i.name === item!.name);
+        if (hasItem.length > 0) {
+            await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
+        } else {
+            await receiver!.createEmbeddedDocuments("Item", [recItem]);
+        }
+
+        const senderUpdate: any = {};
+        if (item!.system.quantity > 0) senderUpdate["system.quantity"] = (+item!.system.quantity) - 1;
+        await item!.update(senderUpdate);
+
+        if ((sender!.type === "character" || sender!.type === "container")
+            && item!.system.quantity === 0) {
+            await sender!.deleteEmbeddedDocuments("Item", [item!.id]);
+        }
+    } else {
+        await receiver!.createEmbeddedDocuments("Item", [recItem]);
+        await sender!.deleteEmbeddedDocuments("Item", [item!.id]);
+    }
+
+    await sheet.render();
+}

--- a/src/module/actor/sheet-helpers/inventory-transfer.ts
+++ b/src/module/actor/sheet-helpers/inventory-transfer.ts
@@ -1,12 +1,16 @@
 /**
  * Cross-actor item moves invoked from the actor sheet:
  *
- *   - `onPurchase` — fires after a purchase roll succeeds (called from
- *     `roll-execute`, `chat-log-listeners`, `handle-wild-die`, and the
- *     inventory listener for the cost=0 / `OD6S.cost === '0'` shortcut).
- *     Deducts credits when the credit-check setting is on, then copies the
- *     item from seller to buyer (stacking gear by name) and decrements the
- *     seller's quantity.
+ *   - `onPurchase` — finalize a purchase. Two entry paths:
+ *     1. After a purchase roll resolves: chat-card / wild-die / difficulty-
+ *        edit handlers call `seller.sheet._onPurchase(...)` to commit the
+ *        sale (this is the path used when `OD6S.cost === '0'`, i.e. the
+ *        funds-based purchase-by-roll system).
+ *     2. Direct purchase without a roll: the inventory listener calls
+ *        `_onPurchase` immediately when `OD6S.cost !== '0'` (credit-based
+ *        system; `OD6S.cost === '1'` additionally deducts buyer credits).
+ *     Either way, the helper copies the item from seller to buyer
+ *     (stacking same-name gear) and decrements the seller's quantity.
  *
  *   - `onTransfer` — straight item move between two actors. Same gear-
  *     stacking rule as `onPurchase`; for non-gear types the source doc
@@ -24,18 +28,31 @@ export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promi
     const buyer = (game as any).actors.get(buyerId);
     const item = seller.items.get(itemId);
 
+    // The post-roll entry paths (chat-card, wild-die, difficulty-edit) can
+    // resolve much later than the roll itself; the seller may have removed
+    // the stock between roll and resolve. Fail with the same not-found
+    // warning `rollPurchase` uses rather than crashing on the next deref.
+    if (typeof item === "undefined") {
+        ui.notifications.warn(game.i18n.localize("OD6S.ITEM_NOT_FOUND"));
+        return;
+    }
+
     if (OD6S.cost === "1") {
-        if ((+buyer!.system.credits.value) < (+item!.system.cost)) {
+        if ((+buyer!.system.credits.value) < (+item.system.cost)) {
             ui.notifications.warn(game.i18n.localize("OD6S.WARN_NOT_ENOUGH_CURRENCY"));
             return;
         }
-        await buyer!.update({"system.credits.value": (+buyer!.system.credits.value) - (+item!.system.cost)});
+        await buyer!.update({"system.credits.value": (+buyer!.system.credits.value) - (+item.system.cost)});
     }
 
     const boughtItem = JSON.parse(JSON.stringify(item));
     boughtItem.system.quantity = 1;
-    if (item!.type === "gear") {
-        const hasItem = buyer!.items.filter((i: any) => i.name === item!.name);
+    if (item.type === "gear") {
+        // Gear-only merge: the legacy code matched by name alone, which
+        // would silently bump a non-gear (weapon/armor) of the same name
+        // already on the buyer. Restrict the match to gear so cross-type
+        // collisions create a fresh document instead.
+        const hasItem = buyer!.items.filter((i: any) => i.type === "gear" && i.name === item.name);
         if (hasItem.length > 0) {
             await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
         } else {
@@ -46,8 +63,8 @@ export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promi
     }
 
     const sellerUpdate: any = {};
-    if (item!.system.quantity > 0) sellerUpdate["system.quantity"] = (+item!.system.quantity) - 1;
-    await item!.update(sellerUpdate);
+    if (item.system.quantity > 0) sellerUpdate["system.quantity"] = (+item.system.quantity) - 1;
+    await item.update(sellerUpdate);
 }
 
 export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId: any): Promise<void> {
@@ -56,9 +73,16 @@ export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId
     const item = sender!.items.get(itemId);
 
     const recItem = JSON.parse(JSON.stringify(item));
-    recItem.quantity = 1;
+    // Schema stores quantity under `system`, not at the top level. The
+    // legacy `recItem.quantity = 1` set a stray top-level field while
+    // the inner `system.quantity` retained whatever the sender had —
+    // transferring a stack would create the full original count on the
+    // receiver instead of a single unit. Match `onPurchase`'s pattern.
+    recItem.system.quantity = 1;
     if (item!.type === "gear") {
-        const hasItem = receiver!.items.filter((i: any) => i.name === item!.name);
+        // Gear-only merge — same cross-type collision rationale as in
+        // `onPurchase`.
+        const hasItem = receiver!.items.filter((i: any) => i.type === "gear" && i.name === item!.name);
         if (hasItem.length > 0) {
             await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
         } else {

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -1,0 +1,168 @@
+/**
+ * Roll-dialog dispatchers for the actor sheet. Each function takes the sheet
+ * (instead of being a method on it) so the sheet class can stay focused on
+ * Foundry's V2 lifecycle while these stay testable in isolation. All four
+ * funnel into `od6sroll._onRollDialog` — they assemble its input from the
+ * triggering DOM event plus the actor's current state.
+ */
+
+import {od6sroll} from "../../apps/roll";
+import {od6sutilities} from "../../system/utilities";
+import OD6S from "../../config/config-od6s";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sheet = any;
+
+export async function rollAvailableVehicleAction(sheet: Sheet, ev: any): Promise<void> {
+    const rollData: any = {score: 0, scale: 0};
+    const data = ev.currentTarget.dataset;
+    const actorData = sheet.document.system;
+
+    if (data.rollable !== "true") return;
+
+    if (["vehicleramattack", "vehiclemaneuver", "vehicledodge"].includes(data.type)) {
+        rollData.score = od6sutilities.getScoreFromSkill(sheet.document,
+                actorData.vehicle.specialization.value,
+                actorData.vehicle.skill.value, OD6S.vehicle_actions[data.id].base)
+            + actorData.vehicle.maneuverability.score;
+    } else if (data.type === "vehiclesensors") {
+        rollData.score = +(od6sutilities.getScoreFromSkill(sheet.document, "",
+            actorData.vehicle.sensors.skill, OD6S.vehicle_actions[data.id].base)) + (+data.score);
+    } else if (data.type === "vehicleshields") {
+        rollData.score = od6sutilities.getScoreFromSkill(sheet.document, "",
+            actorData.vehicle.shields.skill.value, OD6S.vehicle_actions[data.id].base);
+    } else {
+        const item = actorData.vehicle.vehicle_weapons.find((i: any) => i.id === data.id);
+        if (item !== null && typeof item !== "undefined") {
+            rollData.score = od6sutilities.getScoreFromSkill(sheet.document, item.system.specialization.value,
+                game.i18n.localize(item.system.skill.value), item.system.attribute.value);
+            rollData.score += item.system.fire_control.score;
+            rollData.scale = item.system.scale.score;
+            rollData.damage = item.system.damage.score;
+            rollData.damage_type = item.system.damage.type;
+        }
+    }
+
+    if (!rollData.scale) rollData.scale = actorData.vehicle.scale.score;
+    rollData.name = game.i18n.localize(data.name);
+    rollData.type = "action";
+    rollData.actor = sheet.document;
+    rollData.subtype = data.type;
+    await od6sroll._onRollDialog(rollData);
+}
+
+export async function rollAvailableAction(sheet: Sheet, ev: any): Promise<void> {
+    const rollData: any = {token: sheet.token};
+    const data = ev.currentTarget.dataset;
+    let name = game.i18n.localize(data.name);
+    let flatPips = 0;
+
+    if (data.rollable !== "true") return;
+    if (data.id !== "") {
+        const item = sheet.document.items.find((i: any) => i.id === data.id);
+        if (item !== null && typeof item !== "undefined") {
+            await item.roll(data.type === "parry");
+            return;
+        }
+    }
+
+    if (["dodge", "parry", "block"].includes(data.type)) {
+        switch (data.type) {
+            case "dodge": name = OD6S.actions.dodge.skill; break;
+            case "parry": name = OD6S.actions.parry.skill; break;
+            case "block": name = OD6S.actions.block.skill; break;
+        }
+        name = game.i18n.localize(name);
+    }
+
+    if (data.type === "attribute") {
+        name = data.name;
+        rollData.attribute = data.id;
+    } else {
+        let skill = sheet.document.items.find((i: any) => i.type === "skill" && i.name === name);
+        if (skill !== null && typeof skill !== "undefined") {
+            if (OD6S.flatSkills) {
+                rollData.score = (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+                flatPips = (+skill.system.score);
+            } else {
+                rollData.score = (+skill.system.score)
+                    + (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+            }
+        } else {
+            skill = await od6sutilities._getItemFromWorld(name);
+            if (skill !== null && typeof skill !== "undefined") {
+                rollData.score = (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+            } else {
+                skill = await od6sutilities._getItemFromCompendium(name);
+                if (skill !== null && typeof skill !== "undefined") {
+                    rollData.score = (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+                } else {
+                    for (const a in OD6S.actions) {
+                        if (OD6S.actions[a].type === ev.currentTarget.dataset.type) {
+                            rollData.score = (+sheet.document.system.attributes[OD6S.actions[a].base].score);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (flatPips > 0) rollData.flatpips = flatPips;
+    rollData.name = name;
+    rollData.type = "action";
+    rollData.actor = sheet.document;
+    rollData.subtype = data.type;
+    await od6sroll._onRollDialog(rollData);
+}
+
+/**
+ * Roll the strength dice plus the bodyPoints +20 base, hide for GMs when
+ * configured, and stash the result on `system.wounds.body_points.max`.
+ * Wild-die handling matches the legacy implementation: 1dw if str < 2,
+ * else (str-1)d6+1dw — when the wild-die setting is on.
+ */
+export async function rollBodyPoints(sheet: Sheet): Promise<void> {
+    const strDice = od6sutilities.getDiceFromScore(sheet.document.system.attributes.str.score
+        + sheet.document.system.attributes.str.mod);
+    let rollString;
+    if (game.settings.get("od6s", "use_wild_die")) {
+        if (strDice.dice < 2) rollString = "1dw";
+        else rollString = (+strDice.dice - 1) + "d6+1dw";
+    } else {
+        rollString = strDice.dice + "d6";
+    }
+    rollString += "+" + (+strDice.pips + 20);
+
+    const label = game.i18n.localize("OD6S.ROLLING") + " " + game.i18n.localize(OD6S.bodyPointsName);
+
+    let rollMode: any = CONST.DICE_ROLL_MODES.PUBLIC;
+    if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
+        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+    }
+    const roll = await new Roll(rollString).evaluate();
+    await roll.toMessage({
+        speaker: ChatMessage.getSpeaker(),
+        flavor: label,
+    }, {rollMode, create: true});
+
+    await sheet.document.update({"system.wounds.body_points.max": roll.total});
+}
+
+export async function rollPurchase(sheet: Sheet, ev: any, buyerId: any): Promise<void> {
+    const item = sheet.document.items.get(ev.currentTarget.dataset.itemId);
+    if (typeof item === "undefined") {
+        ui.notifications.warn(game.i18n.localize("OD6S.ITEM_NOT_FOUND"));
+        return;
+    }
+    const data: any = {
+        name: game.i18n.localize("OD6S.PURCHASE") + " " + item.name,
+        itemId: item.id,
+        actor: (game as any).actors.get(buyerId),
+        seller: sheet.document.id,
+        type: "purchase",
+        difficultyLevel: OD6S.difficultyShort[item.system.price],
+    };
+    data.score = data.actor.system.funds.score;
+    await od6sroll._onRollDialog(data);
+}

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -1,9 +1,17 @@
 /**
- * Roll-dialog dispatchers for the actor sheet. Each function takes the sheet
- * (instead of being a method on it) so the sheet class can stay focused on
- * Foundry's V2 lifecycle while these stay testable in isolation. All four
- * funnel into `od6sroll._onRollDialog` — they assemble its input from the
- * triggering DOM event plus the actor's current state.
+ * Roll dispatchers for the actor sheet. Each function takes the sheet
+ * (instead of being a method on it) so the sheet class can stay focused
+ * on Foundry's V2 lifecycle while these stay testable in isolation.
+ *
+ * Three of the four funnel into `od6sroll._onRollDialog` — assembling its
+ * input from the triggering DOM event plus the actor's current state.
+ * Two exceptions worth noting:
+ *   - `rollAvailableAction` short-circuits via `item.roll(...)` when the
+ *     dataset row references a real owned item, never reaching the dialog
+ *     helper directly (the item path itself opens the dialog further down).
+ *   - `rollBodyPoints` posts a vanilla Foundry `Roll` straight to chat —
+ *     it's a one-shot strength-die roll that updates the actor's body-
+ *     points cap, not a player roll that needs the modifier dialog.
  */
 
 import {od6sroll} from "../../apps/roll";


### PR DESCRIPTION
## Summary
- Phase 2 of #83. Pulls the four roll dispatchers (`rollAvailableVehicleAction`, `rollAvailableAction`, `rollBodyPoints`, `rollPurchase`) and the two cross-actor inventory ops (`onPurchase`, `onTransfer`) out of `actor-sheet.ts` into:
  - `sheet-helpers/rolls.ts` — roll-dialog dispatchers
  - `sheet-helpers/inventory-transfer.ts` — purchase finalize + item transfer
- The six methods on `OD6SActorSheet` keep their public names (each has at least one caller in another module: combat-actions / scores listeners, chat-log-listeners, handle-wild-die, roll-execute, etc.) and now delegate one-line into the helpers, matching the existing `deleteItem` / `addItem` / `_onDrop*` pattern.
- `actor-sheet.ts`: **651 → 473 LOC** (-178). Phase 3 (drag/crew consolidation) closes the gap to the issue's `<~400` acceptance.

## Test plan
- [x] `pnpm run check` — lint, typecheck, 152 unit + 303 domain tests pass.
- [x] Targeted smoke: `tier-2-sheets`, `tier-3-roll`, `tier-3-skill-roll`, `tier-3-weapon-roll`, `tier-3-action-rolls` (brawl, vehicleramattack, vehicletoughness), `tier-3-vehicle` — all 9 specs green.
- No new unit tests; these methods are Foundry-coupled (`Roll`, `ChatMessage`, `od6sroll._onRollDialog`, `ui.notifications`). Existing smoke coverage is the gate.

## Phase status (#83)
- ✅ Phase 1 (PR #107): item categorization + sci-fi default icons + helper rename. 788 → 651 LOC.
- ✅ Phase 2 (this PR): roll + inventory-transfer extraction. 651 → 473 LOC.
- ⏳ Phase 3: drag/crew consolidation (`_dragAvailable*`, `_dragCrewMember`, `_onDragStart`, `linkCrew`, `unlinkCrew`).
- ⏳ Phase 4: `ActorSheetContext` typing — gated on #57 closing augmentation gaps.