### PR TITLE
refactor(types): #57 augment vehicle system + vehicle-weapon item types

### DIFF
--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -88,10 +88,7 @@ export function isCrewMember(actor: Actor): boolean {
 export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void> {
     if (!isVehicleActor(actor)) return;
     const data: any = {};
-    // OD6SVehicleSystem augmentation lacks the runtime-defined `attribute`,
-    // `skill`, `specialization` fields from vehicle-common.ts schema; keep
-    // a Record fallback until that gap is closed.
-    const sys = actor.system as typeof actor.system & Record<string, any>;
+    const sys = actor.system;
     data.uuid = actor.uuid;
     data.name = actor.name;
     data.type = actor.type;

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -108,9 +108,8 @@ export class OD6SActor extends Actor {
         }
     }
 
-    getVehicleActionScore(action: string) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let vehicle: any;
+    getVehicleActionScore(action: string): number | undefined {
+        let vehicle: OD6SVehicleSystem | OD6SCharacterSystem["vehicle"];
         let pilot: Actor | null;
 
         if (isCharacterActor(this)) {
@@ -124,25 +123,26 @@ export class OD6SActor extends Actor {
         }
 
         if(action === 'maneuver') {
-            let score = vehicle.maneuverability.score;
-            if (pilot) {
+            let score: number = vehicle.maneuverability?.score ?? 0;
+            const attrKey = vehicle.attribute?.value;
+            if (pilot && attrKey) {
                 let found = false;
                 const spec = pilot.items.find(i => i.type === "specialization" &&
-                    i.name === vehicle.specialization.value);
+                    i.name === vehicle.specialization?.value);
                 if (spec !== undefined && isSpecializationItem(spec)) {
-                    score = (+score) + (+spec.system.score) + (pilot.system.attributes[vehicle.attribute.value].score);
+                    score = (+score) + (+spec.system.score) + (pilot.system.attributes[attrKey].score);
                     found = true;
                 }
 
                 if (!found) {
-                    const skill = pilot.items.find(i => i.type === "skill" && i.name === vehicle.skill.value);
+                    const skill = pilot.items.find(i => i.type === "skill" && i.name === vehicle.skill?.value);
                     if (skill !== undefined && isSkillItem(skill)) {
-                        score = (+score) + (+skill.system.score) + (pilot.system.attributes[vehicle.attribute.value].score);
+                        score = (+score) + (+skill.system.score) + (pilot.system.attributes[attrKey].score);
                         found = true;
                     }
                 }
                 if (!found) {
-                    score = (+score) + (pilot.system.attributes[vehicle.attribute.value].score);
+                    score = (+score) + (pilot.system.attributes[attrKey].score);
                 }
             }
             return score;
@@ -158,7 +158,7 @@ export class OD6SActor extends Actor {
     }
 
     getVehicleActionScoreText(action: string) {
-        const dice = od6sutilities.getDiceFromScore(this.getVehicleActionScore(action));
+        const dice = od6sutilities.getDiceFromScore(this.getVehicleActionScore(action) ?? 0);
         if (typeof dice.dice === 'undefined' || isNaN(dice.dice)) return;
         return `${dice.dice}D+${dice.pips}`;
     }

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -125,24 +125,27 @@ export class OD6SActor extends Actor {
         if(action === 'maneuver') {
             let score: number = vehicle.maneuverability?.score ?? 0;
             const attrKey = vehicle.attribute?.value;
+            // Vehicle attribute is user-editable; fall back to 0 when it
+            // doesn't map to one of the pilot's attributes (typo/unset/custom).
+            const attrScore = attrKey ? (pilot?.system.attributes[attrKey]?.score ?? 0) : 0;
             if (pilot && attrKey) {
                 let found = false;
                 const spec = pilot.items.find(i => i.type === "specialization" &&
                     i.name === vehicle.specialization?.value);
                 if (spec !== undefined && isSpecializationItem(spec)) {
-                    score = (+score) + (+spec.system.score) + (pilot.system.attributes[attrKey].score);
+                    score = (+score) + (+spec.system.score) + attrScore;
                     found = true;
                 }
 
                 if (!found) {
                     const skill = pilot.items.find(i => i.type === "skill" && i.name === vehicle.skill?.value);
                     if (skill !== undefined && isSkillItem(skill)) {
-                        score = (+score) + (+skill.system.score) + (pilot.system.attributes[attrKey].score);
+                        score = (+score) + (+skill.system.score) + attrScore;
                         found = true;
                     }
                 }
                 if (!found) {
-                    score = (+score) + (pilot.system.attributes[attrKey].score);
+                    score = (+score) + attrScore;
                 }
             }
             return score;

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -30,7 +30,7 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {cancelAction, getEffectMod} from "./roll-effects";
-import {isCharacterActor} from "../../system/type-guards";
+import {isCharacterActor, isVehicleActor} from "../../system/type-guards";
 import {bucketRangeFromDistance, flatSkillBonusPips, splitBonusForPenalty} from "./difficulty-math";
 import type {IncomingRollData, RollData, ClassifiedRoll, RollTypeKey} from "./roll-data";
 import {classifyRoll} from "./roll-data";
@@ -96,11 +96,7 @@ function resolveItemForDispatch(data: IncomingRollData): Item | undefined {
 
 function resolveVehicleStatsForCharacter(actor: Actor): HandlerContext['vehicleStats'] {
     if (!isCharacterActor(actor)) return undefined;
-    const v = actor.system.vehicle as {
-        scale?: { score: number };
-        ram?: { score: number };
-        ram_damage?: { score: number };
-    } | undefined;
+    const v = actor.system.vehicle;
     if (!v) return undefined;
     return {
         scale: v.scale ? { score: +v.scale.score } : undefined,
@@ -332,8 +328,10 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     // 245 and 487 — same condition twice).
     if (classified.key === 'action-vehicleramattack') {
         const vehicleData = isCharacterActor(data.actor)
-            ? (data.actor.system.vehicle as { ram?: { score?: number } })
-            : (data.actor.system as { ram?: { score?: number } });
+            ? data.actor.system.vehicle
+            : isVehicleActor(data.actor)
+                ? data.actor.system
+                : undefined;
         if (typeof vehicleData?.ram?.score === 'number') {
             bonusmod += vehicleData.ram.score;
         }
@@ -357,7 +355,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         if (isVehicleSubtype) {
             attackerScale = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
                 ? +((data.actor.system as { scale?: { score?: number } }).scale?.score ?? 0)
-                : +(((data.actor.system as OD6SCharacterSystem).vehicle?.scale as { score?: number } | undefined)?.score ?? 0);
+                : +((data.actor.system as OD6SCharacterSystem).vehicle?.scale?.score ?? 0);
         } else {
             attackerScale = +(((data.actor.system as { scale?: { score?: number } }).scale?.score) ?? 0);
         }

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -41,14 +41,12 @@ export class OD6SItem extends Item {
             this.system.score = (+this.system.base) + (+this.system.mod);
         }
         if (isVehicleWeaponItem(this) || isStarshipWeaponItem(this)) {
-            const sys = this.system as OD6SVehicleWeaponItemSystem & {
-                stats: { attribute: string; skill: string; specialization: string };
-                subtype: string;
+            const sys = this.system;
+            sys.stats = {
+                attribute: sys.attribute.value,
+                skill: sys.skill.value,
+                specialization: sys.specialization.value,
             };
-            sys.stats = {} as typeof sys.stats;
-            sys.stats.attribute = sys.attribute.value;
-            sys.stats.skill = sys.skill.value;
-            sys.stats.specialization = sys.specialization.value;
             sys.subtype = 'vehiclerangedweaponattack';
         }
     }

--- a/src/module/system/utilities/skills.ts
+++ b/src/module/system/utilities/skills.ts
@@ -33,7 +33,7 @@ export function getScoreFromSkill(actor: Actor, spec: string, skill: string, att
 export function getSensorTotal(actor: Actor, score: number): number {
     let skillName = '';
     if (actor.getFlag('od6s', 'crew') && isCharacterActor(actor)) {
-        const sensors = (actor.system.vehicle as { sensors?: { skill?: string } }).sensors;
+        const sensors = actor.system.vehicle.sensors as { skill?: string } | undefined;
         if (typeof sensors?.skill !== 'undefined' && sensors.skill !== '') {
             skillName = sensors.skill;
         }

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -85,8 +85,36 @@ interface OD6SCharacterSystem {
         skills: Record<string, number>;
         specializations: Record<string, number>;
     };
-    /** Crewmember actors carry a reference back to their vehicle. */
-    vehicle: { uuid: string; name?: string; scale?: OD6SScoreField; vehicle_weapons?: any[] };
+    /**
+     * Crewmember actors carry a snapshot of their vehicle's data, pushed by
+     * `actor-helpers/crew-vehicle.ts:sendVehicleData`. Fields mirror the
+     * vehicle-common schema; all are optional because the proxy is built
+     * field-by-field at runtime.
+     */
+    vehicle: {
+        uuid: string;
+        name?: string;
+        type?: string;
+        move?: { value: number; type: string; label: string };
+        maneuverability?: { score: number; type: string; label: string };
+        toughness?: { score: number; type: string; label: string };
+        armor?: { score: number; type: string; label: string };
+        crewmembers?: Array<{ uuid: string; name?: string }>;
+        attribute?: OD6SVehicleStringField;
+        skill?: OD6SVehicleStringField;
+        specialization?: OD6SVehicleStringField;
+        damage?: { value: string; type: string; label: string };
+        shields?: Record<string, unknown>;
+        scale?: OD6SScoreField;
+        sensors?: Record<string, unknown>;
+        dodge?: { score: number; mod: number; type: string; label: string };
+        ranged?: { score: number; type: string; label: string };
+        ranged_damage?: { score: number; type: string; label: string };
+        ram?: { score: number; type: string; label: string };
+        ram_damage?: { score: number; type: string; label: string };
+        vehicle_weapons?: any[];
+        items?: unknown;
+    };
     /** Container actors expose a per-player visibility flag. */
     visible?: boolean;
     /** Created marker on character actors. */
@@ -110,6 +138,13 @@ interface OD6SContainerSystem {
     locked: boolean;
 }
 
+/** Top-level `{value, type, label}` shape used for pilot skill/spec/attribute on vehicle actors (per `vehicle-common.ts`). */
+interface OD6SVehicleStringField {
+    value: string;
+    type: string;
+    label: string;
+}
+
 /** System data for vehicle and starship actor types. */
 interface OD6SVehicleSystem {
     attributes: OD6SAttributes;
@@ -129,6 +164,32 @@ interface OD6SVehicleSystem {
     crew: { value: number };
     /** Vehicle/starship damage state — wound-table key. */
     damage: { value: string };
+    /** Pilot attribute key (top-level, from `vehicle-common.ts`). */
+    attribute: OD6SVehicleStringField;
+    /** Pilot skill name (top-level, from `vehicle-common.ts`). */
+    skill: OD6SVehicleStringField;
+    /** Pilot specialization name (top-level, from `vehicle-common.ts`). */
+    specialization: OD6SVehicleStringField;
+    /** Movement speed (top-level, from `vehicle-common.ts`). */
+    move: { value: number; type: string; label: string };
+    /** Shield state (top-level, from `vehicle-common.ts`). */
+    shields: {
+        value: number;
+        allocated: number;
+        type: string;
+        label: string;
+        skill: string;
+        arcs: Record<string, { label: string; value: number; type: string }>;
+    };
+    /** Sensor state (top-level, from `vehicle-common.ts`). */
+    sensors: {
+        value: boolean;
+        type: string;
+        label: string;
+        skill: string;
+        mod: number;
+        types: Record<string, { score: number; range: number; label: string; type: string }>;
+    };
     roll_mod: number;
     use_wild_die: boolean;
 }
@@ -337,11 +398,23 @@ interface OD6SVehicleItemSystem extends OD6SVehicleCommon {
     altitude: { value: number; type: string; label: string };
 }
 
+/**
+ * Runtime-derived fields populated by `OD6SItem.prepareDerivedData` for
+ * vehicle-weapon and starship-weapon items.
+ */
+interface OD6SVehicleWeaponDerivedFields {
+    /** Snapshot of the {attribute,skill,specialization} `.value`s as plain strings. */
+    stats: { attribute: string; skill: string; specialization: string };
+    /** Always `'vehiclerangedweaponattack'` at present. */
+    subtype: string;
+}
+
 interface OD6SVehicleWeaponItemSystem
     extends OD6SItemBase,
         OD6SEquipment,
         OD6SEquip,
-        OD6SVehicleWeaponsFields {}
+        OD6SVehicleWeaponsFields,
+        OD6SVehicleWeaponDerivedFields {}
 
 interface OD6SVehicleGearItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
     quantity: number;
@@ -352,7 +425,8 @@ interface OD6SStarshipWeaponItemSystem
     extends OD6SItemBase,
         OD6SEquipment,
         OD6SEquip,
-        OD6SVehicleWeaponsFields {
+        OD6SVehicleWeaponsFields,
+        OD6SVehicleWeaponDerivedFields {
     "area-units": { type: string; value: number; label: string };
     mass: { type: string; value: number; label: string };
     energy: { type: string; value: number; label: string };


### PR DESCRIPTION
## Summary
- Closes the two augmentation gaps tracked in #57 that were blocking #83 phase 4: top-level vehicle pilot fields (`skill`/`specialization`/`attribute`) and runtime-derived vehicle-weapon fields (`stats`/`subtype`).
- Widens `OD6SCharacterSystem.vehicle` to mirror the snapshot pushed by `sendVehicleData`, so character-side vehicle access types cleanly.
- Drops dependent casts: `vehicle: any` in `getVehicleActionScore`, the `Record<string,any>` fallback in `sendVehicleData`, the inline `& { stats; subtype }` cast in `prepareDerivedData`, and assorted `as { ram?... }` / `as { sensors?... }` casts in `roll-setup.ts` and `skills.ts`.

Refs #57, unblocks #83 phase 4.

## Test plan
- [x] `pnpm run check` (lint + typecheck + unit + domain) — 0 errors, 685 warnings (under the 720 CI gate)
- [ ] Smoke pass on a live world for vehicle/starship sheets (rolling maneuver, vehicle weapons, crew sensors)