### PR TITLE
refactor(actor-sheet): #83 phase 3 — drag handlers + crew helpers

### DIFF
--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -31,6 +31,7 @@ import {
     rollBodyPoints, rollPurchase as rollPurchaseHelper,
 } from "./sheet-helpers/rolls";
 import {onPurchase, onTransfer} from "./sheet-helpers/inventory-transfer";
+import {linkCrew, unlinkCrew} from "./sheet-helpers/crew";
 
 
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
@@ -333,61 +334,6 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
 
     /* -------------------------------------------- */
-    /*  Drag Handlers                                */
-    /* -------------------------------------------- */
-
-    async _dragAvailableCombatAction(event: any) {
-        const data = event.target.children[0].dataset;
-        const transferData = {
-            name: data.name,
-            type: "availableaction",
-            subtype: typeof data.subtype !== "undefined" ? data.subtype : data.type,
-            itemId: data.id,
-            rollable: data.rollable,
-        };
-        return event.dataTransfer.setData("text/plain", JSON.stringify(transferData));
-    }
-
-    async _dragAssignedCombatAction(event: any) {
-        const data = event.target.children[0].dataset;
-        const transferData = {
-            name: data.name,
-            type: "assignedaction",
-            subtype: typeof data.subtype !== "undefined" ? data.subtype : data.type,
-            itemId: data.itemId,
-            rollable: data.rollable,
-            id: data.id,
-        };
-        return event.dataTransfer.setData("text/plain", JSON.stringify(transferData));
-    }
-
-    async _dragCrewMember(event: any) {
-        const data = event.target.dataset;
-        const transferData = {crewUuid: data.crewUuid, type: "crewmember"};
-        return event.dataTransfer.setData("text/plain", JSON.stringify(transferData));
-    }
-
-    _onDragStart(event: any) {
-        const li = event.currentTarget;
-        if ("link" in event.target.dataset) return;
-
-        let dragData;
-        if (li.dataset.itemId) {
-            const item = this.document.items.get(li.dataset.itemId);
-            dragData = item!.toDragData();
-        }
-        if (li.dataset.effectId) {
-            const effect = this.document.effects.get(li.dataset.effectId);
-            dragData = effect!.toDragData();
-        }
-        if (li.dataset.crewUuid) {
-            dragData = li.dataset.crewUuid;
-        }
-        if (!dragData) return;
-        event.dataTransfer.setData("text/plain", JSON.stringify(dragData));
-    }
-
-    /* -------------------------------------------- */
     /*  Roll Methods (delegates)                     */
     /* -------------------------------------------- */
 
@@ -405,50 +351,15 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
 
     /* -------------------------------------------- */
-    /*  Crew Management                              */
+    /*  Crew Management (delegates)                  */
     /* -------------------------------------------- */
 
     async linkCrew(uuid: any) {
-        if (this.document.system.crewmembers.includes(uuid)) return;
-
-        const actor = await od6sutilities.getActorFromUuid(uuid);
-        let result;
-        if (game.user.isGM) {
-            result = await actor!.addToCrew(this.document.uuid);
-        } else {
-            result = await OD6S.socket.executeAsGM("addToVehicle", this.document.uuid, uuid);
-        }
-
-        if (result) {
-            const crew = {uuid: actor!.uuid, name: actor!.name, sort: 0};
-            const update: any = {
-                id: this.document.id,
-                system: {crewmembers: this.document.system.crewmembers},
-            };
-            update.system.crewmembers.push(crew);
-            await this.document.update(update);
-        }
+        return linkCrew(this, uuid);
     }
 
     async unlinkCrew(crewID: any) {
-        const crewMembers = this.document.system.crewmembers.filter((e: any) => e.uuid !== crewID);
-
-        if (await fromUuid(crewID)) {
-            if (game.user.isGM) {
-                const actor = await od6sutilities.getActorFromUuid(crewID);
-                await actor!.removeFromCrew(this.document.uuid);
-            } else {
-                game.socket.emit("system.od6s", {
-                    operation: "removeFromVehicle",
-                    message: {actorId: crewID, vehicleId: this.document.uuid},
-                });
-            }
-        }
-
-        await this.document.update({
-            id: this.document.id,
-            system: {crewmembers: crewMembers},
-        });
+        return unlinkCrew(this, crewID);
     }
 
     /* -------------------------------------------- */

