### PR TITLE
refactor(actor-sheet): #83 drop HTMLElement[] listener shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ### Changed
 
+- Actor-sheet listener modules now take the sheet root as
+  `HTMLElement` rather than a single-element `HTMLElement[]`. Drops
+  the `[root]` shim from `_onRender` and the `const el = html[0]`
+  prologue from each listener (#83).
+
 ### Fixed
 
 ### Removed

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -142,10 +142,9 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         // Roll triggers must be bound for any owner regardless of edit mode —
         // V2 sheets render in PLAY mode by default (isEditable === false), but
         // rolling a skill/attack is a play-mode action. See issue #76.
-        const html = [root];
         if (this.actor.isOwner) {
-            registerRollListeners(html, this);
-            registerCombatRollListeners(html, this);
+            registerRollListeners(root, this);
+            registerCombatRollListeners(root, this);
         }
 
         if (!this.isEditable) return;
@@ -189,13 +188,12 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
                 if (ok) await this._onClearSpeciesTemplate();
             }));
 
-        // Existing listener modules accept html[0]; pass [root] for compatibility.
-        registerInventoryListeners(html, this);
-        registerCombatActionListeners(html, this);
-        registerVehicleListeners(html, this);
-        registerScoreListeners(html, this);
-        registerEffectListeners(html, this);
-        registerDragListeners(html, this);
+        registerInventoryListeners(root, this);
+        registerCombatActionListeners(root, this);
+        registerVehicleListeners(root, this);
+        registerScoreListeners(root, this);
+        registerEffectListeners(root, this);
+        registerDragListeners(root, this);
     }
 
     _sortItems(items: Item[], sortType: string): Item[] {

--- a/src/module/actor/sheet-listeners/combat-actions.ts
+++ b/src/module/actor/sheet-listeners/combat-actions.ts
@@ -4,18 +4,17 @@
  * sheets can still roll attacks.
  */
 export function registerCombatRollListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
-    el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
+    root.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
         elem.addEventListener('click', async (ev: Event) => {
             await sheet._rollAvailableAction(ev);
         }));
 
