### PR TITLE
refactor(types): #56 fix Collection iterator + Document.updateDocuments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   `HTMLElement` rather than a single-element `HTMLElement[]`. Drops
   the `[root]` shim from `_onRender` and the `const el = html[0]`
   prologue from each listener (#83).
+- `Collection<T>` now declares its iterator as `IterableIterator<T>`
+  (matching Foundry runtime behaviour) instead of inheriting Map's
+  `[key, value]` iteration. `Document.updateDocuments` /
+  `deleteDocuments` are also typed. Removes 15 stale `as any` casts
+  in migration, explosives, and chat-log code (#56).
 
 ### Fixed
 

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -333,8 +333,8 @@ export function registerChatLogListeners() {
                 if (game.combat) {
                     for (const t of game.combat.combatants) {
                         const target = {
-                            "id": (t as any).token.id,
-                            "name": (t as any).token.name
+                            "id": t.token.id,
+                            "name": t.token.name
                         }
                         data.targets.push(target);
 

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -101,7 +101,7 @@ async function migrateStatusEffectIcons() {
 
   for (const actor of game.actors) {
     const updates = [];
-    for (const effect of (actor as any).effects) {
+    for (const effect of actor.effects) {
       const img: string = effect.img ?? "";
       if (img.startsWith("systems/od6s/") && img.endsWith(".png")) {
         updates.push({ _id: effect.id, img: img.replace(/\.png$/, ".svg") });
@@ -109,14 +109,14 @@ async function migrateStatusEffectIcons() {
     }
     if (updates.length > 0) {
       logActorBefore("icons", actor);
-      await (actor as any).updateEmbeddedDocuments("ActiveEffect", updates);
+      await actor.updateEmbeddedDocuments("ActiveEffect", updates);
       logActorAfter("icons", actor);
       count += updates.length;
     }
   }
 
   for (const scene of game.scenes) {
-    for (const token of (scene as any).tokens) {
+    for (const token of scene.tokens) {
       const updates = [];
       for (const effect of token.actor?.effects ?? []) {
         const img: string = effect.img ?? "";
@@ -125,9 +125,9 @@ async function migrateStatusEffectIcons() {
         }
       }
       if (updates.length > 0) {
-        logActorBefore("icons", token.actor, ` (token in ${(scene as any).name})`);
+        logActorBefore("icons", token.actor, ` (token in ${scene.name})`);
         await token.actor.updateEmbeddedDocuments("ActiveEffect", updates);
-        logActorAfter("icons", token.actor, ` (token in ${(scene as any).name})`);
+        logActorAfter("icons", token.actor, ` (token in ${scene.name})`);
         count += updates.length;
       }
     }
@@ -157,7 +157,7 @@ async function migrateExplosiveTemplateFlags() {
 
   for (const actor of game.actors) {
     const updates = [];
-    for (const item of (actor as any).items) {
+    for (const item of actor.items) {
       const explosiveTemplate = item.getFlag("od6s", "explosiveTemplate");
       if (explosiveTemplate) {
         updates.push({
@@ -171,7 +171,7 @@ async function migrateExplosiveTemplateFlags() {
     }
     if (updates.length > 0) {
       logActorBefore("explosive-flags", actor);
-      await (actor as any).updateEmbeddedDocuments("Item", updates);
+      await actor.updateEmbeddedDocuments("Item", updates);
       logActorAfter("explosive-flags", actor);
       count += updates.length;
     }
@@ -180,10 +180,10 @@ async function migrateExplosiveTemplateFlags() {
   // Also check unowned items in the world collection
   const worldItemUpdates = [];
   for (const item of game.items) {
-    const explosiveTemplate = (item as any).getFlag("od6s", "explosiveTemplate");
+    const explosiveTemplate = item.getFlag("od6s", "explosiveTemplate");
     if (explosiveTemplate) {
       worldItemUpdates.push({
-        _id: (item as any).id,
+        _id: item.id,
         "flags.od6s.-=explosiveTemplate": null,
         "flags.od6s.-=explosiveSet": null,
         "flags.od6s.-=explosiveOrigin": null,
@@ -192,7 +192,7 @@ async function migrateExplosiveTemplateFlags() {
     }
   }
   if (worldItemUpdates.length > 0) {
-    await (Item as any).updateDocuments(worldItemUpdates);
+    await Item.updateDocuments(worldItemUpdates);
     count += worldItemUpdates.length;
   }
 
@@ -210,9 +210,9 @@ async function migrateChatMessageFlags() {
 
   const updates = [];
   for (const message of game.messages) {
-    if ((message as any).getFlag("od6s", "isExplosive") && (message as any).getFlag("od6s", "template")) {
+    if (message.getFlag("od6s", "isExplosive") && message.getFlag("od6s", "template")) {
       updates.push({
-        _id: (message as any).id,
+        _id: message.id,
         "flags.od6s.-=template": null,
         "flags.od6s.handled": true,
       });
@@ -221,7 +221,7 @@ async function migrateChatMessageFlags() {
   }
 
   if (updates.length > 0) {
-    await (ChatMessage as any).updateDocuments(updates);
+    await ChatMessage.updateDocuments(updates);
   }
 
   console.log(`od6s | Cleaned explosive flags from ${count} chat messages.`);

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -164,7 +164,7 @@ export async function detonateExplosives(combat: any): Promise<void> {
                 } else if (origMessage.whisper.length > 0) {
                     rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
                 }
-                await (ChatMessage as any).deleteDocuments([origMessage.id]);
+                await ChatMessage.deleteDocuments([origMessage.id]);
                 cloneMessage.flags.od6s.canUseCp = false;
                 cloneMessage.rolls[0].toMessage(cloneMessage, {rollMode});
             }

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -393,6 +393,8 @@ declare class FoundryDocument {
     static metadata: { name: string; label: string; [key: string]: any };
     static create(data: any, options?: any): Promise<any>;
     static defaultName(): string;
+    static updateDocuments(updates: any[], context?: any): Promise<any[]>;
+    static deleteDocuments(ids: string[], context?: any): Promise<any[]>;
 
     getFlag(scope: string, key: string): any;
     setFlag(scope: string, key: string, value: any): Promise<this>;
@@ -855,6 +857,13 @@ declare class Collection<T> extends Map<string, T> {
     every(predicate: (value: T) => boolean): boolean;
     render(force?: boolean): void;
     _formatFolderSelectOptions(): any[];
+
+    /**
+     * Foundry's Collection overrides Map's iterator to yield values directly,
+     * not [key, value] entries. This makes `for (const x of collection)` work
+     * the way every call site expects.
+     */
+    [Symbol.iterator](): IterableIterator<T>;
 
     [key: string]: any;
 }


### PR DESCRIPTION
## Summary

- Declare `Collection<T>[Symbol.iterator]` as `IterableIterator<T>` so `for (const actor of game.actors)` yields `Actor`, not `[string, Actor]`. Foundry's runtime overrides Map's iterator; the local typing didn't.
- Add static `updateDocuments` / `deleteDocuments` to `FoundryDocument`, replacing `(ChatMessage as any).updateDocuments(...)` etc.
- Remove the 15 `as any` casts those gaps caused in `migration.ts`, `explosives.ts`, and `chat-log-listeners.ts`. No behavior change.

## #56 progress

This continues the augmentation work. The mechanical augmentation surface in #87 covered OD6S-specific members; this addresses the **base Foundry typing** gaps that were forcing the same `as any` pattern at call sites the augmentation already in principle covered.

Issue stays open — there's still tail in `item.ts` (`createDialog`, char-creation casts), `system/handlebars/`, and a handful of other sites. Each removable cluster can ship as its own focused PR.

## Test plan

- [x] `pnpm run check` — 0 errors, **654 lint warnings** (was 671), 344 unit + 303 domain tests pass
- [ ] Smoke: trigger a v2.0 → current world migration; resolve an explosive chat card; open the choose-target dialog from a chat message