--- a/src/module/actor/sheet-helpers/crew.ts
+++ b/src/module/actor/sheet-helpers/crew.ts
@@ -1,0 +1,65 @@
+/**
+ * Vehicle crew membership management: link an actor to a vehicle's crew or
+ * remove them. Both call paths run from any user; non-GMs bounce the
+ * actor-side mutation through the socket so the GM can apply it.
+ *
+ * Called from:
+ *   - `sheet-helpers/drops.ts` (drag-drop onto a vehicle sheet)
+ *   - `sheet-listeners/vehicle.ts` (the unlink button)
+ *   - `add-crew.ts` (the "add crew" dialog)
+ *   - `actor-helpers/crew-vehicle.ts` (auto re-link when a vehicle changes)
+ *   - `socketlib.ts` (GM-side handler when a non-GM requested unlink)
+ */
+
+import OD6S from "../../config/config-od6s";
+import {od6sutilities} from "../../system/utilities";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sheet = any;
+
+export async function linkCrew(sheet: Sheet, uuid: string): Promise<void> {
+    if (sheet.document.system.crewmembers.includes(uuid)) return;
+
+    const actor = await od6sutilities.getActorFromUuid(uuid);
+    let result;
+    if (game.user.isGM) {
+        result = await actor!.addToCrew(sheet.document.uuid);
+    } else {
+        result = await OD6S.socket.executeAsGM("addToVehicle", sheet.document.uuid, uuid);
+    }
+
+    if (result) {
+        const crew = {uuid: actor!.uuid, name: actor!.name, sort: 0};
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const update: any = {
+            id: sheet.document.id,
+            system: {crewmembers: sheet.document.system.crewmembers},
+        };
+        update.system.crewmembers.push(crew);
+        await sheet.document.update(update);
+    }
+}
+
+export async function unlinkCrew(sheet: Sheet, crewID: string): Promise<void> {
+    const crewMembers = sheet.document.system.crewmembers.filter(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (e: any) => e.uuid !== crewID,
+    );
+
+    if (await fromUuid(crewID)) {
+        if (game.user.isGM) {
+            const actor = await od6sutilities.getActorFromUuid(crewID);
+            await actor!.removeFromCrew(sheet.document.uuid);
+        } else {
+            game.socket.emit("system.od6s", {
+                operation: "removeFromVehicle",
+                message: {actorId: crewID, vehicleId: sheet.document.uuid},
+            });
+        }
+    }
+
+    await sheet.document.update({
+        id: sheet.document.id,
+        system: {crewmembers: crewMembers},
+    });
+}

