### PR TITLE
refactor(types): #56 type GameSystem.template + handlebars accumulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   `(game as any)` and `(canvas as any)` casts that were papering over
   the gap (14 game / 2 canvas sites) and the `(buyer.system as any)`
   casts in inventory transfer (#56).
+- `GameSystem.template` is now typed (Foundry's `template.json`
+  descriptor used by item-sheet creation/edit dialogs), and several
+  Handlebars accumulators are typed as `Record<string, T>` instead
+  of being indexed via `as any`. `OD6SItem.createDialog` now takes a
+  typed `data` parameter (#56).
 
 ### Fixed
 

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -353,7 +353,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
             "systems/od6s/templates/item/item-template-add.html",
             {templateItems});
         const label = game.i18n.localize(
-            (game.system as any).template.Item[event.currentTarget.dataset.type].label);
+            game.system.template.Item[event.currentTarget.dataset.type].label);
         const result = await DialogV2.input({
             window: {title: game.i18n.localize("OD6S.ADD") + " " + label + "!"},
             content,
@@ -398,7 +398,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
             "systems/od6s/templates/item/item-template-item-edit.html",
             itemData);
         const label = game.i18n.localize(
-            (game.system as any).template.Item[target.dataset.type!].label);
+            game.system.template.Item[target.dataset.type!].label);
         const result = await DialogV2.input({
             window: {title: game.i18n.localize("OD6S.EDIT") + " " + label + "!"},
             content,

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -135,7 +135,10 @@ export class OD6SItem extends Item {
     /**
      * Filter the Create New Item dialog
      */
-    static async createDialog(data={}, {parent=null, pack=null, ...options}={}) {
+    static async createDialog(
+        data: { name?: string; folder?: string; type?: string; [key: string]: unknown } = {},
+        {parent=null, pack=null, ...options}: { parent?: Actor | null; pack?: string | null; [key: string]: unknown } = {},
+    ) {
 
         // Collect data
         const documentName = this.metadata.name;
@@ -174,13 +177,13 @@ export class OD6SItem extends Item {
             "templates/sidebar/document-create.html",
             {
                 folders,
-                name: (data as any).name || game.i18n.format("DOCUMENT.New", {type: label}),
-                folder: (data as any).folder,
+                name: data.name || game.i18n.format("DOCUMENT.New", {type: label}),
+                folder: data.folder,
                 hasFolders: folders.length >= 1,
-                type: (data as any).type || CONFIG[documentName]?.defaultType || types[0],
-                types: types.reduce((obj, t) => {
+                type: data.type || CONFIG[documentName]?.defaultType || types[0],
+                types: types.reduce<Record<string, string>>((obj, t) => {
                     const label = CONFIG[documentName]?.typeLabels?.[t] ?? t;
-                    (obj as any)[t] = game.i18n.has(label) ? game.i18n.localize(label) : t;
+                    obj[t] = game.i18n.has(label) ? game.i18n.localize(label) : t;
                     return obj;
                 }, {}),
                 hasTypes: types.length > 1
@@ -200,9 +203,9 @@ export class OD6SItem extends Item {
         if (!result) return null;
 
         foundry.utils.mergeObject(data, result, {inplace: true});
-        if (!(data as any).folder) delete (data as any).folder;
-        if (types.length === 1) (data as any).type = types[0];
-        if (!(data as any).name?.trim()) (data as any).name = this.defaultName();
+        if (!data.folder) delete data.folder;
+        if (types.length === 1) data.type = types[0];
+        if (!data.name?.trim()) data.name = this.defaultName();
         return this.create(data, {parent, pack, renderSheet: true});
     }
 

--- a/src/module/system/handlebars/combat.ts
+++ b/src/module/system/handlebars/combat.ts
@@ -172,17 +172,17 @@ export function registerCombatHelpers() {
     })
 
     Handlebars.registerHelper('getArmorDamageLevels', function () {
-        const levels = {};
+        const levels: Record<string, string> = {};
         for (const level in OD6S.armorDamage) {
-            (levels as any)[level] = OD6S.armorDamage[level].label;
+            levels[level] = OD6S.armorDamage[level].label;
         }
         return levels;
     })
 
     Handlebars.registerHelper('getWeaponDamageLevels', function () {
-        const levels = {};
+        const levels: Record<string, string> = {};
         for (const level in OD6S.weaponDamage) {
-            (levels as any)[level] = OD6S.weaponDamage[level].label;
+            levels[level] = OD6S.weaponDamage[level].label;
         }
         return levels;
     })

--- a/src/module/system/handlebars/config-helpers.ts
+++ b/src/module/system/handlebars/config-helpers.ts
@@ -206,9 +206,9 @@ export function registerConfigHelpers() {
     })
 
     Handlebars.registerHelper('getAttributes', function () {
-        const active = {};
+        const active: Record<string, OD6SAttributeField> = {};
         for (const attribute in OD6S.attributes) {
-            if (OD6S.attributes[attribute].active) (active as any)[attribute] = OD6S.attributes[attribute];
+            if (OD6S.attributes[attribute].active) active[attribute] = OD6S.attributes[attribute];
         }
         return active;
     })
@@ -218,10 +218,10 @@ export function registerConfigHelpers() {
     });
 
     Handlebars.registerHelper('getActiveAttributes', function (attributes) {
-        const active = {};
+        const active: Record<string, OD6SAttributeField> = {};
         for (const attr in attributes) {
             if(attributes[attr].active) {
-                (active as any)[attr] = attributes[attr];
+                active[attr] = attributes[attr];
             }
         }
         return active;
@@ -291,7 +291,7 @@ export function registerConfigHelpers() {
     });
 
     Handlebars.registerHelper('templateItemTypes', function (type, actorTypes) {
-        const itemTypes = {};
+        const itemTypes: Record<string, { label: string }> = {};
         let templateItems = [];
 
         // Item group, filter by actor types
@@ -319,7 +319,7 @@ export function registerConfigHelpers() {
             const defaultData = model ? model.defineSchema() : {};
             const label = (e === 'manifestation') ? OD6S.manifestationsName :
                 (defaultData.label?.initial ?? e);
-            (itemTypes as any)[e] = { label };
+            itemTypes[e] = { label };
         }
         return itemTypes;
     })

--- a/src/module/system/handlebars/display.ts
+++ b/src/module/system/handlebars/display.ts
@@ -184,9 +184,9 @@ export function registerDisplayHelpers() {
     })
 
     Handlebars.registerHelper('getContainerItemCategories', function () {
-        const categories = {};
+        const categories: Record<string, string> = {};
         for (const i of OD6S.allowedItemTypes['container']) {
-            (categories as any)[i] = OD6S.itemLabels[i]
+            categories[i] = OD6S.itemLabels[i]
         }
         return categories;
     })

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -953,6 +953,16 @@ interface GameSocket {
 interface GameSystem {
     id: string;
     version: string;
+    /**
+     * `template.json` — the legacy schema descriptor exposed by Foundry on
+     * the GameSystem. Indexed by document type then sub-type, with a `label`
+     * the system's templates and dialogs localize against.
+     */
+    template: {
+        Actor: Record<string, { label: string; [key: string]: any }>;
+        Item: Record<string, { label: string; [key: string]: any }>;
+        [key: string]: any;
+    };
 }
 
 // ---- Hooks ----


### PR DESCRIPTION
## Summary

Three small, independent cast clusters:

- `GameSystem.template` — added to `foundry.d.ts` so the item-sheet template-add/edit dialogs can read `game.system.template.Item[type].label` directly (Foundry's `template.json` descriptor; 2 sites in `item-sheet.ts`).
- **Handlebars accumulators** — six helpers built `{}` and indexed it with `(obj as any)[key] = …`. Typed each as `Record<string, T>` instead. Sites: `display.ts:getContainerItemCategories`, `combat.ts:getArmorDamageLevels` / `getWeaponDamageLevels`, `config-helpers.ts:getAttributes` / `getActiveAttributes` / `templateItemTypes`.
- **`OD6SItem.createDialog`** — `data` was implicitly `{}` so every read forced `(data as any).name/folder/type`. Typed the parameter; replaced the `reduce<unknown>` with `reduce<Record<string, string>>`. Drops 8 `as any` casts in `item.ts`.

No behavior change; no schema additions beyond the already-Foundry-authoritative `template`.

## #56 progress

Continues the cleanup chain (#87, #113, #114). Remaining tail is mostly the #86-tracked suspected-runtime-bug sites (`actor.dodge` flat-field reads, `od6sutilities.getDamageResistance`, the `for-in` skill loop in `handlebars/skills.ts`) which can't be fixed by typing alone.

## Test plan

- [x] `pnpm run check` — 0 errors, **619 lint warnings** (was 636), 344 unit + 303 domain tests pass
- [ ] Smoke: create a new item via the sidebar (exercises `Item.createDialog`), open the template-add dialog on an item-group / character-template (exercises the `game.system.template` reads)