### PR TITLE
refactor(types): #56 drop (game as any) / (canvas as any) casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   `[key, value]` iteration. `Document.updateDocuments` /
   `deleteDocuments` are also typed. Removes 15 stale `as any` casts
   in migration, explosives, and chat-log code (#56).
+- `OD6SCharacterSystem` now declares `credits` and `funds`, matching
+  the actual `data/actor/fields/common.ts` schema. Drops the
+  `(game as any)` and `(canvas as any)` casts that were papering over
+  the gap (14 game / 2 canvas sites) and the `(buyer.system as any)`
+  casts in inventory transfer (#56).
 
 ### Fixed
 

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -220,7 +220,7 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
     }
 
     const rollMessage = await roll.toMessage({
-        speaker: ChatMessage.getSpeaker({actor: (game as any).actors.find((a: any) => a.id === actor.id)}),
+        speaker: ChatMessage.getSpeaker({actor: game.actors.find((a: any) => a.id === actor.id)}),
         flavor: label,
         flags: {od6s: flags},
     }, {rollMode, create: true});

--- a/src/module/actor/add-item.ts
+++ b/src/module/actor/add-item.ts
@@ -87,10 +87,10 @@ export class OD6SAddItem extends HandlebarsApplicationMixin(ApplicationV2) {
 
         let actor: any;
         if (data.token !== "") {
-            const token = (game as any).scenes.active.tokens.get(data.token);
+            const token = game.scenes.active.tokens.get(data.token);
             actor = token!.actor;
         } else {
-            actor = await (game as any).actors.get(data.actor);
+            actor = await game.actors.get(data.actor);
         }
 
         if (mode === "selected") {

--- a/src/module/actor/sheet-helpers/inventory-transfer.ts
+++ b/src/module/actor/sheet-helpers/inventory-transfer.ts
@@ -25,7 +25,7 @@ type Sheet = any;
 
 export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promise<void> {
     const seller = sheet.document;
-    const buyer = (game as any).actors.get(buyerId);
+    const buyer = game.actors.get(buyerId);
     const item = seller.items.get(itemId);
 
     // The post-roll entry paths (chat-card, wild-die, difficulty-edit) can
@@ -37,12 +37,16 @@ export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promi
         return;
     }
 
+    // Buyer is always a character/npc/creature in the purchase flows;
+    // narrow off the Actor.system union to access character-only fields.
+    const buyerSystem = buyer!.system as OD6SCharacterSystem;
+    const itemSystem = item.system as OD6SEquipment;
     if (OD6S.cost === "1") {
-        if ((+buyer!.system.credits.value) < (+item.system.cost)) {
+        if ((+buyerSystem.credits.value) < (+itemSystem.cost)) {
             ui.notifications.warn(game.i18n.localize("OD6S.WARN_NOT_ENOUGH_CURRENCY"));
             return;
         }
-        await buyer!.update({"system.credits.value": (+buyer!.system.credits.value) - (+item.system.cost)});
+        await buyer!.update({"system.credits.value": (+buyerSystem.credits.value) - (+itemSystem.cost)});
     }
 
     const boughtItem = JSON.parse(JSON.stringify(item));
@@ -52,9 +56,9 @@ export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promi
         // would silently bump a non-gear (weapon/armor) of the same name
         // already on the buyer. Restrict the match to gear so cross-type
         // collisions create a fresh document instead.
-        const hasItem = buyer!.items.filter((i: any) => i.type === "gear" && i.name === item.name);
+        const hasItem = buyer!.items.filter((i: Item) => i.type === "gear" && i.name === item.name);
         if (hasItem.length > 0) {
-            await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
+            await hasItem[0].update({"system.quantity": (+(hasItem[0].system as OD6SEquipment).quantity) + 1});
         } else {
             await buyer!.createEmbeddedDocuments("Item", [boughtItem]);
         }
@@ -63,13 +67,13 @@ export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promi
     }
 
     const sellerUpdate: any = {};
-    if (item.system.quantity > 0) sellerUpdate["system.quantity"] = (+item.system.quantity) - 1;
+    if (itemSystem.quantity > 0) sellerUpdate["system.quantity"] = (+itemSystem.quantity) - 1;
     await item.update(sellerUpdate);
 }
 
 export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId: any): Promise<void> {
-    const sender = (game as any).actors.get(senderId);
-    const receiver = (game as any).actors.get(recId);
+    const sender = game.actors.get(senderId);
+    const receiver = game.actors.get(recId);
     const item = sender!.items.get(itemId);
 
     const recItem = JSON.parse(JSON.stringify(item));
@@ -82,19 +86,20 @@ export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId
     if (item!.type === "gear") {
         // Gear-only merge — same cross-type collision rationale as in
         // `onPurchase`.
-        const hasItem = receiver!.items.filter((i: any) => i.type === "gear" && i.name === item!.name);
+        const itemSystem = item!.system as OD6SEquipment;
+        const hasItem = receiver!.items.filter((i: Item) => i.type === "gear" && i.name === item!.name);
         if (hasItem.length > 0) {
-            await hasItem[0].update({"system.quantity": (+hasItem[0].system.quantity) + 1});
+            await hasItem[0].update({"system.quantity": (+(hasItem[0].system as OD6SEquipment).quantity) + 1});
         } else {
             await receiver!.createEmbeddedDocuments("Item", [recItem]);
         }
 
         const senderUpdate: any = {};
-        if (item!.system.quantity > 0) senderUpdate["system.quantity"] = (+item!.system.quantity) - 1;
+        if (itemSystem.quantity > 0) senderUpdate["system.quantity"] = (+itemSystem.quantity) - 1;
         await item!.update(senderUpdate);
 
         if ((sender!.type === "character" || sender!.type === "container")
-            && item!.system.quantity === 0) {
+            && itemSystem.quantity === 0) {
             await sender!.deleteEmbeddedDocuments("Item", [item!.id]);
         }
     } else {

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -166,7 +166,7 @@ export async function rollPurchase(sheet: Sheet, ev: any, buyerId: any): Promise
     const data: any = {
         name: game.i18n.localize("OD6S.PURCHASE") + " " + item.name,
         itemId: item.id,
-        actor: (game as any).actors.get(buyerId),
+        actor: game.actors.get(buyerId),
         seller: sheet.document.id,
         type: "purchase",
         difficultyLevel: OD6S.difficultyShort[item.system.price],

--- a/src/module/apps/choose-target.ts
+++ b/src/module/apps/choose-target.ts
@@ -52,7 +52,7 @@ export class OD6SChooseTarget extends HandlebarsApplicationMixin(ApplicationV2) 
         formData: any,
     ): Promise<void> {
         const data = formData.object;
-        const message = (game as any).messages.get(data.messageId);
+        const message = game.messages.get(data.messageId);
         if (!message) return;
 
         if (message.getFlag("od6s", "isExplosive")) {
@@ -77,7 +77,7 @@ export class OD6SChooseTarget extends HandlebarsApplicationMixin(ApplicationV2) 
             await message.setFlag("od6s", "targets", targets);
         } else {
             await message.setFlag("od6s", "targetId", data.choosetarget);
-            const targetName = (game as any).scenes.active.tokens
+            const targetName = game.scenes.active.tokens
                 .find((t: any) => t.id === data.choosetarget)?.name;
             await message.setFlag("od6s", "targetName", targetName);
         }

--- a/src/module/apps/edit-damage.ts
+++ b/src/module/apps/edit-damage.ts
@@ -53,7 +53,7 @@ export class OD6SEditDamage extends HandlebarsApplicationMixin(ApplicationV2) {
         formData: any,
     ): Promise<void> {
         const data = formData.object;
-        const message = (game as any).messages.get(data.messageId);
+        const message = game.messages.get(data.messageId);
         if (!message) return;
 
         const damageScore = od6sutilities.getScoreFromDice(data.damageDice, data.damagePips);

--- a/src/module/apps/edit-difficulty.ts
+++ b/src/module/apps/edit-difficulty.ts
@@ -51,7 +51,7 @@ export default class OD6SEditDifficulty extends HandlebarsApplicationMixin(Appli
         formData: any,
     ): Promise<void> {
         const data = formData.object;
-        const message = (game as any).messages.get(data.messageId);
+        const message = game.messages.get(data.messageId);
         if (!message) return;
 
         const diff = (+data.baseDifficulty) - (+message.getFlag("od6s", "baseDifficulty"));

--- a/src/module/apps/explosive-dialog.ts
+++ b/src/module/apps/explosive-dialog.ts
@@ -70,7 +70,7 @@ export default class ExplosiveDialog extends HandlebarsApplicationMixin(Applicat
                 radius = this.data.item.system.blast_radius["3"].range;
             }
 
-            this.token = (canvas as any).tokens.controlled[0];
+            this.token = canvas.tokens.controlled[0];
             const explosiveTemplate = new ExplosivesTemplate(radius);
             await explosiveTemplate.setExplosiveData(
                 this.data,
@@ -103,7 +103,7 @@ export default class ExplosiveDialog extends HandlebarsApplicationMixin(Applicat
 
         if (this.data.stage === 1 && this.data.type === "OD6S.EXPLOSIVE_THROWN") {
             const region = regions[0];
-            const distance = Math.floor((canvas as any).grid.measurePath([
+            const distance = Math.floor(canvas.grid.measurePath([
                 {x: this.token.center.x, y: this.token.center.y},
                 {x: region.shapes[0].x, y: region.shapes[0].y},
             ]).distance);

--- a/src/module/apps/handle-wild-die.ts
+++ b/src/module/apps/handle-wild-die.ts
@@ -55,7 +55,7 @@ export class OD6SHandleWildDieForm extends HandlebarsApplicationMixin(Applicatio
         formData: any,
     ): Promise<void> {
         const data = formData.object;
-        const message: any = (game as any).messages.get(data.messageId);
+        const message: any = game.messages.get(data.messageId);
         if (!message) return;
 
         switch (data.wilddie) {
@@ -104,7 +104,7 @@ export class OD6SHandleWildDieForm extends HandlebarsApplicationMixin(Applicatio
         }
 
         if (message.getFlag("od6s", "subtype") === "purchase" && message.getFlag("od6s", "success")) {
-            const seller: any = (game as any).actors.get(message.getFlag("od6s", "seller") as string);
+            const seller: any = game.actors.get(message.getFlag("od6s", "seller") as string);
             await seller.sheet._onPurchase(message.getFlag("od6s", "purchasedItem"), message.speaker.actor);
         }
     }

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -135,7 +135,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
     async _addActorType(): Promise<void> {
         const data = {
-            actorTypes: (game as any).od6s.OD6SActor.TYPES.filter((i: any) => !this.item.system.actor_types.includes(i)),
+            actorTypes: game.od6s.OD6SActor.TYPES.filter((i: any) => !this.item.system.actor_types.includes(i)),
         };
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-add-actor-type.html", data);

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -74,6 +74,8 @@ interface OD6SCharacterSystem {
     block: OD6SModScoreField;
     pr: OD6SModScoreField;
     er: OD6SModScoreField;
+    credits: { type: string; label: string; value: number };
+    funds: { type: string; label: string; score: number };
     sheetmode: { value: string };
     scale: OD6SScoreField;
     initiative: { score: number; mod: number; formula: string };


### PR DESCRIPTION
## Summary

- Strip 14 `(game as any).` and 2 `(canvas as any).` casts. Both globals are typed in `foundry.d.ts` (`game: Game`, `canvas: Canvas`); the casts were defensive boilerplate from before the typings landed.
- Removing them exposed two real schema gaps the casts had been masking:
  - `OD6SCharacterSystem.credits` and `funds` were absent from the augmentation despite being declared in `src/module/data/actor/fields/common.ts`. Added.
  - `inventory-transfer.ts` reads through `Actor.system` (a `Character | Vehicle` union) and `Item.system` (full item union). Narrowed with explicit `as OD6SCharacterSystem` / `as OD6SEquipment` casts where the discriminated-union work in #57 hasn't reached yet.

## #56 progress

Continues the cleanup started in #113. Each removable cluster is shipping as its own focused PR:

- #87 — initial OD6S-specific augmentation surface
- #113 — `Collection<T>` iterator + `Document.updateDocuments`/`deleteDocuments`
- This PR — `(game/canvas as any)` cluster + character credits/funds gap

Issue stays open. Remaining tail: `(item.ts) static createDialog` casts on `data: any`, `system/handlebars/` helpers, a few `(actor as any).dodge` etc.

## Test plan

- [x] `pnpm run check` — 0 errors, **636 lint warnings** (was 654), 344 unit + 303 domain tests pass
- [ ] Smoke: trigger a credit-based purchase (`OD6S.cost === '1'`), an item transfer between actors, and the choose-target / explosive-dialog token flows