-    el.querySelectorAll<HTMLElement>('.vehicle-action').forEach((elem: HTMLElement) =>
+    root.querySelectorAll<HTMLElement>('.vehicle-action').forEach((elem: HTMLElement) =>
         elem.addEventListener('click', async (ev: Event) => {
             await sheet._rollAvailableVehicleAction(ev);
         }));
@@ -25,25 +24,24 @@ export function registerCombatRollListeners(
  * Register combat action-related event listeners on the actor sheet.
  */
 export function registerCombatActionListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
     // Add/remove actions
-    el.querySelectorAll<HTMLElement>('.addaction').forEach((elem: HTMLElement) =>
+    root.querySelectorAll<HTMLElement>('.addaction').forEach((elem: HTMLElement) =>
         elem.addEventListener('click', () => {
             sheet._onActionAdd();
         }));
 
-    el.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
+    root.querySelectorAll<HTMLElement>('.combat-action').forEach((elem: HTMLElement) =>
         elem.addEventListener('contextmenu', (ev: Event) => {
             sheet._onAvailableActionAdd(ev);
         }));
 
     // Edit misc action
-    el.querySelectorAll<HTMLElement>('.editmiscaction').forEach((elem: HTMLElement) =>
+    root.querySelectorAll<HTMLElement>('.editmiscaction').forEach((elem: HTMLElement) =>
         elem.addEventListener('change', async (ev: Event) => {
             const update: Record<string, unknown> = {};
             const ct = ev.currentTarget as HTMLElement;
@@ -55,7 +53,7 @@ export function registerCombatActionListeners(
         }));
 
     // Fate point in effect checkbox
-    el.querySelectorAll<HTMLElement>('.fatepointeffect').forEach((elem: HTMLElement) =>
+    root.querySelectorAll<HTMLElement>('.fatepointeffect').forEach((elem: HTMLElement) =>
         elem.addEventListener('change', async () => {
             // Don't allow if actor has 0 points
             if (sheet.document.system.fatepoints.value < 1) {

--- a/src/module/actor/sheet-listeners/drag.ts
+++ b/src/module/actor/sheet-listeners/drag.ts
@@ -69,33 +69,31 @@ function onDragStart(sheet: Sheet, event: DragEvent): void {
 /**
  * Register drag event listeners on the actor sheet.
  */
-export function registerDragListeners(html: HTMLElement[], sheet: Sheet): void {
-    const el = html[0];
-
+export function registerDragListeners(root: HTMLElement, sheet: Sheet): void {
     if (sheet.document.isOwner) {
         const handler = (ev: DragEvent) => onDragStart(sheet, ev);
 
         if (sheet.document.type === 'container' && !game.user.isGM) return;
 
         // Items
-        el.querySelectorAll<HTMLElement>('li.item').forEach((li) => {
+        root.querySelectorAll<HTMLElement>('li.item').forEach((li) => {
             if (li.classList.contains("inventory-header")) return;
             li.setAttribute("draggable", "true");
             li.addEventListener("dragstart", handler, false);
         });
 
         // Combat Actions
-        el.querySelectorAll<HTMLElement>('li.availableaction').forEach((li) => {
+        root.querySelectorAll<HTMLElement>('li.availableaction').forEach((li) => {
             li.setAttribute("draggable", "true");
             li.addEventListener("dragstart", dragAvailableCombatAction, false);
         });
-        el.querySelectorAll<HTMLElement>('li.assignedaction').forEach((li) => {
+        root.querySelectorAll<HTMLElement>('li.assignedaction').forEach((li) => {
             li.setAttribute("draggable", "true");
             li.addEventListener("dragstart", dragAssignedCombatAction, false);
         });
 
         // Crewmembers
-        el.querySelectorAll<HTMLElement>('li.crew-list').forEach((li) => {
+        root.querySelectorAll<HTMLElement>('li.crew-list').forEach((li) => {
             li.setAttribute('draggable', "true");
             li.addEventListener("dragstart", dragCrewMember, false);
         });

--- a/src/module/actor/sheet-listeners/effects.ts
+++ b/src/module/actor/sheet-listeners/effects.ts
@@ -2,14 +2,13 @@
  * Register active effect and manifestation event listeners on the actor sheet.
  */
 export function registerEffectListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
     // Update Effect
-    el.querySelectorAll<HTMLElement>('.effect-edit').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.effect-edit').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const effect = sheet.document.effects.get(ct.dataset.effectId);
@@ -17,14 +16,14 @@ export function registerEffectListeners(
         }));
 
     // Delete Effect
-    el.querySelectorAll<HTMLElement>('.effect-delete').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.effect-delete').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             await sheet.document.deleteEmbeddedDocuments('ActiveEffect', [ct.dataset.effectId]);
         }));
 
     // Activate a manifestation
-    el.querySelectorAll<HTMLElement>('.active-checkbox').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.active-checkbox').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             const ct = ev.currentTarget as HTMLElement;

--- a/src/module/actor/sheet-listeners/inventory.ts
+++ b/src/module/actor/sheet-listeners/inventory.ts
@@ -6,14 +6,13 @@ import OD6S from "../../config/config-od6s";
  * Register inventory-related event listeners on the actor sheet.
  */
 export function registerInventoryListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
     // Edit item quantity
-    el.querySelectorAll<HTMLElement>('.edit-quantity').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.edit-quantity').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const item = sheet.document.items.get(ct.dataset.itemId);
@@ -23,7 +22,7 @@ export function registerInventoryListeners(
         }));
 
     // Use a consumable
-    el.querySelectorAll<HTMLElement>('.use-consumable').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.use-consumable').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const item = sheet.document.items.get(ct.dataset.itemId);
@@ -58,7 +57,7 @@ export function registerInventoryListeners(
         }));
 
     // Equip an item
-    el.querySelectorAll<HTMLElement>('.equip-checkbox').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.equip-checkbox').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const item = sheet.document.items.find((i: Item) => i.id === ct.dataset.itemId);
@@ -117,7 +116,7 @@ export function registerInventoryListeners(
         }));
 
     // Update Inventory Item
-    el.querySelectorAll<HTMLElement>('.item-edit').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.item-edit').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             let itemId;
@@ -132,27 +131,27 @@ export function registerInventoryListeners(
         }));
 
     // Delete Inventory Item
-    el.querySelectorAll<HTMLElement>('.item-delete').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.item-delete').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             await sheet.deleteItem(ev);
         }));
 
     // Add Inventory Item
-    el.querySelectorAll<HTMLElement>('.item-create').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.item-create').forEach((elem) =>
         elem.addEventListener('click', sheet._onItemCreate.bind(sheet)));
-    el.querySelectorAll<HTMLElement>('.cargo-hold-add').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.cargo-hold-add').forEach((elem) =>
         elem.addEventListener('click', sheet.document.onCargoHoldItemCreate.bind(sheet.document)));
 
     // Add Item to actor using a button
-    el.querySelectorAll<HTMLElement>('.item-add').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.item-add').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             await sheet.addItem(ev);
         }));
 
     // Show item details
-    el.querySelectorAll<HTMLElement>('.show-item-details').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.show-item-details').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             const ct = ev.currentTarget as HTMLElement;
@@ -175,7 +174,7 @@ export function registerInventoryListeners(
         }));
 
     // Purchase click event
