### PR TITLE
fix(explosives): #40 key per-throw state by region id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ### Fixed
 
+- Throwing a second instance of the same explosive item before the
+  first resolves no longer clobbers the first throw's flags. The
+  per-throw state (`explosiveTemplate` / `explosiveOrigin` /
+  `explosiveRange` / `explosiveSet`) was scalar on the item document,
+  so throw 2 overwrote the region pointer set by throw 1 and throw 1
+  could no longer be resolved. Replaced with a per-region keyed map
+  at `flags.od6s.explosivePending.<regionId>`; the region id is
+  threaded through `OD6SItem.roll(parry, regionId)` and stamped on
+  each attack chat message as `flags.od6s.template`, so cleanup
+  paths address only their own throw's entry. Migration drops the
+  legacy scalars on world upgrade (#40).
+
 ### Removed
 
 ## [2.4.0] - 2026-05-02

--- a/src/module/apps/explosive-dialog.ts
+++ b/src/module/apps/explosive-dialog.ts
@@ -109,13 +109,9 @@ export default class ExplosiveDialog extends HandlebarsApplicationMixin(Applicat
             ]).distance);
 
             await this.data.item.update({
-                flags: {
-                    od6s: {
-                        explosiveSet: true,
-                        explosiveTemplate: region.id,
-                        explosiveRange: distance,
-                        explosiveOrigin: {x: this.token.center.x, y: this.token.center.y},
-                    },
+                [`flags.od6s.explosivePending.${region.id}`]: {
+                    origin: {x: this.token.center.x, y: this.token.center.y},
+                    range: distance,
                 },
             });
 
@@ -129,7 +125,7 @@ export default class ExplosiveDialog extends HandlebarsApplicationMixin(Applicat
                 },
             });
 
-            this.data.item.roll(false);
+            this.data.item.roll(false, region.id);
         } else if (this.data.stage === 1) {
             this.render({force: true});
         }

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -88,6 +88,15 @@ export interface RollData {
     attackerScale: number;
     modifiers: RollModifiers;
     rollmode?: string;
+    /**
+     * Region id of the explosive blast template tied to this roll. Set by
+     * `OD6SItem.roll(parry, regionId)` for explosive throws routed through
+     * the auto-explosive flow. All later read sites (range/origin lookup,
+     * cleanup, scatter) address the per-throw `flags.od6s.explosivePending`
+     * map by this id, so multiple in-flight throws of the same item can't
+     * clobber each other.
+     */
+    regionId?: string;
 }
 
 /**
@@ -111,6 +120,8 @@ export interface IncomingRollData {
     damage?: number;
     damage_type?: string;
     range?: { short: number; medium: number; long: number } | false;
+    /** See {@link RollData.regionId}. */
+    regionId?: string;
 }
 
 /** Flags written into ChatMessage.flags.od6s by executeRollAction. */
@@ -170,6 +181,14 @@ export interface RollMessageFlags {
      * `whisper === [author.id]` is ambiguous.
      */
     rollMode?: string;
+    /**
+     * Region id of the blast template for explosive attack messages. Lets
+     * cleanup paths (chat preDelete, detonation, manual remove) recover the
+     * per-throw entry in `item.flags.od6s.explosivePending` without falling
+     * back to the latest scalar item flag (which is racy across multiple
+     * in-flight throws of the same item).
+     */
+    template?: string;
 }
 
 /** Minimal payload for metaphysics multi-skill roll dialogs — not a full RollData. */

--- a/src/module/apps/roll-helpers/roll-effects.ts
+++ b/src/module/apps/roll-helpers/roll-effects.ts
@@ -4,6 +4,7 @@
 
 import type {RollData} from "./roll-data";
 import {isCharacterActor, isSpecializationItem} from "../../system/type-guards";
