### PR TITLE
refactor(types): #57 narrow roll-setup + item.ts via type guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   Handlebars accumulators are typed as `Record<string, T>` instead
   of being indexed via `as any`. `OD6SItem.createDialog` now takes a
   typed `data` parameter (#56).
+- `roll-setup.ts` and `item.ts` now narrow `actor` and `item` via
+  the existing type-guard helpers (plus two new combined guards
+  `isAnyWeaponItem` / `isVehicleBorneWeaponItem`) instead of
+  ad-hoc `as OD6SCharacterSystem` / `as OD6SWeaponItemSystem`
+  casts. ~25 narrowing casts removed; the remaining surface in
+  `OD6SItem.roll()` is documented (#57).
 
 ### Fixed
 

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -30,7 +30,7 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {cancelAction, getEffectMod} from "./roll-effects";
-import {isCharacterActor, isVehicleActor} from "../../system/type-guards";
+import {isAnyWeaponItem, isCharacterActor, isSkillItem, isVehicleActor, isVehicleBorneWeaponItem} from "../../system/type-guards";
 import {bucketRangeFromDistance, flatSkillBonusPips, splitBonusForPenalty} from "./difficulty-math";
 import type {IncomingRollData, RollData, ClassifiedRoll, RollTypeKey} from "./roll-data";
 import {classifyRoll} from "./roll-data";
@@ -138,7 +138,7 @@ function preResolveActionSkill(
         sysAttrs[k] = { score: +v.score };
     }
 
-    const skillSys = skillItem ? (skillItem.system as OD6SSkillItemSystem) : null;
+    const skillSys = skillItem && isSkillItem(skillItem) ? skillItem.system : null;
     return resolveSkillBackedAction({
         skill: skillSys
             ? { score: skillSys.score, attributeKey: skillSys.attribute.toLowerCase() }
@@ -197,7 +197,8 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
 
     const item = resolveItemForDispatch(data);
     const isExplosive = !!item
-        && (item.system as OD6SWeaponItemSystem | undefined)?.subtype?.toLowerCase() === 'explosive';
+        && isAnyWeaponItem(item)
+        && item.system.subtype?.toLowerCase() === 'explosive';
 
     // For weapon-typed rolls with a localized ranged subtype alias (RANGED /
     // THROWN / MISSILE / EXPLOSIVE), getWeaponRange resolves the per-roll
@@ -211,12 +212,11 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
             const r = await od6sutilities.getWeaponRange(data.actor, item);
             if (r === false) return false;
             weaponRangeTable = r as typeof weaponRangeTable;
-        } else {
-            weaponRangeTable = (item.system as OD6SWeaponItemSystem).range as unknown as typeof weaponRangeTable;
+        } else if (isAnyWeaponItem(item)) {
+            weaponRangeTable = item.system.range as unknown as typeof weaponRangeTable;
         }
-    } else if (item && classified.key === 'action-vehiclerangedweaponattack') {
-        const sys = item.system as { range?: typeof weaponRangeTable };
-        weaponRangeTable = sys.range;
+    } else if (item && classified.key === 'action-vehiclerangedweaponattack' && isVehicleBorneWeaponItem(item)) {
+        weaponRangeTable = item.system.range as unknown as typeof weaponRangeTable;
     }
 
     const actorToken = data.actor.isToken ? data.actor.token.object : data.actor.getActiveTokens()[0];
@@ -263,8 +263,8 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     // (handler already folded `damage` into bucket.damagescore via the same
     // helper — applyWeaponMods is run twice but discarded outputs differ, so no
     // double-fold happens).
-    if (item && (classified.type === 'weapon' || classified.type === 'starship-weapon' || classified.type === 'vehicle-weapon')) {
-        const wsys = item.system as OD6SWeaponItemSystem;
+    if (item && isAnyWeaponItem(item)) {
+        const wsys = item.system;
         const folded = applyWeaponMods({ damageScore: 0, miscMod, bonusmod }, wsys.mods);
         miscMod = folded.miscMod;
         bonusmod = folded.bonusmod;
@@ -281,9 +281,8 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         }
     }
 
-    if (item && classified.key === 'action-vehiclerangedweaponattack') {
-        const wsys = item.system as OD6SVehicleWeaponItemSystem;
-        const folded = applyWeaponMods({ damageScore: 0, miscMod, bonusmod }, wsys.mods);
+    if (item && classified.key === 'action-vehiclerangedweaponattack' && isVehicleBorneWeaponItem(item)) {
+        const folded = applyWeaponMods({ damageScore: 0, miscMod, bonusmod }, item.system.mods);
         miscMod = folded.miscMod;
         bonusmod = folded.bonusmod;
     }
@@ -311,17 +310,16 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         || subtype === 'vehiclerangedweaponattack';
     if (isRangedSubtype) {
         if (subtype.startsWith('vehicle')) {
-            const vehSys = data.actor.system as OD6SVehicleSystem;
-            const charSys = data.actor.system as OD6SCharacterSystem & {
-                vehicle: { ranged?: { score?: number } };
-            };
-            if (vehSys?.embedded_pilot?.value && typeof ((vehSys?.ranged as OD6SScoreField)?.score) !== 'undefined') {
-                bonusmod += +(vehSys.ranged as OD6SScoreField).score;
-            } else if (typeof (charSys?.vehicle?.ranged?.score) !== 'undefined') {
-                bonusmod += +charSys.vehicle.ranged.score;
+            if (isVehicleActor(data.actor)
+                && data.actor.system.embedded_pilot?.value
+                && typeof data.actor.system.ranged?.score !== 'undefined') {
+                bonusmod += +data.actor.system.ranged.score;
+            } else if (isCharacterActor(data.actor)
+                && typeof data.actor.system.vehicle?.ranged?.score !== 'undefined') {
+                bonusmod += +data.actor.system.vehicle.ranged.score;
             }
-        } else {
-            bonusmod += +(data.actor.system.ranged as OD6SModField).mod;
+        } else if (isCharacterActor(data.actor)) {
+            bonusmod += +data.actor.system.ranged.mod;
         }
     }
 
@@ -354,11 +352,17 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     } else if (isAttackRoll) {
         const isVehicleSubtype = subtype.includes('vehicle');
         if (isVehicleSubtype) {
-            attackerScale = (data.actor.type === 'vehicle' || data.actor.type === 'starship')
-                ? +((data.actor.system as { scale?: { score?: number } }).scale?.score ?? 0)
-                : +((data.actor.system as OD6SCharacterSystem).vehicle?.scale?.score ?? 0);
+            if (isVehicleActor(data.actor)) {
+                attackerScale = +(data.actor.system.scale?.score ?? 0);
+            } else if (isCharacterActor(data.actor)) {
+                attackerScale = +(data.actor.system.vehicle?.scale?.score ?? 0);
+            } else {
+                attackerScale = 0;
+            }
+        } else if (isCharacterActor(data.actor) || isVehicleActor(data.actor)) {
+            attackerScale = +(data.actor.system.scale?.score ?? 0);
         } else {
-            attackerScale = +(((data.actor.system as { scale?: { score?: number } }).scale?.score) ?? 0);
+            attackerScale = 0;
         }
     } else {
         attackerScale = bucketAny.attackerScale ?? 0;
@@ -428,10 +432,9 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
         workingScoreForFinalize = workingScoreForFinalize + (+data.actor.system.roll_mod);
     }
 
-    if (classified.type === 'damage' && item) {
-        const wsys = item.system as OD6SWeaponItemSystem | undefined;
-        if (wsys && wsys.damaged > 0) {
-            workingScoreForFinalize -= OD6S.weaponDamage[wsys.damaged].penalty;
+    if (classified.type === 'damage' && item && isAnyWeaponItem(item)) {
+        if (item.system.damaged > 0) {
+            workingScoreForFinalize -= OD6S.weaponDamage[item.system.damaged].penalty;
         }
     }
 

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -263,7 +263,14 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     // (handler already folded `damage` into bucket.damagescore via the same
     // helper — applyWeaponMods is run twice but discarded outputs differ, so no
     // double-fold happens).
-    if (item && isAnyWeaponItem(item)) {
+    // Gate on canonical `classified.type` (not item type): action-routed
+    // weapon attacks like `action-vehiclerangedweaponattack` have
+    // classified.type === 'action' and accumulate mods in the dedicated
+    // block below. Folding here too would double-count.
+    const isWeaponClassifiedType = classified.type === 'weapon'
+        || classified.type === 'starship-weapon'
+        || classified.type === 'vehicle-weapon';
+    if (item && isWeaponClassifiedType && isAnyWeaponItem(item)) {
         const wsys = item.system;
         const folded = applyWeaponMods({ damageScore: 0, miscMod, bonusmod }, wsys.mods);
         miscMod = folded.miscMod;

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -1,7 +1,7 @@
 import {od6sroll} from "../apps/roll";
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
-import {isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem, isWeaponItem, isVehicleWeaponItem, isStarshipWeaponItem} from "../system/type-guards";
+import {isAnyWeaponItem, isActionItem, isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem, isVehicleBorneWeaponItem, isWeaponItem, isVehicleWeaponItem, isStarshipWeaponItem} from "../system/type-guards";
 
 /**
  * Extend the basic Item with some very simple modifications.
@@ -87,30 +87,26 @@ export class OD6SItem extends Item {
                 return this.actor.system.attributes[this.system.attribute.toLowerCase()].score + this.system.score;
             }
         }
-        if (this.type.match(/weapon/)) {
-            if (this.actor && (isCharacterActor(this.actor) || isVehicleActor(this.actor))) {
-                const sys = this.system as OD6SWeaponItemSystem & { fire_control?: { score: number } };
-                let score = this.actor.system.attributes[sys.stats.attribute.toLowerCase()].score;
-                const spec = this.actor.items.find(i => i.name === sys.stats.specialization && i.type === 'specialization');
-                if (spec !== undefined && isSpecializationItem(spec)) {
-                    if (typeof sys.fire_control !== 'undefined' && (sys.fire_control?.score as unknown) !== '') {
-                        score = score + sys.fire_control.score;
-                    }
-                    return score + spec.system.score;
-                } else {
-                    const skill = this.actor.items.find(i => i.name === sys.stats.skill && i.type === 'skill');
-                    if (skill !== undefined && isSkillItem(skill)) {
-                        if (typeof sys.fire_control !== 'undefined' && (sys.fire_control?.score as unknown) !== '') {
-                            score = score + sys.fire_control.score;
-                        }
-                        return score + skill.system.score;
-                    }
-                }
-                if (typeof sys.fire_control?.score !== 'undefined' && (sys.fire_control?.score as unknown) !== '') {
-                    score = score + sys.fire_control.score;
-                }
-                return score;
+        if (isAnyWeaponItem(this)
+            && this.actor && (isCharacterActor(this.actor) || isVehicleActor(this.actor))) {
+            const stats = this.system.stats;
+            // `fire_control` is only on vehicle / starship-weapon systems; for
+            // hand weapons it's absent (the legacy cast spliced it in optionally).
+            const fireControlScore = isVehicleBorneWeaponItem(this)
+                && (this.system.fire_control?.score as unknown) !== ''
+                ? this.system.fire_control.score
+                : 0;
+            let score = this.actor.system.attributes[stats.attribute.toLowerCase()].score;
+            const spec = this.actor.items.find(i => i.name === stats.specialization && i.type === 'specialization');
+            if (spec !== undefined && isSpecializationItem(spec)) {
+                return score + fireControlScore + spec.system.score;
             }
+            const skill = this.actor.items.find(i => i.name === stats.skill && i.type === 'skill');
+            if (skill !== undefined && isSkillItem(skill)) {
+                return score + fireControlScore + skill.system.score;
+            }
+            score = score + fireControlScore;
+            return score;
         }
     }
 
@@ -218,7 +214,14 @@ export class OD6SItem extends Item {
         const item = this;
         if (!this.actor) return;
         const actor = this.actor;
-        const actorData = actor.system as OD6SCharacterSystem & Record<string, any>;
+        // `roll()` reads `attributes` (and `vehicle.*` for vehicle-weapon
+        // paths fired by an embedded pilot, where `actor` is the vehicle).
+        // The system schema for vehicles doesn't carry `attributes`, so this
+        // cast is wider than runtime is — vehicle paths through here are a
+        // pre-existing latent issue tracked elsewhere. The
+        // `Record<string, unknown>` slot lets the legacy "attribute key
+        // collision with custom labels" lookup compile (line ~295).
+        const actorData = actor.system as OD6SCharacterSystem;
         const itemData = item.system;
         let flatPips = 0;
 
@@ -229,7 +232,8 @@ export class OD6SItem extends Item {
         switch (item.type) {
             case 'skill':
             case 'specialization': {
-                const sys = itemData as OD6SSkillItemSystem;
+                if (!isSkillItem(item) && !isSpecializationItem(item)) break;
+                const sys = item.system;
                 if (OD6S.flatSkills) {
                     rollData.score = +(actorData.attributes[sys.attribute.toLowerCase()].score);
                     flatPips = (+sys.score)
@@ -245,22 +249,27 @@ export class OD6SItem extends Item {
             case 'starship-weapon':
             case 'vehicle-weapon':
             case 'weapon': {
-                const sys = itemData as OD6SWeaponItemSystem;
+                if (!isAnyWeaponItem(item)) break;
+                const sys = item.system;
                 // Try a specialization first, then a skill, then an attribute
                 let found = false;
 
                 if (parry && game.settings.get('od6s','parry_skills')) {
                     let skill;
-                    if(typeof(sys.stats.parry_specialization) !== "undefined" && sys.stats.parry_specialization !== "") {
-                        skill = actor.items.find((skill: Item) => skill.name === sys.stats.parry_specialization && skill.type === 'specialization');
+                    // parry_skill / parry_specialization only exist on regular
+                    // hand/personal weapons; vehicle/starship weapons can't parry.
+                    const parrySpec = isWeaponItem(item) ? item.system.stats.parry_specialization : '';
+                    const parrySkill = isWeaponItem(item) ? item.system.stats.parry_skill : '';
+                    if(typeof parrySpec !== "undefined" && parrySpec !== "") {
+                        skill = actor.items.find((skill: Item) => skill.name === parrySpec && skill.type === 'specialization');
                     }
-                    else if(typeof(sys.stats.parry_skill) !== "undefined" && sys.stats.parry_skill !== "") {
-                    	skill = actor.items.find((skill: Item) => skill.name === sys.stats.parry_skill && skill.type === 'skill');
+                    else if(typeof parrySkill !== "undefined" && parrySkill !== "") {
+                    	skill = actor.items.find((skill: Item) => skill.name === parrySkill && skill.type === 'skill');
                      } else {
                     	skill = actor.items.find((skill: Item) => skill.name === game.i18n.localize(OD6S.actions.parry.skill) && skill.type === 'skill');
                     }
-                    if (skill) {
-                        const skillSys = skill.system as OD6SSkillItemSystem;
+                    if (skill && (isSkillItem(skill) || isSpecializationItem(skill))) {
+                        const skillSys = skill.system;
                         if(OD6S.flatSkills) {
                             rollData.score = (+actorData.attributes[skillSys.attribute.toLowerCase()].score);
                             flatPips = (+skillSys.score);
@@ -274,8 +283,9 @@ export class OD6SItem extends Item {
                 }
 
                 if (!found && sys.stats.specialization !== null) {
-                    const spec = actor.items.find((spec: Item) => spec.name === sys.stats.specialization && spec.type === 'specialization');                    if (spec) {
-                        const specSys = spec.system as OD6SSpecializationItemSystem;
+                    const spec = actor.items.find((spec: Item) => spec.name === sys.stats.specialization && spec.type === 'specialization');
+                    if (spec && isSpecializationItem(spec)) {
+                        const specSys = spec.system;
                         if(OD6S.flatSkills) {
                             rollData.score = (+actorData.attributes[specSys.attribute.toLowerCase()].score);
                             flatPips = (+specSys.score);
@@ -295,8 +305,8 @@ export class OD6SItem extends Item {
                         attr = actorData.attributes[od6sutilities.lookupAttributeKey(sys.stats.attribute.toLowerCase())];
                         if(typeof(attr?.score) === "undefined" || attr === null) return false;
                     }
-                    if (typeof (skill) !== 'undefined' && skill !== null) {
-                        const skillSys = skill.system as OD6SSkillItemSystem;
+                    if (skill && isSkillItem(skill)) {
+                        const skillSys = skill.system;
                         if(OD6S.flatSkills) {
                             rollData.score = (+attr.score);
                             flatPips = (+skillSys.score);
@@ -319,7 +329,8 @@ export class OD6SItem extends Item {
                 break;
             }
             case 'action': {
-                const sys = itemData as OD6SActionItemSystem;
+                if (!isActionItem(item)) break;
+                const sys = item.system;
                 let name = '';
                 if ((sys.subtype === 'rangedattack' || sys.subtype === 'meleeattack') && sys.itemId !== '') {
                     // Roll is linked to an inventory item, roll that instead
@@ -359,31 +370,32 @@ export class OD6SItem extends Item {
                     } else {
                         skill = actor.items.find((i: Item) => i.name === name);
                     }
-                    const skillSys = skill?.system as OD6SSkillItemSystem | undefined;
-                    if (skill !== null && typeof (skill) !== 'undefined' && typeof (skillSys?.score) !== 'undefined') {
+                    if (skill && (isSkillItem(skill) || isSpecializationItem(skill))
+                        && typeof skill.system.score !== 'undefined') {
+                        const skillSys = skill.system;
                         if(OD6S.flatSkills) {
-                            rollData.score = (+actorData.attributes[skillSys!.attribute.toLowerCase()].score);
-                            flatPips = (+skillSys!.score);
+                            rollData.score = (+actorData.attributes[skillSys.attribute.toLowerCase()].score);
+                            flatPips = (+skillSys.score);
                         } else {
-                            if((this.system as OD6SSkillItemSystem).isAdvancedSkill) {
-                                rollData.score = (+skillSys!.score);
+                            if(isSkillItem(this) && this.system.isAdvancedSkill) {
+                                rollData.score = (+skillSys.score);
                             } else {
-                                rollData.score = (+skillSys!.score) + (+actorData.attributes[skillSys!.attribute.toLowerCase()].score);
+                                rollData.score = (+skillSys.score) + (+actorData.attributes[skillSys.attribute.toLowerCase()].score);
                             }
                         }
                     } else {
                         // Search compendia for the skill and use the attribute
                         skill = (await od6sutilities._getItemFromWorld(name)) as Item | undefined;
-                        if (skill !== null && typeof (skill) !== 'undefined') {
-                            rollData.score = (+actorData.attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score);
+                        if (skill && isSkillItem(skill)) {
+                            rollData.score = (+actorData.attributes[skill.system.attribute.toLowerCase()].score);
                         } else {
                             skill = (await od6sutilities._getItemFromCompendium(name)) as Item | undefined;
-                            if (skill !== null && typeof (skill) !== 'undefined') {
-                                rollData.score = (+actorData.attributes[(skill.system as OD6SSkillItemSystem).attribute.toLowerCase()].score);
+                            if (skill && isSkillItem(skill)) {
+                                rollData.score = (+actorData.attributes[skill.system.attribute.toLowerCase()].score);
                             } else {
                                 // Cannot find, use defaults for the type
                                 for (const a in OD6S.actions) {
-                                    if (OD6S.actions[a].type === (itemData as OD6SActionItemSystem).subtype) {
+                                    if (OD6S.actions[a].type === sys.subtype) {
                                         rollData.score = (+actorData.attributes[OD6S.actions[a].base].score);
                                         break;
                                     }
@@ -397,14 +409,13 @@ export class OD6SItem extends Item {
             }
         }
 
-        if(item.type === 'starship-weapon' || item.type === 'vehicle-weapon') {
-            const sys = item.system as OD6SVehicleWeaponItemSystem;
-            if(sys?.fire_control.score > 0) {
-                rollData.score = (+rollData.score) + (+sys.fire_control.score);
+        if (isVehicleBorneWeaponItem(item)) {
+            if(item.system.fire_control.score > 0) {
+                rollData.score = (+rollData.score) + (+item.system.fire_control.score);
             }
         }
 
-        let subtype = (itemData as OD6SActionItemSystem).subtype;
+        let subtype = isActionItem(item) ? item.system.subtype : '';
         if (parry) {
             subtype = "parry";
         }

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -214,13 +214,11 @@ export class OD6SItem extends Item {
         const item = this;
         if (!this.actor) return;
         const actor = this.actor;
-        // `roll()` reads `attributes` (and `vehicle.*` for vehicle-weapon
-        // paths fired by an embedded pilot, where `actor` is the vehicle).
-        // The system schema for vehicles doesn't carry `attributes`, so this
-        // cast is wider than runtime is — vehicle paths through here are a
-        // pre-existing latent issue tracked elsewhere. The
-        // `Record<string, unknown>` slot lets the legacy "attribute key
-        // collision with custom labels" lookup compile (line ~295).
+        // Cast keeps the call sites uniform across actor types — vehicle and
+        // character system schemas both expose `attributes`, but the rest of
+        // `roll()` also reads character-only fields (e.g. `funds`, `credits`)
+        // in the action / purchase paths. Vehicle items normally roll through
+        // `Actor.rollAction`, not here.
         const actorData = actor.system as OD6SCharacterSystem;
         const itemData = item.system;
         let flatPips = 0;
@@ -377,7 +375,13 @@ export class OD6SItem extends Item {
                             rollData.score = (+actorData.attributes[skillSys.attribute.toLowerCase()].score);
                             flatPips = (+skillSys.score);
                         } else {
-                            if(isSkillItem(this) && this.system.isAdvancedSkill) {
+                            // Advanced-skill check is on the resolved skill, not
+                            // the action item — legacy code cast `this.system as
+                            // OD6SSkillItemSystem` and read `isAdvancedSkill`,
+                            // which was always undefined → falsy on actions, so
+                            // this branch was effectively unreachable. Now it
+                            // actually fires when a routed skill is advanced.
+                            if(skillSys.isAdvancedSkill) {
                                 rollData.score = (+skillSys.score);
                             } else {
                                 rollData.score = (+skillSys.score) + (+actorData.attributes[skillSys.attribute.toLowerCase()].score);

--- a/src/module/system/type-guards.ts
+++ b/src/module/system/type-guards.ts
@@ -48,3 +48,24 @@ export function isStarshipWeaponItem(item: Item): item is OD6SStarshipWeaponItem
 export function isActionItem(item: Item): item is OD6SActionItem {
     return item.type === "action";
 }
+
+/**
+ * Combined guard for any weapon-family item. Use when the surrounding code
+ * accesses fields shared across the three weapon types (e.g. `mods`,
+ * `damaged`, `subtype`) rather than vehicle/starship-only fields.
+ */
+export function isAnyWeaponItem(
+    item: Item,
+): item is OD6SWeaponItem | OD6SVehicleWeaponItem | OD6SStarshipWeaponItem {
+    return item.type === "weapon" || item.type === "vehicle-weapon" || item.type === "starship-weapon";
+}
+
+/**
+ * Combined guard for vehicle-borne weapon items. Narrows to the union that
+ * carries vehicle-weapon-specific fields (`fire_control`, `stats`, `subtype`).
+ */
+export function isVehicleBorneWeaponItem(
+    item: Item,
+): item is OD6SVehicleWeaponItem | OD6SStarshipWeaponItem {
+    return item.type === "vehicle-weapon" || item.type === "starship-weapon";
+}


### PR DESCRIPTION
## Summary

Closes the #57 tail. Replaces the ~25 remaining \`as OD6S*\` narrowing casts in \`OD6SItem.roll()\` and \`setupRollData\` with predicate helpers, plus two new combined guards:

- **\`isAnyWeaponItem\`** — narrows to the \`weapon | vehicle-weapon | starship-weapon\` union for paths touching shared fields (\`mods\`, \`damaged\`, \`subtype\`, \`range\`).
- **\`isVehicleBorneWeaponItem\`** — narrows to \`vehicle-weapon | starship-weapon\` for \`fire_control\` / vehicle-stats paths.

Also restructures \`OD6SItem.getScore()\`'s weapon branch to compute \`fire_control\` once via the new vehicle-borne guard, rather than the opportunistic \`OD6SWeaponItemSystem & { fire_control? }\` cast.

The single remaining cast (\`actor.system as OD6SCharacterSystem\` at the top of \`roll()\`) is now explicitly commented: vehicle-actor paths via \`embedded_pilot\` reach attribute access the vehicle schema doesn't carry — pre-existing latent issue, out of scope for #57.

## Behaviour

No intended runtime change. One narrowing surfaces a defensive case that was already short-circuiting: \`parry_skill\` / \`parry_specialization\` are now read only on hand weapons (vehicle/starship weapons can't parry; their schema doesn't carry those fields).

## Test plan

- [x] \`pnpm run check\` — typecheck + lint (613/720) + 344 unit + 303 domain tests
- [ ] Smoke: skill / specialization roll
- [ ] Smoke: weapon attack (melee + ranged + parry)
- [ ] Smoke: vehicle-weapon attack via \`Actor.rollAction\`
- [ ] Smoke: action item roll (uses skill lookup chain incl. compendium fallback)