-    el.querySelectorAll<HTMLElement>('.item-purchase').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.item-purchase').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             if (typeof game.user.character === 'undefined') {
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_NO_CHARACTER_ASSIGNED'));
@@ -190,7 +189,7 @@ export function registerInventoryListeners(
         }));
 
     // Transfer click event
-    el.querySelectorAll<HTMLElement>('.item-transfer').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.item-transfer').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             if (typeof game.user.character === 'undefined') {
                 ui.notifications.warn(game.i18n.localize('OD6S.WARN_NO_CHARACTER_ASSIGNED'));
@@ -201,7 +200,7 @@ export function registerInventoryListeners(
         }));
 
     // Merchant owner edit quantity
-    el.querySelectorAll<HTMLElement>('.merchant-quantity-owner').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.merchant-quantity-owner').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const item = sheet.document.items.get(ct.dataset.itemId);
@@ -212,7 +211,7 @@ export function registerInventoryListeners(
         }));
 
     // Merchant owner edit cost
-    el.querySelectorAll<HTMLElement>('.merchant-cost-owner').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.merchant-cost-owner').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const item = sheet.document.items.get(ct.dataset.itemId);
@@ -223,7 +222,7 @@ export function registerInventoryListeners(
         }));
 
     // Merchant owner edit price
-    el.querySelectorAll<HTMLElement>('.merchant-price-owner').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.merchant-price-owner').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const item = sheet.document.items.get(ct.dataset.itemId);

--- a/src/module/actor/sheet-listeners/scores.ts
+++ b/src/module/actor/sheet-listeners/scores.ts
@@ -41,21 +41,20 @@ function recalcScoreFromInput(
  * rolling is a play-mode action and must work for any owner.
  */
 export function registerRollListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
     const rollDialog = new (od6sroll);
-    el.querySelectorAll<HTMLElement>('.rolldialog').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.rolldialog').forEach((elem) =>
         elem.addEventListener('click', rollDialog._onRollEvent.bind(sheet)));
-    el.querySelectorAll<HTMLElement>('.initrolldialog').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.initrolldialog').forEach((elem) =>
         elem.addEventListener('click', od6sInitRoll._onInitRollDialog.bind(sheet) as unknown as EventListener));
-    el.querySelectorAll<HTMLElement>('.actionroll').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.actionroll').forEach((elem) =>
         elem.addEventListener('click', rollDialog._onRollItem.bind(sheet)));
 