+import {clearExplosivePending} from "../../system/utilities/explosives";
 
 export function getEffectMod(type: string, name: string, actor: Actor): number {
     if (!isCharacterActor(actor)) return 0;
@@ -43,15 +44,15 @@ export function getRange(value: string, actor: Actor): string | number {
 export async function cancelAction(rollData: RollData): Promise<void> {
     if(rollData?.isExplosive) {
         const item = rollData.actor.items.find((i: Item) => i.id === rollData.itemid);
-        const regionId = item?.getFlag('od6s','explosiveTemplate');
+        const regionId = rollData.regionId;
         if (regionId) {
             try {
                 await canvas.scene.deleteEmbeddedDocuments('Region', [regionId]);
-            } catch {}
+            } catch {/* region already gone */}
+            if (item) await clearExplosivePending(item, regionId);
+        } else {
+            // Manual (non-auto) path: only `explosiveSet` was written.
+            await item?.unsetFlag('od6s', 'explosiveSet');
         }
-        await item?.unsetFlag('od6s', 'explosiveSet');
-        await item?.unsetFlag('od6s', 'explosiveTemplate');
-        await item?.unsetFlag('od6s', 'explosiveOrigin');
-        await item?.unsetFlag('od6s', 'explosiveRange');
     }
 }

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -9,6 +9,7 @@ import {isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem, isW
 import type {Modifier} from "./difficulty-math";
 import type {RollData, RollMessageFlags, DiceValue} from "./roll-data";
 import {computeHighHitDamage, computeWildDieReduction, resolveRollMode} from "./roll-execute-math";
+import {clearExplosivePending, getExplosivePending} from "../../system/utilities/explosives";
 import {debug} from "../../system/logger";
 
 export async function executeRollAction(rollData: RollData): Promise<unknown> {
@@ -249,6 +250,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         "stun": rollData.stun,
         "fatepointineffect": rollData.fatepointeffect,
         "isExplosive": rollData.isExplosive,
+        "template": rollData.regionId ?? '',
         "range": rollData.modifiers.range,
         "type": rollData.type,
         "subtype": rollData.subtype ? rollData.subtype : '',
@@ -347,7 +349,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         if(game.settings.get('od6s','auto_explosive')
             && !game.settings.get('od6s','explosive_end_of_round')) {
             flags.targets = await od6sutilities.getExplosiveTargets(
-                rollData.actor.isToken ? rollData.actor.token.actor : rollData.actor, rollData.itemid
+                rollData.actor.isToken ? rollData.actor.token.actor : rollData.actor, rollData.itemid, rollData.regionId
             )
         }
     }
@@ -494,9 +496,10 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
 
     if(rollData.isExplosive) {
         const item = rollData.actor.items.find((i: Item) => i.id === rollData.itemid);
-        const origin = item!.getFlag('od6s', 'explosiveOrigin');
-        const regionId = item!.getFlag('od6s', 'explosiveTemplate');
-        const region = canvas.scene.getEmbeddedDocument('Region', regionId);
+        const regionId = rollData.regionId;
+        const pending = item && regionId ? getExplosivePending(item, regionId) : undefined;
+        const origin = pending?.origin;
+        const region = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
         if (region) {
             await region.setFlag('od6s','message', rollMessage.id);
 
@@ -513,7 +516,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
             if (!flags.success) {
                 await od6sutilities.scatterExplosive(rollData.range, origin, regionId);
                 await od6sutilities.wait(100);
-                const newTargets = await od6sutilities.getExplosiveTargets(rollData.actor, rollData.itemid);
+                const newTargets = await od6sutilities.getExplosiveTargets(rollData.actor, rollData.itemid, regionId);
                 if (Object.keys(newTargets).length === 0) {
                     await rollMessage.unsetFlag('od6s', 'showButton');
                     await rollMessage.setFlag('od6s', 'showButton', false);
@@ -526,11 +529,10 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         if (region && !game.settings.get('od6s', 'explosive_end_of_round')) {
             await region.update({ visibility: 2 });
         }
-        if (game.settings.get('od6s', 'auto_explosive')) {
-            await item?.unsetFlag('od6s', 'explosiveSet');
-            await item?.unsetFlag('od6s', 'explosiveTemplate');
-            await item?.unsetFlag('od6s', 'explosiveOrigin');
-            await item?.unsetFlag('od6s', 'explosiveRange');
+        if (game.settings.get('od6s', 'auto_explosive') && item) {
+            // Clear only this throw's pending entry so other in-flight throws
+            // of the same item document remain resolvable (#40).
+            await clearExplosivePending(item, regionId);
         }
     }
 

--- a/src/module/apps/roll-helpers/roll-finalize.ts
+++ b/src/module/apps/roll-helpers/roll-finalize.ts
@@ -104,6 +104,8 @@ export interface FinalizeInput<K extends RollTypeKey> {
     targetRef?: unknown;
     /** Output of HANDLERS[classified.key]. */
     bucket: HandlerOutput<K>;
+    /** Region id for the explosive throw being resolved (auto-explosive path). */
+    regionId?: string;
 }
 
 export function runFinalize<K extends RollTypeKey>(input: FinalizeInput<K>): RollData {
@@ -209,6 +211,7 @@ export function runFinalize<K extends RollTypeKey>(input: FinalizeInput<K>): Rol
         stun: false,
         attackerScale: 0,
         specSkill: '',
+        regionId: input.regionId,
 
         // Bucket overrides — handler-owned fields take precedence over the
         // safe defaults above. The Pick-typed bucket guarantees only valid

--- a/src/module/apps/roll-helpers/roll-preflight.ts
+++ b/src/module/apps/roll-helpers/roll-preflight.ts
@@ -49,6 +49,10 @@ async function passesExplosiveGate(data: IncomingRollData): Promise<boolean> {
     const sys = item?.system as OD6SWeaponItemSystem | undefined;
     if (sys?.subtype?.toLowerCase() !== 'explosive') return true;
     if (item!.getFlag('od6s', 'explosiveSet')) return true;
+    // Auto-explosive throws skip `explosiveSet` and stamp the pending map
+    // directly (one entry per region) so multiple in-flight throws can co-exist.
+    const pending = item!.getFlag('od6s', 'explosivePending') as Record<string, unknown> | undefined;
+    if (pending && Object.keys(pending).length > 0) return true;
 
     await new ExplosiveDialog({
         options: OD6S.explosives,

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -35,6 +35,7 @@ import {bucketRangeFromDistance, flatSkillBonusPips, splitBonusForPenalty} from 
 import type {IncomingRollData, RollData, ClassifiedRoll, RollTypeKey} from "./roll-data";
 import {classifyRoll} from "./roll-data";
 import {applyWeaponMods} from "./weapon-context-math";
+import {clearExplosivePending, getExplosivePending} from "../../system/utilities/explosives";
 import {computePenalties, isPenaltyBypassType, resolveSkillBackedAction} from "./action-math";
 import type {ActionResolution} from "./action-math";
 import {runPreflight} from "./roll-preflight";
@@ -249,7 +250,7 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     if (workingScore < settings.pipsPerDice && !flatSkillsBypass) {
         ui.notifications.warn(game.i18n.localize("OD6S.SCORE_TOO_LOW"));
         if (isExplosive) {
-            await cancelAction({ ...data, isExplosive, itemid: data.itemId } as unknown as RollData);
+            await cancelAction({ ...data, isExplosive, itemid: data.itemId, regionId: data.regionId } as unknown as RollData);
         }
         return false;
     }
@@ -388,22 +389,17 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             && !!weaponRangeTable;
         if (wantsBucket) {
             let distance: number | undefined;
-            if (isExplosive) {
-                distance = item?.getFlag('od6s', 'explosiveRange') as number | undefined;
+            if (isExplosive && item) {
+                distance = getExplosivePending(item, data.regionId)?.range;
             } else {
                 distance = Math.floor(canvas.grid.measurePath([(actorToken as Token).center, targets[0].center]).distance);
             }
             if (typeof distance === 'number') {
                 const bucketRange = bucketRangeFromDistance(distance, weaponRangeTable!, rangeDifficulty);
                 if (bucketRange === null) {
-                    if (isExplosive && item) {
-                        const regionId = item.getFlag('od6s', 'explosiveTemplate') as string | undefined;
-                        if (regionId) {
-                            try { await canvas.scene.deleteEmbeddedDocuments('Region', [regionId]); } catch {/* region already gone */}
-                            await item.unsetFlag('od6s', 'explosiveSet');
-                            await item.unsetFlag('od6s', 'explosiveTemplate');
-                            await item.unsetFlag('od6s', 'explosiveRange');
-                        }
+                    if (isExplosive && item && data.regionId) {
+                        try { await canvas.scene.deleteEmbeddedDocuments('Region', [data.regionId]); } catch {/* region already gone */}
+                        await clearExplosivePending(item, data.regionId);
                     }
                     ui.notifications.warn(game.i18n.localize('OD6S.OUT_OF_RANGE'));
                     return false;
@@ -550,5 +546,6 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         targetsRef: targets,
         targetRef: targets[0],
         bucket: bucketWithOverrides,
+        regionId: data.regionId,
     });
 }

--- a/src/module/apps/roll-helpers/roll-type-fields.ts
+++ b/src/module/apps/roll-helpers/roll-type-fields.ts
@@ -40,6 +40,9 @@ export const COMMON_FIELDS = [
     'isvisible', 'isknown',
     // Derived from item flag at top of setup, before dispatch.
     'isExplosive',
+    // Region id of the explosive blast template (auto-explosive throws);
+    // threaded through from `OD6SItem.roll(parry, regionId)`. See #40.
+    'regionId',
     // Produced by classifyRoll, not handlers.
     'type', 'subtype',
     'actor', 'token',

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -46,20 +46,17 @@ export function registerChatHooks() {
                 actor = game.actors.get(message.speaker.actor);
             }
             const item = actor!.items.find(i => i.id === message.getFlag('od6s', 'itemId'));
-            const regionId = item?.getFlag('od6s', 'explosiveTemplate');
+            const regionId = message.getFlag('od6s', 'template') as string | undefined;
             if (regionId) {
                 const region = canvas.scene.getEmbeddedDocument('Region', regionId);
                 if (region) {
                     await canvas.scene.deleteEmbeddedDocuments('Region', [regionId]);
                 }
-            }
-            if (item) {
-                await item.update({
-                    "flags.od6s.-=explosiveSet": null,
-                    "flags.od6s.-=explosiveTemplate": null,
-                    "flags.od6s.-=explosiveOrigin": null,
-                    "flags.od6s.-=explosiveRange": null,
-                });
+                if (item) {
+                    await item.update({
+                        [`flags.od6s.explosivePending.-=${regionId}`]: null,
+                    });
+                }
             }
             await od6sutilities.wait(100);
         }
@@ -84,8 +81,10 @@ export function registerChatHooks() {
 
                     if (!data.flags.od6s.success && OD6S.autoExplosive) {
                         // Missed, scatter it
-                        if (message.getFlag('od6s', 'isExplosive')) {
-                            await od6sutilities.scatterExplosive(message.getFlag('od6s', 'range'), item!.getFlag('od6s', 'explosiveOrigin'), template!.id);
+                        if (message.getFlag('od6s', 'isExplosive') && item && template) {
+                            const pending = (item.getFlag('od6s', 'explosivePending') as
+                                Record<string, { origin: { x: number; y: number } }> | undefined)?.[template.id];
+                            await od6sutilities.scatterExplosive(message.getFlag('od6s', 'range'), pending?.origin, template.id);
                             await od6sutilities.wait(100);
                             updateTargets = true;
                         }
@@ -102,7 +101,7 @@ export function registerChatHooks() {
                     }
 
                     if (updateTargets) {
-                        newTargets = await od6sutilities.getExplosiveTargets(actor, item!.id);
+                        newTargets = await od6sutilities.getExplosiveTargets(actor, item!.id, template?.id);
                         if (Object.keys(newTargets).length === 0) {
                             await message.setFlag('od6s','showButton', false);
                         } else {
@@ -154,13 +153,14 @@ export function registerChatHooks() {
                     }
                     const item = actor!.items.find(i => i.id === msg.getFlag('od6s', 'item'));
 
-                    await item!.unsetFlag('od6s', 'explosiveSet');
-                    await item!.unsetFlag('od6s', 'explosiveTemplate');
-                    await item!.unsetFlag('od6s', 'explosiveOrigin');
-                    await item!.unsetFlag('od6s', 'explosiveRange');
+                    const regionId = msg.getFlag('od6s', 'template') as string | undefined;
+                    if (item && regionId) {
+                        await item.update({
+                            [`flags.od6s.explosivePending.-=${regionId}`]: null,
+                        });
+                    }
                     await od6sutilities.wait(100);
 
-                    const regionId = msg.getFlag('od6s', 'template');
                     const region = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
                     if (region) {
                         await region.setFlag('od6s', 'handled', true);

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -57,6 +57,11 @@ export function registerChatHooks() {
                         [`flags.od6s.explosivePending.-=${regionId}`]: null,
                     });
                 }
+            } else if (item) {
+                // Manual (non-auto) flow has no region. The dialog set
+                // `explosiveSet=true` to gate the resolution roll; clear it
+                // so a future throw reopens the placement dialog.
+                await item.unsetFlag('od6s', 'explosiveSet');
             }
             await od6sutilities.wait(100);
         }
@@ -84,9 +89,16 @@ export function registerChatHooks() {
                         if (message.getFlag('od6s', 'isExplosive') && item && template) {
                             const pending = (item.getFlag('od6s', 'explosivePending') as
                                 Record<string, { origin: { x: number; y: number } }> | undefined)?.[template.id];
-                            await od6sutilities.scatterExplosive(message.getFlag('od6s', 'range'), pending?.origin, template.id);
-                            await od6sutilities.wait(100);
-                            updateTargets = true;
+                            // Origin can be absent on edit-after-execute because
+                            // executeRollAction clears the pending entry once
+                            // the attack message is created (pre-existing in
+                            // the legacy scalar shape too). Skip scatter rather
+                            // than throwing in `Ray(undefined, target)`.
+                            if (pending?.origin) {
+                                await od6sutilities.scatterExplosive(message.getFlag('od6s', 'range'), pending.origin, template.id);
+                                await od6sutilities.wait(100);
+                                updateTargets = true;
+                            }
                         }
                     }
 

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -123,8 +123,13 @@ export function registerChatLogListeners() {
                 ? game.actors.get(message!.speaker.actor)
                 : game!.scenes.active.tokens.get(message!.speaker.token)?.actor;
             const item = actor!.items.get(message!.getFlag('od6s','itemId'));
-            const regionId = item!.getFlag('od6s','explosiveTemplate');
+            const regionId = message!.getFlag('od6s','template') as string | undefined;
             const region = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
+            if (item && regionId) {
+                await item.update({
+                    [`flags.od6s.explosivePending.-=${regionId}`]: null,
+                });
+            }
             if (region) await region.setFlag('od6s','handled', true);
             await message!.setFlag('od6s','handled', true);
             if (region) await canvas.scene.deleteEmbeddedDocuments('Region', [region.id]);

--- a/src/module/hooks/region-hooks.ts
+++ b/src/module/hooks/region-hooks.ts
@@ -19,7 +19,8 @@ export function registerRegionHooks() {
                 }
                 const targets = await od6sutilities.getExplosiveTargets(
                     actor,
-                    region.getFlag('od6s', 'item'));
+                    region.getFlag('od6s', 'item'),
+                    region.id);
                 await message.unsetFlag('od6s', 'targets');
                 await message.setFlag('od6s', 'targets', targets);
                 await message.render();
@@ -43,11 +44,10 @@ export function registerRegionHooks() {
         if (actor) {
             const item = actor.items.get(region.getFlag('od6s', 'item'));
             if (item) {
+                // Drop only the entry for this region — other in-flight
+                // throws of the same item retain their own pending state (#40).
                 await item.update({
-                    "flags.od6s.-=explosiveOrigin": null,
-                    "flags.od6s.-=explosiveRange": null,
-                    "flags.od6s.-=explosiveSet": null,
-                    "flags.od6s.-=explosiveTemplate": null,
+                    [`flags.od6s.explosivePending.-=${region.id}`]: null,
                 });
             }
         }

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -210,7 +210,7 @@ export class OD6SItem extends Item {
      * Handle clickable item rolls.
      * @private
      */
-    async roll(parry = false) {
+    async roll(parry = false, regionId?: string) {
         // Basic template rendering data
         const item = this;
         if (!this.actor) return;
@@ -221,6 +221,7 @@ export class OD6SItem extends Item {
 
         const rollData: any = {};
         rollData.token = this.parent.sheet.token;
+        if (regionId) rollData.regionId = regionId;
 
         switch (item.type) {
             case 'skill':

--- a/src/module/system/handlebars/explosives.ts
+++ b/src/module/system/handlebars/explosives.ts
@@ -25,8 +25,8 @@ export function registerExplosiveHelpers() {
         return zones;
     });
 
-    Handlebars.registerHelper('getExplosiveTargets', async (actorId, itemId) => {
-        return await od6sutilities.getExplosiveTargets(actorId, itemId);
+    Handlebars.registerHelper('getExplosiveTargets', async (actorId, itemId, regionId) => {
+        return await od6sutilities.getExplosiveTargets(actorId, itemId, regionId);
     })
 
     Handlebars.registerHelper('checkExplosiveTargets', (targets) => {

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -30,6 +30,10 @@ const MIGRATION_STEPS: Array<{ since: string; run: () => Promise<void> }> = [
     since: "2.2.0",
     run: () => migrateStatusEffectIcons(),
   },
+  {
+    since: "2.5.0",
+    run: () => migrateExplosivePendingFlags(),
+  },
 ];
 
 const CURRENT_MIGRATION_VERSION = MIGRATION_STEPS[MIGRATION_STEPS.length - 1]!.since;
@@ -197,6 +201,57 @@ async function migrateExplosiveTemplateFlags() {
   }
 
   console.log(`od6s | Cleaned explosive flags from ${count} items.`);
+}
+
+/**
+ * Drop the legacy scalar explosive flags (`explosiveTemplate`, `explosiveOrigin`,
+ * `explosiveRange`, `explosiveSet`). #40 replaces them with a per-region keyed
+ * map at `flags.od6s.explosivePending.<regionId>`. Stale scalars are transient
+ * pending state — the regions they pointed at have been gone since the v14
+ * migration, and the new code reads only the keyed map.
+ */
+async function migrateExplosivePendingFlags() {
+  console.log("od6s | Dropping legacy scalar explosive flags...");
+  let count = 0;
+
+  const drop = {
+    "flags.od6s.-=explosiveTemplate": null,
+    "flags.od6s.-=explosiveOrigin": null,
+    "flags.od6s.-=explosiveRange": null,
+    "flags.od6s.-=explosiveSet": null,
+  };
+
+  for (const actor of game.actors) {
+    const updates = [];
+    for (const item of actor.items) {
+      if (item.getFlag("od6s", "explosiveTemplate")
+          || item.getFlag("od6s", "explosiveOrigin")
+          || item.getFlag("od6s", "explosiveRange")
+          || item.getFlag("od6s", "explosiveSet")) {
+        updates.push({ _id: item.id, ...drop });
+      }
+    }
+    if (updates.length > 0) {
+      await actor.updateEmbeddedDocuments("Item", updates);
+      count += updates.length;
+    }
+  }
+
+  const worldItemUpdates = [];
+  for (const item of game.items) {
+    if (item.getFlag("od6s", "explosiveTemplate")
+        || item.getFlag("od6s", "explosiveOrigin")
+        || item.getFlag("od6s", "explosiveRange")
+        || item.getFlag("od6s", "explosiveSet")) {
+      worldItemUpdates.push({ _id: item.id, ...drop });
+    }
+  }
+  if (worldItemUpdates.length > 0) {
+    await Item.updateDocuments(worldItemUpdates);
+    count += worldItemUpdates.length;
+  }
+
+  console.log(`od6s | Dropped legacy scalar explosive flags from ${count} items.`);
 }
 
 /**

--- a/src/module/system/utilities.ts
+++ b/src/module/system/utilities.ts
@@ -25,8 +25,8 @@ export const od6sutilities = {
     async scatterExplosive(range: any, origin: any, regionId: any) {
         return explosiveUtils.scatterExplosive(range, origin, regionId);
     },
-    async getExplosiveTargets(actor: any, itemId: any) {
-        return explosiveUtils.getExplosiveTargets(actor, itemId);
+    async getExplosiveTargets(actor: any, itemId: any, regionId: string | undefined) {
+        return explosiveUtils.getExplosiveTargets(actor, itemId, regionId);
     },
     async detonateExplosives(combat: any) {
         return explosiveUtils.detonateExplosives(combat);

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -5,6 +5,30 @@ import { getDiceFromScore } from "./dice";
 import { getActorFromUuid } from "./actors";
 import { isWeaponItem } from "../type-guards";
 
+/**
+ * Per-throw state for an in-flight explosive, keyed by the blast region's id
+ * on `flags.od6s.explosivePending`. One entry per throw lets multiple
+ * unresolved instances of the same explosive item co-exist (#40) — the
+ * previous scalar flags clobbered each other on the second throw.
+ */
+export interface ExplosivePending {
+    origin: { x: number; y: number };
+    range: number;
+}
+
+/** Read the per-throw pending entry for `regionId`, or undefined if absent. */
+export function getExplosivePending(item: Item, regionId: string | undefined): ExplosivePending | undefined {
+    if (!regionId) return undefined;
+    const map = item.getFlag('od6s', 'explosivePending') as Record<string, ExplosivePending> | undefined;
+    return map?.[regionId];
+}
+
+/** Delete only the entry for `regionId` from the pending map (preserves other in-flight throws). */
+export async function clearExplosivePending(item: Item, regionId: string | undefined): Promise<void> {
+    if (!regionId) return;
+    await item.update({ [`flags.od6s.explosivePending.-=${regionId}`]: null });
+}
+
 export async function scatterExplosive(range: any, origin: any, regionId: any): Promise<void> {
     let distanceTerms = '';
     let angle = 0;
@@ -91,9 +115,9 @@ export async function scatterExplosive(range: any, origin: any, regionId: any): 
     await wait(100);
 }
 
-export async function getExplosiveTargets(actor: any, itemId: any): Promise<any[]> {
+export async function getExplosiveTargets(actor: any, itemId: any, regionId: string | undefined): Promise<any[]> {
     const item = actor.isToken ? actor.token.actor.items.get(itemId) : actor.items.get(itemId);
-    const regionId = item.getFlag('od6s', 'explosiveTemplate');
+    if (!regionId) return [];
     const region = canvas.scene.getEmbeddedDocument('Region', regionId);
     if (!region) return [];
     const shape = region.shapes[0];
@@ -146,7 +170,7 @@ export async function detonateExplosives(combat: any): Promise<void> {
             tokenId: region.getFlag('od6s', 'token'),
             itemId: region.getFlag('od6s','item'),
             templateId: region.id,
-            targets: await getExplosiveTargets(actor, region.getFlag('od6s','item')),
+            targets: await getExplosiveTargets(actor, region.getFlag('od6s','item'), region.id),
             triggered: true
         }
 
@@ -182,18 +206,21 @@ export async function detonateExplosive(data: any): Promise<any> {
         actor = token!.actor;
     }
 
+    // Region id stamped on the attack message at creation; falls back to the
+    // dataset templateId for legacy / handler-driven callers.
+    const regionId = (message?.getFlag('od6s', 'template') as string | undefined) || data.templateId;
+
     let targets;
     if (message) {
         targets = await game!.messages!.get(data.messageId)!.getFlag('od6s', 'targets');
     } else {
-        targets = await getExplosiveTargets(actor, data.itemId);
+        targets = await getExplosiveTargets(actor, data.itemId, regionId);
     }
 
     const item = actor!.items.get(data.itemId);
     const wsys = item && isWeaponItem(item) ? item.system : undefined;
 
     if (game.settings.get('od6s', 'auto_explosive')) {
-        const regionId = item!.getFlag('od6s', 'explosiveTemplate');
         const region = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
 
         if (region) {

--- a/src/module/system/utilities/misc.ts
+++ b/src/module/system/utilities/misc.ts
@@ -27,7 +27,10 @@ export function getTemplateFromMessage(message: ChatMessage): { actor: Actor | u
         actor = game.actors.get(message.speaker.actor);
     }
     const item = actor!.items.get(message.getFlag('od6s', 'itemId'));
-    const regionId = item?.getFlag('od6s', 'explosiveTemplate');
+    // Region id stamped on the message at creation (roll-execute). Falls back
+    // to the (deprecated) item flag for messages created before #40 landed.
+    const regionId = (message.getFlag('od6s', 'template') as string | undefined)
+        ?? (item?.getFlag('od6s', 'explosiveTemplate') as string | undefined);
     const data: any = {};
     data.actor = actor;
     data.item = item;


### PR DESCRIPTION
## Summary

Closes #40. A second throw of the same explosive item before the first resolved clobbered the first throw's flags — the per-throw state lived as four scalar item flags (`explosiveTemplate`, `explosiveOrigin`, `explosiveRange`, `explosiveSet`) so throw 2 overwrote throw 1's region pointer.

- Replace the scalars with a per-region keyed map at `flags.od6s.explosivePending.<regionId> = {origin, range}`.
- Thread the region id through `OD6SItem.roll(parry, regionId)` and `RollData.regionId`, stamp it onto every explosive attack chat message as `flags.od6s.template`, and switch every cleanup path to address only its own throw's entry.
- `getExplosiveTargets(actor, itemId, regionId)` is now region-explicit at every call site.
- `explosiveSet` retained as the manual (non-auto) placement gate; auto path no longer writes it. The explosive preflight gate also accepts a non-empty pending map.
- Migration step at `2.5.0` drops the legacy scalars from owned + world items.

## Test plan

- [x] `pnpm run check` — typecheck + lint (636/720) + 344 unit + 303 domain tests
- [ ] Smoke: single auto-explosive throw resolves and cleans up
- [ ] Smoke: **two queued throws of the same grenade item both resolve** (the bug)
- [ ] Smoke: chat-message preDelete cleans up its region only
- [ ] Smoke: remove-template-button still deletes region + entry
- [ ] Smoke: end-of-round detonation still finds targets
- [ ] Smoke: manual (non-auto) explosive flow unchanged
- [ ] Migration: world with stale legacy `explosive*` scalars on owned items boots cleanly and clears them