### PR TITLE
fix(explosives): #86 read target dodge from system, drop dead metaphysics dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,19 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   each attack chat message as `flags.od6s.template`, so cleanup
   paths address only their own throw's entry. Migration drops the
   legacy scalars on world upgrade (#40).
+- Auto-explosive zone-damage code now reads target dodge from
+  `actor.system.dodge.score` (via a type-guarded helper) instead of
+  flat `(actor as any).dodge`, which was always `undefined` — so
+  `undefined > total` always returned `false` and the
+  dodge-vs-explosive evade branch never fired. High-dodge targets
+  now actually evade as intended (#86).
 
 ### Removed
+
+- Dead `od6sroll._metaphysicsRollDialog` method and the
+  `MetaphysicsRollData` type. Zero call sites in code or templates;
+  the `(actor as any).actions.length` access inside it would have
+  thrown `TypeError` if reached (#86).
 
 ## [2.4.0] - 2026-05-02
 

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -191,18 +191,6 @@ export interface RollMessageFlags {
     template?: string;
 }
 
-/** Minimal payload for metaphysics multi-skill roll dialogs — not a full RollData. */
-export interface MetaphysicsRollData {
-    title: string;
-    skills: Record<string, { difficulty: string; skill: Item }>;
-    wilddie: boolean;
-    showWildDie: boolean | unknown;
-    actor: Actor;
-    actionpenalty: number;
-    stunnedpenalty: number;
-    template: string;
-}
-
 // ---- Pure helpers ----
 
 /**

--- a/src/module/apps/roll.ts
+++ b/src/module/apps/roll.ts
@@ -1,16 +1,15 @@
-import OD6S from "../config/config-od6s";
 import {RollDialog} from "./roll-dialog";
 import {setupRollData} from "./roll-helpers/roll-setup";
 import {executeRollAction} from "./roll-helpers/roll-execute";
-import {isCharacterActor, isVehicleActor, isActionItem} from "../system/type-guards";
+import {isVehicleActor, isActionItem} from "../system/type-guards";
 import {getDifficulty, applyDifficultyEffects, applyDamageEffects} from "./roll-helpers/roll-difficulty";
 import {getEffectMod, getRange, cancelAction} from "./roll-helpers/roll-effects";
-import type {RollData, IncomingRollData, MetaphysicsRollData} from "./roll-helpers/roll-data";
+import type {RollData, IncomingRollData} from "./roll-helpers/roll-data";
 
 export class od6sroll {
 
-    rollData: RollData | MetaphysicsRollData | undefined;
-    static rollData: RollData | MetaphysicsRollData | undefined;
+    rollData: RollData | undefined;
+    static rollData: RollData | undefined;
 
     activateListeners(html: HTMLElement) {
         // @ts-expect-error super reference in mixin-style class
@@ -73,57 +72,6 @@ export class od6sroll {
 
     async rollPurchase(data: IncomingRollData) {
         await (this as any)._onRollDialog(data);
-    }
-
-    static async _metaphysicsRollDialog(item: Item, actor: Actor) {
-        const skills: Record<string, { difficulty: string; skill: Item }> = {};
-
-        for (const s in (item.system as any).skills) {
-            let name: string | undefined;
-            switch (s) {
-                case 'channel':
-                    name = OD6S.channelSkillName;
-                    break;
-                case 'sense':
-                    name = OD6S.senseSkillName;
-                    break;
-                case 'transform':
-                    name = OD6S.transformSkillName;
-                    break;
-                default:
-                    break;
-            }
-            if ((item.system as any).skills[s].value) {
-                const skill = actor.items.filter((i: Item) => i.name === name);
-                if (typeof (skill[0]) !== 'undefined') {
-                    skills[s] = {
-                        difficulty: OD6S.difficultyShort[(item.system as any).skills[s].difficulty],
-                        skill: skill[0],
-                    };
-                } else {
-                    return ui.notifications.warn(
-                        OD6S.metaphysicsSkills[s] + game.i18n.localize("OD6S.WARN_SKILL_NOT_FOUND")
-                    )
-                }
-            }
-        }
-
-        const actions = Object.keys(skills).length;
-        const actionpenalty = (+actions) + ((actor as any).actions.length) - 1;
-        const stunnedpenalty = isCharacterActor(actor) ? actor.system.stuns.current : 0;
-
-        this.rollData = {
-            title: item.name,
-            skills: skills,
-            wilddie: Boolean(game.settings.get('od6s', 'use_wild_die') && actor.system.use_wild_die),
-            showWildDie: game.settings.get('od6s', 'use_wild_die'),
-            actor: actor,
-            actionpenalty: actionpenalty,
-            stunnedpenalty: stunnedpenalty,
-            template: "systems/od6s/templates/metaphysicsRoll.html"
-        } satisfies MetaphysicsRollData;
-
-        new RollDialog(this, () => void od6sroll.rollAction()).render({force: true});
     }
 
     static async _onRollDialog(data: IncomingRollData) {

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -3,7 +3,21 @@ import { wait } from "./converters";
 import { boolCheck } from "./converters";
 import { getDiceFromScore } from "./dice";
 import { getActorFromUuid } from "./actors";
-import { isWeaponItem } from "../type-guards";
+import { isCharacterActor, isVehicleActor, isWeaponItem } from "../type-guards";
+
+/**
+ * Resolve a target actor's dodge score for the auto-explosive evade check.
+ * Both `OD6SCharacterSystem.dodge` and `OD6SVehicleSystem.dodge` carry a
+ * `.score` field; pre-#86 code read `(actor as any).dodge` flat off the
+ * actor — always undefined, so `undefined > number` always returned false
+ * and the dodge branch never fired.
+ */
+function getDodgeScore(actor: Actor): number {
+    if (isCharacterActor(actor) || isVehicleActor(actor)) {
+        return Number(actor.system.dodge?.score ?? 0);
+    }
+    return 0;
+}
 
 /**
  * Per-throw state for an in-flight explosive, keyed by the blast region's id
@@ -294,7 +308,7 @@ export async function detonateExplosive(data: any): Promise<any> {
                 if(!message) {
                     // TODO: Figure out a better way to deal with this
                     damage = roll.total;
-                } else if ((actor as any).dodge > message.getFlag('od6s', 'total')) {
+                } else if (getDodgeScore(actor) > (message.getFlag('od6s', 'total') as number)) {
                     damage = 0;
                 } else {
                     damage = roll.total;
@@ -353,7 +367,7 @@ export async function detonateExplosive(data: any): Promise<any> {
             let actor = await game.actors.get(target.id);
             if (typeof (actor) === 'undefined') actor = game!.scenes!.active!.tokens.get(target.id)!.actor;
             if(typeof(actor) === 'undefined') continue;
-            if((actor as any).dodge > message!.getFlag('od6s','total')) {
+            if(getDodgeScore(actor) > (message!.getFlag('od6s','total') as number)) {
                 // noop
             } else {
                 switch(target.zone) {


### PR DESCRIPTION
## Summary

Closes #86. Two of the three suspected runtime-bug sites; the third was already cleaned up by #57 / #98.

- **`(actor as any).dodge` (explosives.ts × 2)** — real silent bug. \`dodge\` lives at \`actor.system.dodge.score\` for character and vehicle actors, so \`(actor as any).dodge\` was always \`undefined\` and \`undefined > total\` always returned \`false\`. The auto-explosive evade-on-dodge branch never fired. Replaced with a typed \`getDodgeScore(actor)\` helper using \`isCharacterActor\` / \`isVehicleActor\` guards.
- **\`(actor as any).actions.length\` (roll.ts:112)** — dead code. \`_metaphysicsRollDialog\` had zero call sites in source or templates, and \`actor.actions\` isn't on any system schema. Deleted the method and the \`MetaphysicsRollData\` type; the rollData union collapses to \`RollData | undefined\`. Net `-23` lint warnings.
- **\`(data.actor as any).vehicle_weapons\` (roll-setup.ts)** — already migrated to \`data.actor.system.vehicle.vehicle_weapons\` during prior sweeps. Verified, no work needed.

## Test plan

- [x] \`pnpm run check\` — typecheck + lint (613/720) + 344 unit + 303 domain tests
- [ ] Smoke: throw an auto-explosive at a target with high dodge and verify it now evades when dodge > attacker total
- [ ] Smoke: regression — low-dodge target still takes damage as before
- [ ] Confirm no UI flow opened the metaphysics roll (it didn't have a button binding) — sheet renders + skill rolls unchanged