### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-05-06
+
 Two user-facing bug fixes (#40, #86) plus the close-out of three
 long-running internal-decomposition issues (#98 `setupRollData` →
 typed per-roll-type handlers; #83 `actor-sheet.ts` 788 → 401 LOC;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opend6-space",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "description": "OpenD6 Space system for Foundry VTT v14. Uses the rules from the OpenD6 Project SRD.",
   "scripts": {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "od6s",
   "title": "OpenD6 Space",
   "description": "OpenD6 Space System for FoundryVTT",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360",


### PR DESCRIPTION
## Summary

Version-bump for the 2.5.0 release.

- \`src/system.json\`: \`2.4.0\` → \`2.5.0\`
- \`package.json\`: \`2.4.0\` → \`2.5.0\`
- \`CHANGELOG.md\`: \`[Unreleased]\` → \`[2.5.0] - 2026-05-06\` (preserves a fresh empty Unreleased above)

## After merge

Run \`task release:minor\` on \`main\` to create and push the \`v2.5.0\` tag. The release workflow then builds the signed \`od6s.zip\` artifact.

## Test plan

- [x] \`pnpm run check\` — typecheck + lint + 344 unit + 303 domain tests
- [x] \`task release:minor\` preconditions inspected — versions in both files match the next tag, working tree clean