-    el.querySelectorAll<HTMLElement>('.rollbodypoints').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.rollbodypoints').forEach((elem) =>
         elem.addEventListener('click', async () => {
             const ok = await foundry.applications.api.DialogV2.confirm({
                 window: {title: game.i18n.localize("OD6S.ROLL") + " " + game.i18n.localize(OD6S.bodyPointsName)},
@@ -70,37 +69,36 @@ export function registerRollListeners(
  * advances, funds, toughness, maneuverability, body points, etc.) on the actor sheet.
  */
 export function registerScoreListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
     // Attribute/skill advances
     const advanceDialog = new (od6sadvance);
-    el.querySelectorAll<HTMLElement>('.advancedialog').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.advancedialog').forEach((elem) =>
         elem.addEventListener('click', advanceDialog._onAdvance.bind(sheet)));
 
     // Attribute context menu (no-op handlers preserved)
-    el.querySelectorAll<HTMLElement>('.attributedialog').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.attributedialog').forEach((elem) =>
         elem.addEventListener('contextmenu', () => {}));
 
     // Skill context menu (no-op handlers preserved)
-    el.querySelectorAll<HTMLElement>('.skilldialog').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.skilldialog').forEach((elem) =>
         elem.addEventListener('contextmenu', () => {}));
 
     // Skill specialization
     const specializeDialog = new (od6sspecialize);
-    el.querySelectorAll<HTMLElement>('.specializedialog').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.specializedialog').forEach((elem) =>
         elem.addEventListener('click', specializeDialog._onSpecialize.bind(sheet)));
 
     // Free edit attribute
     const attributeEditDialog = new od6sattributeedit();
-    el.querySelectorAll<HTMLElement>('.attribute-edit').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.attribute-edit').forEach((elem) =>
         elem.addEventListener('click', attributeEditDialog._onAttributeEdit.bind(sheet)));
 
     // Edit funds
-    el.querySelectorAll<HTMLElement>('.edit-funds').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.edit-funds').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const target = ev.target as HTMLInputElement;
             const oldScore = od6sutilities.getDiceFromScore(sheet.document.system.funds.score);
@@ -110,7 +108,7 @@ export function registerScoreListeners(
         }));
 
     // Edit maneuverability
-    el.querySelectorAll<HTMLElement>('.edit-maneuverability').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.edit-maneuverability').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const target = ev.target as HTMLInputElement;
             const oldScore = od6sutilities.getDiceFromScore(sheet.document.system.maneuverability.score);
@@ -120,7 +118,7 @@ export function registerScoreListeners(
         }));
 
     // Edit toughness
-    el.querySelectorAll<HTMLElement>('.edit-toughness').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.edit-toughness').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const target = ev.target as HTMLInputElement;
             const oldScore = od6sutilities.getDiceFromScore(sheet.document.system.toughness.score);
@@ -130,7 +128,7 @@ export function registerScoreListeners(
         }));
 
     // Edit body points
-    el.querySelectorAll<HTMLElement>('.editbodypoints').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.editbodypoints').forEach((elem) =>
         elem.addEventListener('change', async (ev: Event) => {
             const target = ev.target as HTMLInputElement;
             await sheet.document.setWoundLevelFromBodyPoints(+target.value);
@@ -138,13 +136,13 @@ export function registerScoreListeners(
         }));
 
     // Edit active effect (score-related effects)
-    el.querySelectorAll<HTMLElement>('.edit-effect').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.edit-effect').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             await sheet._editEffect(ev);
         }));
 
     // Event listener for skill usage checkboxes