--- a/src/module/actor/sheet-helpers/crew.ts
+++ b/src/module/actor/sheet-helpers/crew.ts
@@ -18,7 +18,11 @@ import {od6sutilities} from "../../system/utilities";
 type Sheet = any;
 
 export async function linkCrew(sheet: Sheet, uuid: string): Promise<void> {
-    if (sheet.document.system.crewmembers.includes(uuid)) return;
+    // crewmembers is an array of {uuid, name, sort} objects, so .includes(uuid)
+    // would always be false — match by .uuid to actually deduplicate.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const existing: any[] = sheet.document.system.crewmembers;
+    if (existing.some((c) => c.uuid === uuid)) return;
 
     const actor = await od6sutilities.getActorFromUuid(uuid);
     let result;
@@ -30,13 +34,10 @@ export async function linkCrew(sheet: Sheet, uuid: string): Promise<void> {
 
     if (result) {
         const crew = {uuid: actor!.uuid, name: actor!.name, sort: 0};
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const update: any = {
+        await sheet.document.update({
             id: sheet.document.id,
-            system: {crewmembers: sheet.document.system.crewmembers},
-        };
-        update.system.crewmembers.push(crew);
-        await sheet.document.update(update);
+            system: {crewmembers: [...existing, crew]},
+        });
     }
 }
 

--- a/src/module/actor/sheet-listeners/drag.ts
+++ b/src/module/actor/sheet-listeners/drag.ts
@@ -1,15 +1,79 @@
 /**
+ * Drag-source wiring for the actor sheet. Owns both the listener registration
+ * and the per-source `dragstart` payload builders. The handlers are pure
+ * functions of the event (no `this`), so they're attached by reference; the
+ * item/effect/crew variants serialize their own dataset shape into
+ * `dataTransfer`. The generic `onDragStart` covers the common item / effect /
+ * crew-uuid case from `li.dataset` and needs the sheet for document lookups.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sheet = any;
+
+function dragAvailableCombatAction(event: DragEvent): void {
+    const data = ((event.target as HTMLElement).children[0] as HTMLElement)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .dataset as any;
+    const transferData = {
+        name: data.name,
+        type: "availableaction",
+        subtype: typeof data.subtype !== "undefined" ? data.subtype : data.type,
+        itemId: data.id,
+        rollable: data.rollable,
+    };
+    event.dataTransfer!.setData("text/plain", JSON.stringify(transferData));
+}
+
+function dragAssignedCombatAction(event: DragEvent): void {
+    const data = ((event.target as HTMLElement).children[0] as HTMLElement)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .dataset as any;
+    const transferData = {
+        name: data.name,
+        type: "assignedaction",
+        subtype: typeof data.subtype !== "undefined" ? data.subtype : data.type,
+        itemId: data.itemId,
+        rollable: data.rollable,
+        id: data.id,
+    };
+    event.dataTransfer!.setData("text/plain", JSON.stringify(transferData));
+}
+
+function dragCrewMember(event: DragEvent): void {
+    const data = (event.target as HTMLElement).dataset;
+    const transferData = {crewUuid: data.crewUuid, type: "crewmember"};
+    event.dataTransfer!.setData("text/plain", JSON.stringify(transferData));
+}
+
+function onDragStart(sheet: Sheet, event: DragEvent): void {
+    const li = event.currentTarget as HTMLElement;
+    if ("link" in (event.target as HTMLElement).dataset) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let dragData: any;
+    if (li.dataset.itemId) {
+        const item = sheet.document.items.get(li.dataset.itemId);
+        dragData = item!.toDragData();
+    }
+    if (li.dataset.effectId) {
+        const effect = sheet.document.effects.get(li.dataset.effectId);
+        dragData = effect!.toDragData();
+    }
+    if (li.dataset.crewUuid) {
+        dragData = li.dataset.crewUuid;
+    }
+    if (!dragData) return;
+    event.dataTransfer!.setData("text/plain", JSON.stringify(dragData));
+}
+
+/**
  * Register drag event listeners on the actor sheet.
  */
-export function registerDragListeners(
-    html: HTMLElement[],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sheet: any,
-): void {
+export function registerDragListeners(html: HTMLElement[], sheet: Sheet): void {
     const el = html[0];
 
     if (sheet.document.isOwner) {
-        const handler = (ev: DragEvent) => sheet._onDragStart(ev);
+        const handler = (ev: DragEvent) => onDragStart(sheet, ev);
 
         if (sheet.document.type === 'container' && !game.user.isGM) return;
 
@@ -23,17 +87,17 @@ export function registerDragListeners(
         // Combat Actions
         el.querySelectorAll<HTMLElement>('li.availableaction').forEach((li) => {
             li.setAttribute("draggable", "true");
-            li.addEventListener("dragstart", sheet._dragAvailableCombatAction, false);
+            li.addEventListener("dragstart", dragAvailableCombatAction, false);
         });
         el.querySelectorAll<HTMLElement>('li.assignedaction').forEach((li) => {
             li.setAttribute("draggable", "true");
-            li.addEventListener("dragstart", sheet._dragAssignedCombatAction, false);
+            li.addEventListener("dragstart", dragAssignedCombatAction, false);
         });
 
         // Crewmembers
         el.querySelectorAll<HTMLElement>('li.crew-list').forEach((li) => {
             li.setAttribute('draggable', "true");
-            li.addEventListener("dragstart", sheet._dragCrewMember, false);
+            li.addEventListener("dragstart", dragCrewMember, false);
         });
     }
 }


### PR DESCRIPTION
## Summary
- Inline the four drag-source handlers (`_dragAvailableCombatAction`, `_dragAssignedCombatAction`, `_dragCrewMember`, `_onDragStart`) into `sheet-listeners/drag.ts` — no external callers, so no delegate stubs are needed on the sheet.
- Extract `linkCrew` / `unlinkCrew` into a new `sheet-helpers/crew.ts`. The sheet keeps thin delegates because socketlib, drops, the vehicle listener, the add-crew dialog, and `actor-helpers/crew-vehicle.ts` all invoke them via `sheet.linkCrew(...)` / `sheet.unlinkCrew(...)`.
- `actor-sheet.ts`: 473 → 384 LOC, clearing the <400 acceptance target from #83.

Phase 4 (`ActorSheetContext` typing) is still gated on #57 augmentation gaps closing — deferred.

## Test plan
- [x] `pnpm run check` (lint + typecheck + 344 unit + 303 domain tests) green
- [ ] Smoke (manual) — drag/drop items, effects, combat actions, and crew between sheets
- [ ] Smoke (manual) — link/unlink crew on a vehicle as both GM and non-GM