-    el.querySelectorAll<HTMLInputElement>('.skill-used-checkbox, .spec-used-checkbox').forEach((elem) =>
+    root.querySelectorAll<HTMLInputElement>('.skill-used-checkbox, .spec-used-checkbox').forEach((elem) =>
         elem.addEventListener('change', async (event: Event) => {
             const ct = event.currentTarget as HTMLInputElement;
             const itemId = ct.dataset.itemId;
@@ -157,9 +155,9 @@ export function registerScoreListeners(
         }));
 
     // Event listener for Session Reset button
-    el.querySelectorAll<HTMLElement>('.session-reset-button').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.session-reset-button').forEach((elem) =>
         elem.addEventListener('click', () => {
-            const checkboxes = el.querySelectorAll<HTMLInputElement>('.skill-used-checkbox, .spec-used-checkbox');
+            const checkboxes = root.querySelectorAll<HTMLInputElement>('.skill-used-checkbox, .spec-used-checkbox');
             checkboxes.forEach((checkbox) => {
                 const itemId = checkbox.dataset.itemId;
                 const item = sheet.document.items.get(itemId);

--- a/src/module/actor/sheet-listeners/vehicle.ts
+++ b/src/module/actor/sheet-listeners/vehicle.ts
@@ -7,14 +7,13 @@ import OD6S from "../../config/config-od6s";
  * Register vehicle-related event listeners on the actor sheet.
  */
 export function registerVehicleListeners(
-    html: HTMLElement[],
+    root: HTMLElement,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sheet: any,
 ): void {
-    const el = html[0];
 
     // Embedded Pilot
-    el.querySelectorAll<HTMLElement>('.embedded-pilot-add').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.embedded-pilot-add').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             const data: Record<string, unknown> = {};
@@ -23,7 +22,7 @@ export function registerVehicleListeners(
             await new OD6SAddEmbeddedCrew(data).render({force: true});
         }));
 
-    el.querySelectorAll<HTMLElement>('.embedded-pilot-remove').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.embedded-pilot-remove').forEach((elem) =>
         elem.addEventListener('click', async () => {
             // Remove skills/specs from the base actor.
             // `skills`/`specializations` are sheet-prepared item buckets, not on the Actor type.
@@ -45,14 +44,14 @@ export function registerVehicleListeners(
         }));
 
     // Force-exit from vehicle
-    el.querySelectorAll<HTMLElement>('.vehicle-exit').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.vehicle-exit').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             await sheet.document.setFlag('od6s', 'crew', '');
         }));
 
     // Open a crewmember's character sheet
-    el.querySelectorAll<HTMLElement>('.crew-member').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.crew-member').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const actor = await od6sutilities.getActorFromUuid(ct.dataset.uuid!);
@@ -60,7 +59,7 @@ export function registerVehicleListeners(
         }));
 
     // Add/remove crew to vehicles
-    el.querySelectorAll<HTMLElement>('.crew-add').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.crew-add').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             const data: Record<string, unknown> = {};
@@ -107,7 +106,7 @@ export function registerVehicleListeners(
             new OD6SAddCrew(data).render(true);
         }));
 
-    el.querySelectorAll<HTMLElement>('.crew-delete').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.crew-delete').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             ev.preventDefault();
             const ct = ev.currentTarget as HTMLElement;
@@ -122,7 +121,7 @@ export function registerVehicleListeners(
         }));
 
     // Vehicle shield allocation
-    el.querySelectorAll<HTMLElement>('.arc').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.arc').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const arc = ct.dataset.arc!;
@@ -163,7 +162,7 @@ export function registerVehicleListeners(
         }));
 
     // Vehicle shield allocation by crew member
-    el.querySelectorAll<HTMLElement>('.c-arc').forEach((elem) =>
+    root.querySelectorAll<HTMLElement>('.c-arc').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const actor = await od6sutilities.getActorFromUuid(ct.dataset.uuid!);


### PR DESCRIPTION
## Summary

- Listener modules under `src/module/actor/sheet-listeners/` now take the sheet root as `HTMLElement` instead of a single-element `HTMLElement[]`. Each function dropped its `const el = html[0]` prologue; `_onRender` no longer wraps `root` in `[root]`.
- Pure rename inside the listener bodies (`el.` → `root.`); no behavior change.

## Closes #83

Acceptance criteria are now met:

- `actor-sheet.ts` is **401 LOC** (was 788; target ~400). Phase 1–4 PRs (#107–#109, #111) did the heavy lifting; this PR clears the residual shim flagged in the post-#111 review.
- `CONST.DEFAULT_TOKEN` removed (replaced by typed per-item-type defaults in `prepare-items.ts`).
- `_prepareContext` typed via the new `ActorSheetContext` interface; categorization logic lives in pure helpers with unit coverage.

Remaining `: any` on the delegating sheet methods and on `sheet:` parameters is typing debt that belongs with the wider #57 sweep, not under #83's decomposition goal.

## Test plan

- [x] `pnpm run check` — 0 errors, 671 lint warnings (under 720 CI threshold), 344 unit + 303 domain tests pass
- [ ] Smoke: open a character / vehicle / starship / container sheet, verify item lists, drags, rolls, equip toggles still wire up