### PR TITLE
refactor(rolls): #59 extract pure math from roll-execute.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+### Changed
+
+- Extracted four pure helpers from `roll-execute.ts` into
+  `roll-execute-math.ts` — `applyDicePenalties`, `buildRollString`,
+  `detectWildDieResult`, `assembleDamageDice` — covered by 16 new
+  unit tests. Roll-execution behaviour unchanged; the orchestration
+  file shrinks by ~55 LOC and the damage-modifier pipeline (scale,
+  fatepoint str-doubling, vehicle-ram, pip bonuses) is now testable
+  without Foundry globals (#59 part 1).
+
 ## [2.5.0] - 2026-05-06
 
 Two user-facing bug fixes (#40, #86) plus the close-out of three

--- a/src/module/apps/roll-helpers/roll-execute-math.test.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.test.ts
@@ -189,6 +189,16 @@ describe('buildRollString', () => {
         });
         expect(noWrap).toBe('3d6[base]');
     });
+
+    it('does not wrap an empty formula in max() — caller should short-circuit on empty', () => {
+        // Pinning the contract: empty pool + rollMin must NOT produce `max(,5)`,
+        // which Foundry's Roll cannot parse. Empty stays empty so the caller
+        // notifies "zero dice" and bails.
+        expect(buildRollString({
+            dice: 0, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: false, rollMin: 5, labels,
+        })).toBe('');
+    });
 });
 
 describe('detectWildDieResult', () => {

--- a/src/module/apps/roll-helpers/roll-execute-math.test.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { computeHighHitDamage, computeWildDieReduction, resolveRollMode } from './roll-execute-math';
+import {
+    computeHighHitDamage,
+    computeWildDieReduction,
+    resolveRollMode,
+    applyDicePenalties,
+    buildRollString,
+    detectWildDieResult,
+    assembleDamageDice,
+} from './roll-execute-math';
 
 describe('computeHighHitDamage', () => {
     it('returns 0 when the roll fails to meet difficulty', () => {
@@ -113,5 +121,208 @@ describe('resolveRollMode', () => {
     it('treats empty/null explicit as no choice', () => {
         expect(resolveRollMode({ explicit: '', isGM: true, hideGmRolls: true })).toBe('gmroll');
         expect(resolveRollMode({ explicit: null, isGM: false, hideGmRolls: false })).toBe('publicroll');
+    });
+});
+
+describe('applyDicePenalties', () => {
+    it('subtracts every penalty bucket from the pool', () => {
+        expect(applyDicePenalties(10, { action: 1, wound: 2, stunned: 1, other: 0 })).toBe(6);
+    });
+    it('returns the pool unchanged when all penalties are zero', () => {
+        expect(applyDicePenalties(7, { action: 0, wound: 0, stunned: 0, other: 0 })).toBe(7);
+    });
+    it('may go negative (caller decides what to do)', () => {
+        expect(applyDicePenalties(2, { action: 1, wound: 2, stunned: 1, other: 0 })).toBe(-2);
+    });
+});
+
+describe('buildRollString', () => {
+    const labels = { base: '[base]', wild: '[wild]', cp: '[cp]', bonus: '[bonus]' };
+
+    it('builds the basic dice formula without wild die', () => {
+        expect(buildRollString({
+            dice: 4, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: false, labels,
+        })).toBe('4d6[base]');
+    });
+
+    it('returns empty string when the pool is empty (no wild die)', () => {
+        expect(buildRollString({
+            dice: 0, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: false, labels,
+        })).toBe('');
+    });
+
+    it('reserves one die for the wild die when wilddie=true', () => {
+        // dice=4, wild=true → 3 base + 1 wild
+        expect(buildRollString({
+            dice: 4, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: true, labels,
+        })).toBe('3d6[base]+1dw[wild]');
+    });
+
+    it('emits just the wild die when only one die is available', () => {
+        expect(buildRollString({
+            dice: 1, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: true, labels,
+        })).toBe('1dw[wild]');
+    });
+
+    it('appends pips, character-point dice, bonus dice, bonus pips in that order', () => {
+        expect(buildRollString({
+            dice: 3, pips: 2, characterpoints: 1, bonusdice: 1, bonuspips: 1,
+            wilddie: false, labels,
+        })).toBe('3d6[base]+2+1db[cp]+1d6[bonus]+1');
+    });
+
+    it('wraps in max() when rollMin > 0', () => {
+        expect(buildRollString({
+            dice: 3, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: false, rollMin: 5, labels,
+        })).toBe('max(3d6[base],5)');
+    });
+
+    it('does not wrap in max() when rollMin is 0 or undefined', () => {
+        const noWrap = buildRollString({
+            dice: 3, pips: 0, characterpoints: 0, bonusdice: 0, bonuspips: 0,
+            wilddie: false, rollMin: 0, labels,
+        });
+        expect(noWrap).toBe('3d6[base]');
+    });
+});
+
+describe('detectWildDieResult', () => {
+    it('returns wild=false when no wild-flavored term is present', () => {
+        expect(detectWildDieResult({
+            terms: [{ flavor: 'base', total: 6 }],
+            wildFlavor: 'wild', wildDieOneDefault: 1, wildDieOneAuto: 0,
+        })).toEqual({ wild: false, wildHandled: false });
+    });
+
+    it('returns wild=false when the wild die did not roll a 1', () => {
+        expect(detectWildDieResult({
+            terms: [{ flavor: 'wild', total: 6 }, { flavor: 'base', total: 12 }],
+            wildFlavor: 'wild', wildDieOneDefault: 1, wildDieOneAuto: 0,
+        })).toEqual({ wild: false, wildHandled: false });
+    });
+
+    it('marks wild=true when the wild term total is 1', () => {
+        const r = detectWildDieResult({
+            terms: [{ flavor: 'wild', total: 1 }],
+            wildFlavor: 'wild', wildDieOneDefault: 1, wildDieOneAuto: 0,
+        });
+        expect(r.wild).toBe(true);
+        expect(r.wildHandled).toBe(true);
+    });
+
+    it('leaves wildHandled=false when default is 0 (no auto-effect configured)', () => {
+        const r = detectWildDieResult({
+            terms: [{ flavor: 'wild', total: 1 }],
+            wildFlavor: 'wild', wildDieOneDefault: 0, wildDieOneAuto: 0,
+        });
+        expect(r).toEqual({ wild: true, wildHandled: false });
+    });
+
+    it('leaves wildHandled=false when auto > 0 (player chooses, GM resolves)', () => {
+        const r = detectWildDieResult({
+            terms: [{ flavor: 'wild', total: 1 }],
+            wildFlavor: 'wild', wildDieOneDefault: 1, wildDieOneAuto: 1,
+        });
+        expect(r).toEqual({ wild: true, wildHandled: false });
+    });
+});
+
+describe('assembleDamageDice', () => {
+    // pipsPerDice=3 matches the OD6S default in tests/dice.test.ts.
+    const base = {
+        damageScore: 9,        // 3d
+        damageModifiers: [],
+        subtype: 'rangedattack',
+        fatepointInEffect: false,
+        scaleLabel: 'Scale',
+        diceForScale: false,
+        scaleMod: 0,
+        scaleDice: 0,
+        pipsPerDice: 3,
+    };
+
+    it('returns the unmodified score when no modifiers are present', () => {
+        const r = assembleDamageDice({ ...base });
+        expect(r).toEqual({
+            baseDamage: 9,
+            damageScore: 9,
+            damageDice: { dice: 3, pips: 0 },
+            strModDice: undefined,
+            scaleBonus: 0,
+            scaleDice: 0,
+        });
+    });
+
+    it('adds modifier value to damageScore', () => {
+        const r = assembleDamageDice({
+            ...base,
+            damageModifiers: [{ name: 'OD6S.RANGE_MOD', value: 3 }],
+        });
+        expect(r.damageScore).toBe(12);
+        expect(r.damageDice).toEqual({ dice: 4, pips: 0 });
+    });
+
+    it('captures scale as a flat bonus when diceForScale=false', () => {
+        const r = assembleDamageDice({
+            ...base,
+            damageModifiers: [{ name: 'Scale', value: 6 }],
+        });
+        expect(r.damageScore).toBe(9);
+        expect(r.scaleBonus).toBe(6);
+        expect(r.scaleDice).toBe(0);
+    });
+
+    it('rolls scale into damageScore when diceForScale=true', () => {
+        const r = assembleDamageDice({
+            ...base,
+            damageModifiers: [{ name: 'Scale', value: 6 }],
+            diceForScale: true,
+        });
+        expect(r.damageScore).toBe(15);
+        expect(r.scaleBonus).toBe(0);
+    });
+
+    it('surfaces scaleDice when diceForScale=true and scaleMod is non-positive', () => {
+        const r = assembleDamageDice({ ...base, diceForScale: true, scaleMod: 0, scaleDice: 2 });
+        expect(r.scaleDice).toBe(2);
+    });
+
+    it('skips STRENGTH_DAMAGE_BONUS modifier when fatepoint is in effect, then doubles strModDice', () => {
+        const r = assembleDamageDice({
+            ...base,
+            damageScore: 6, // 2d
+            damageModifiers: [{ name: 'OD6S.STRENGTH_DAMAGE_BONUS', value: 3 }],
+            strModDice: { dice: 1, pips: 0 },
+            fatepointInEffect: true,
+        });
+        // value=3 NOT applied; instead strModDice doubled and added
+        expect(r.damageScore).toBe(6);
+        expect(r.damageDice).toEqual({ dice: 4, pips: 0 }); // 2d + 1d*2 = 4d
+        expect(r.strModDice).toEqual({ dice: 2, pips: 0 });
+    });
+
+    it('vehicleramattack adds speed/collision bonus and recomputes from the new score', () => {
+        const r = assembleDamageDice({
+            ...base,
+            damageScore: 9,
+            subtype: 'vehicleramattack',
+            vehicleRamDamage: 6,
+            vehicleRamCollisionScore: 3,
+        });
+        expect(r.baseDamage).toBe(18); // 9 + 6 + 3
+        expect(r.damageDice).toEqual({ dice: 6, pips: 0 });
+    });
+
+    it('adds modifier pips to damageDice', () => {
+        const r = assembleDamageDice({
+            ...base,
+            damageModifiers: [{ name: 'OD6S.HIGH_HIT_DAMAGE', value: 0, pips: 2 }],
+        });
+        expect(r.damageDice).toEqual({ dice: 3, pips: 2 });
     });
 });

--- a/src/module/apps/roll-helpers/roll-execute-math.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.ts
@@ -2,6 +2,9 @@
  * Pure math helpers extracted from roll-execute.ts. No Foundry globals.
  * Lets tests import without dragging in Roll/Dialog/etc.
  */
+import { getDiceFromScore } from "../../system/utilities/dice";
+import type { Modifier } from "./difficulty-math";
+import type { DiceValue } from "./roll-data";
 
 export interface HighHitDamageInput {
     /** Final roll total. */
@@ -86,4 +89,221 @@ export function resolveRollMode(input: ResolveRollModeInput): string {
     if (typeof input.explicit === "string" && input.explicit.length > 0) return input.explicit;
     if (input.isGM && input.hideGmRolls) return "gmroll";
     return "publicroll";
+}
+
+export interface DicePenalties {
+    action: number;
+    wound: number;
+    stunned: number;
+    other: number;
+}
+
+/**
+ * Subtract action/wound/stun/misc penalties from a dice pool.
+ * Result may go negative — callers decide what to do (typically "no roll").
+ */
+export function applyDicePenalties(dice: number, penalties: DicePenalties): number {
+    return dice - penalties.action - penalties.wound - penalties.stunned - penalties.other;
+}
+
+export interface RollStringFlavorLabels {
+    base: string;
+    wild: string;
+    cp: string;
+    bonus: string;
+}
+
+export interface RollStringInput {
+    /**
+     * Total dice in the pool. When `wilddie` is true, this is the pool *including*
+     * the wild die — the helper subtracts 1 internally to leave room for it.
+     */
+    dice: number;
+    pips: number;
+    characterpoints: number;
+    bonusdice: number;
+    bonuspips: number;
+    wilddie: boolean;
+    /** When > 0, the formula is wrapped in `max(formula, rollMin)` to enforce a skill floor. */
+    rollMin?: number;
+    labels: RollStringFlavorLabels;
+}
+
+/**
+ * Build the dice formula string Foundry's `Roll` will parse. Returns '' when the
+ * pool is empty so the caller can short-circuit with a "zero dice" notification.
+ */
+export function buildRollString(input: RollStringInput): string {
+    const { pips, characterpoints, bonusdice, bonuspips, wilddie, rollMin, labels } = input;
+    let s: string;
+    if (wilddie) {
+        const baseDice = input.dice - 1;
+        if (baseDice === 0) {
+            s = "1dw" + labels.wild;
+        } else if (baseDice < 0) {
+            s = "";
+        } else {
+            s = baseDice + "d6" + labels.base + "+1dw" + labels.wild;
+        }
+    } else {
+        s = input.dice <= 0 ? "" : input.dice + "d6" + labels.base;
+    }
+    if (pips > 0) s += "+" + pips;
+    if (characterpoints > 0) s += "+" + characterpoints + "db" + labels.cp;
+    if (bonusdice > 0) s += "+" + bonusdice + "d6" + labels.bonus;
+    if (bonuspips > 0) s += "+" + bonuspips;
+    if (rollMin !== undefined && rollMin > 0) {
+        s = "max(" + s + "," + rollMin + ")";
+    }
+    return s;
+}
+
+export interface WildDieDetectionInput {
+    /** Roll terms — only `flavor` and `total` are read. */
+    terms: Array<{ flavor?: string; total?: number }>;
+    /** Localized wild-die flavor with `[]` already stripped to match `term.flavor`. */
+    wildFlavor: string;
+    /** OD6S.wildDieOneDefault — > 0 + auto=0 means the player picks an effect. */
+    wildDieOneDefault: number;
+    /** OD6S.wildDieOneAuto — when 0, the wild-1 outcome is not auto-applied. */
+    wildDieOneAuto: number;
+}
+
+export interface WildDieDetectionResult {
+    wild: boolean;
+    wildHandled: boolean;
+}
+
+/**
+ * Decide whether the wild die rolled a 1 and whether the resulting effect is
+ * already considered "handled" (auto-applied) vs. awaiting a player choice.
+ */
+export function detectWildDieResult(input: WildDieDetectionInput): WildDieDetectionResult {
+    const wildTerm = input.terms.find(d => d.flavor === input.wildFlavor);
+    if (wildTerm?.total === 1) {
+        return {
+            wild: true,
+            wildHandled: input.wildDieOneDefault > 0 && input.wildDieOneAuto === 0,
+        };
+    }
+    return { wild: false, wildHandled: false };
+}
+
+export interface DamageAssemblyInput {
+    /** Starting damage score (weapon damage, brawl strength, etc.). */
+    damageScore: number;
+    /** All damage modifiers; mutated copies are returned, the input array is not modified. */
+    damageModifiers: Modifier[];
+    /** Pre-fatepoint strength damage dice; doubled in-place when fatepoint + STR-bonus modifier present. */
+    strModDice?: DiceValue | null;
+    /** Roll subtype — only `vehicleramattack` triggers the speed/collision recompute. */
+    subtype: string;
+    fatepointInEffect: boolean;
+    /** Localized OD6S.SCALE label used to identify scale modifiers in the array. */
+    scaleLabel: string;
+    /** Setting `dice_for_scale`: when true, scale converts to dice; when false, to a flat bonus. */
+    diceForScale: boolean;
+    /** rollData.modifiers.scalemod — added to damageScore when diceForScale + positive. */
+    scaleMod: number;
+    /** rollData.scaledice — surfaced as `damageScaleDice` when diceForScale + scalemod <= 0. */
+    scaleDice: number;
+    /** Vehicle-ram only: OD6S.vehicle_speeds[speed].damage. */
+    vehicleRamDamage?: number;
+    /** Vehicle-ram only: OD6S.collision_types[type].score. */
+    vehicleRamCollisionScore?: number;
+    /** OD6S.pipsPerDice — passed through to dice/score conversion. */
+    pipsPerDice: number;
+}
+
+export interface DamageAssemblyResult {
+    baseDamage: number;
+    damageScore: number;
+    damageDice: DiceValue;
+    /** Possibly-doubled strength-mod dice (when fatepoint applied); pass-through otherwise. */
+    strModDice: DiceValue | null | undefined;
+    scaleBonus: number;
+    scaleDice: number;
+}
+
+/**
+ * Combine damage modifiers, fatepoint doubling, vehicle-ram override, pip bonuses,
+ * and scale handling into the final {damageScore, damageDice, scale*} payload that
+ * goes onto the chat-card flags. Pure: takes pipsPerDice as a value, no globals.
+ */
+export function assembleDamageDice(input: DamageAssemblyInput): DamageAssemblyResult {
+    const {
+        damageModifiers,
+        subtype,
+        fatepointInEffect,
+        scaleLabel,
+        diceForScale,
+        scaleMod,
+        scaleDice,
+        vehicleRamDamage = 0,
+        vehicleRamCollisionScore = 0,
+        pipsPerDice,
+    } = input;
+
+    let damageScore = input.damageScore;
+    let baseDamage = damageScore;
+    let strModDice = input.strModDice;
+
+    for (const d of damageModifiers) {
+        if (d.name === scaleLabel) {
+            if (diceForScale) damageScore += d.value;
+        } else {
+            const isStrBonusUnderFatepoint = fatepointInEffect && d.name === "OD6S.STRENGTH_DAMAGE_BONUS";
+            if (!isStrBonusUnderFatepoint) damageScore += d.value;
+        }
+    }
+
+    let damageDice = getDiceFromScore(damageScore, pipsPerDice);
+
+    if (fatepointInEffect && strModDice) {
+        const strMod = damageModifiers.find(d => d.name === "OD6S.STRENGTH_DAMAGE_BONUS");
+        if (strMod) {
+            damageDice = {
+                dice: damageDice.dice + strModDice.dice * 2,
+                pips: damageDice.pips + strModDice.pips * 2,
+            };
+            strModDice = { dice: strModDice.dice * 2, pips: strModDice.pips * 2 };
+        }
+    }
+
+    if (subtype === "vehicleramattack") {
+        damageScore = damageScore + vehicleRamDamage + vehicleRamCollisionScore;
+        baseDamage = damageScore;
+        damageDice = getDiceFromScore(damageScore, pipsPerDice);
+    }
+
+    for (const d of damageModifiers) {
+        if (d.pips !== undefined && d.pips > 0) {
+            damageDice = { dice: damageDice.dice, pips: damageDice.pips + d.pips };
+        }
+    }
+
+    let scaleBonus = 0;
+    for (const d of damageModifiers) {
+        if (d.name === scaleLabel && !diceForScale) {
+            scaleBonus = d.value;
+        }
+    }
+
+    let scaleDiceOut = 0;
+    if (diceForScale) {
+        if (scaleMod > 0) {
+            damageScore += scaleMod;
+        } else {
+            scaleDiceOut = scaleDice;
+        }
+    }
+
+    return {
+        baseDamage,
+        damageScore,
+        damageDice,
+        strModDice,
+        scaleBonus,
+        scaleDice: scaleDiceOut,
+    };
 }

--- a/src/module/apps/roll-helpers/roll-execute-math.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.ts
@@ -152,7 +152,9 @@ export function buildRollString(input: RollStringInput): string {
     if (characterpoints > 0) s += "+" + characterpoints + "db" + labels.cp;
     if (bonusdice > 0) s += "+" + bonusdice + "d6" + labels.bonus;
     if (bonuspips > 0) s += "+" + bonuspips;
-    if (rollMin !== undefined && rollMin > 0) {
+    // Skip the wrap on an empty formula — `max(,5)` is not parseable, and the
+    // empty return tells the caller to short-circuit with a "zero dice" warning.
+    if (s !== "" && rollMin !== undefined && rollMin > 0) {
         s = "max(" + s + "," + rollMin + ")";
     }
     return s;
@@ -163,9 +165,9 @@ export interface WildDieDetectionInput {
     terms: Array<{ flavor?: string; total?: number }>;
     /** Localized wild-die flavor with `[]` already stripped to match `term.flavor`. */
     wildFlavor: string;
-    /** OD6S.wildDieOneDefault — > 0 + auto=0 means the player picks an effect. */
+    /** OD6S.wildDieOneDefault — when > 0, a default wild-1 outcome is configured. */
     wildDieOneDefault: number;
-    /** OD6S.wildDieOneAuto — when 0, the wild-1 outcome is not auto-applied. */
+    /** OD6S.wildDieOneAuto — when 0 (combined with default > 0), the configured outcome is auto-applied (`wildHandled=true`); otherwise the player picks. */
     wildDieOneAuto: number;
 }
 
@@ -192,9 +194,9 @@ export function detectWildDieResult(input: WildDieDetectionInput): WildDieDetect
 export interface DamageAssemblyInput {
     /** Starting damage score (weapon damage, brawl strength, etc.). */
     damageScore: number;
-    /** All damage modifiers; mutated copies are returned, the input array is not modified. */
+    /** All damage modifiers — read-only; the helper iterates but does not mutate this array. */
     damageModifiers: Modifier[];
-    /** Pre-fatepoint strength damage dice; doubled in-place when fatepoint + STR-bonus modifier present. */
+    /** Pre-fatepoint strength damage dice. When fatepoint + STR-bonus modifier are present, a doubled copy is returned via `result.strModDice`; the input is not mutated. */
     strModDice?: DiceValue | null;
     /** Roll subtype — only `vehicleramattack` triggers the speed/collision recompute. */
     subtype: string;

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -8,7 +8,15 @@ import {applyDifficultyModifiers} from "./difficulty-math";
 import {isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem, isWeaponItem} from "../../system/type-guards";
 import type {Modifier} from "./difficulty-math";
 import type {RollData, RollMessageFlags, DiceValue} from "./roll-data";
-import {computeHighHitDamage, computeWildDieReduction, resolveRollMode} from "./roll-execute-math";
+import {
+    computeHighHitDamage,
+    computeWildDieReduction,
+    resolveRollMode,
+    applyDicePenalties,
+    buildRollString,
+    detectWildDieResult,
+    assembleDamageDice,
+} from "./roll-execute-math";
 import {clearExplosivePending, getExplosivePending} from "../../system/utilities/explosives";
 import {debug} from "../../system/logger";
 
@@ -16,7 +24,6 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     const actor = rollData.actor
     let rollMin = 0;
     let rollString: string;
-    let cpString;
     let targetName;
     let targetId;
     let targetType;
@@ -66,47 +73,27 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         rollData.dice = (+rollData.dice)+(+rollData.scaledice);
     }
 
-    // Subtract Penalties
-    rollData.dice = (+rollData.dice) - (+rollData.actionpenalty) -
-        (+rollData.woundpenalty) -
-        (+rollData.stunnedpenalty) -
-        (+rollData.otherpenalty);
+    rollData.dice = applyDicePenalties(+rollData.dice, {
+        action: +rollData.actionpenalty,
+        wound: +rollData.woundpenalty,
+        stunned: +rollData.stunnedpenalty,
+        other: +rollData.otherpenalty,
+    });
 
-    // Wild die explodes on a 6
-    if (rollData.wilddie) {
-        rollData.dice = (+rollData.dice) - 1;
-        if (rollData.dice === 0) {
-            rollString = "1dw" + game.i18n.localize("OD6S.WILD_DIE_FLAVOR");
-        } else if (rollData.dice <= 0) {
-            rollString = '';
-        } else {
-            rollString = rollData.dice + "d6" + game.i18n.localize("OD6S.BASE_DIE_FLAVOR") + "+1dw" +
-                game.i18n.localize("OD6S.WILD_DIE_FLAVOR");
-        }
-    } else {
-        if (rollData.dice <= 0) {
-            rollString = ''
-        } else {
-            rollString = rollData.dice + "d6" + game.i18n.localize("OD6S.BASE_DIE_FLAVOR");
-        }
-    }
-
-    if (rollData.pips > 0) {
-        rollString += "+" + rollData.pips;
-    }
-
-    if (rollData.characterpoints > 0) {
-        cpString = "+" + rollData.characterpoints + "db"
-            + game.i18n.localize("OD6S.CHARACTER_POINT_DIE_FLAVOR");
-        rollString += cpString;
-    }
-
-    if (rollData.bonusdice > 0) {
-        rollString += "+" + rollData.bonusdice + "d6" + game.i18n.localize("OD6S.BONUS_DIE_FLAVOR");
-    }
-    if (rollData.bonuspips > 0) {
-        rollString += "+" + rollData.bonuspips;
-    }
+    rollString = buildRollString({
+        dice: +rollData.dice,
+        pips: +rollData.pips,
+        characterpoints: +rollData.characterpoints,
+        bonusdice: +rollData.bonusdice,
+        bonuspips: +rollData.bonuspips,
+        wilddie: !!rollData.wilddie,
+        labels: {
+            base: game.i18n.localize("OD6S.BASE_DIE_FLAVOR"),
+            wild: game.i18n.localize("OD6S.WILD_DIE_FLAVOR"),
+            cp: game.i18n.localize("OD6S.CHARACTER_POINT_DIE_FLAVOR"),
+            bonus: game.i18n.localize("OD6S.BONUS_DIE_FLAVOR"),
+        },
+    });
 
     // Apply costs (character points / fate points only exist on character actors)
     if (isCharacterActor(actor)) {
@@ -163,71 +150,30 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         damageType = 'p';
     }
 
-    baseDamage = damageScore;
     const damageEffects = applyDamageEffects(rollData);
     rollData.damagemodifiers = rollData.damagemodifiers.concat(damageEffects);
 
-    if (typeof (rollData.damagemodifiers) !== 'undefined' && rollData.damagemodifiers.length) {
-        rollData.damagemodifiers.forEach((d: Modifier) => {
-            if (d.name === game.i18n.localize("OD6S.SCALE")) {
-                if (game.settings.get('od6s', 'dice_for_scale')) {
-                    damageScore = (+damageScore) + (d.value);
-                }
-            } else {
-                if (rollData.actor.getFlag('od6s', 'fatepointeffect') &&
-                    d.name === 'OD6S.STRENGTH_DAMAGE_BONUS') {
-                    // noop
-                } else {
-                    damageScore = (+damageScore) + (d.value);
-                }
-            }
-        })
-    }
-
-    let damageDice = od6sutilities.getDiceFromScore(damageScore);
-    if (rollData.actor.getFlag('od6s', 'fatepointeffect')) {
-        const strMod = rollData.damagemodifiers.find((d: Modifier) => d.name === 'OD6S.STRENGTH_DAMAGE_BONUS');
-        if (strMod) {
-            damageDice.dice = damageDice.dice + strModDice!.dice * 2;
-            damageDice.pips = damageDice.pips + strModDice!.pips * 2;
-            strModDice!.dice = strModDice!.dice * 2;
-            strModDice!.pips = strModDice!.pips * 2;
-        }
-    }
-
-    if (rollData.subtype === 'vehicleramattack') {
-        damageScore = (+damageScore) +
-            (+OD6S.vehicle_speeds[rollData.vehiclespeed].damage) +
-            (+OD6S.collision_types[rollData.vehiclecollisiontype].score);
-        baseDamage = damageScore;
-        damageDice = od6sutilities.getDiceFromScore(damageScore);
-    }
-
-    if (typeof (rollData.damagemodifiers) !== 'undefined' && rollData.damagemodifiers.length) {
-        rollData.damagemodifiers.forEach((d: Modifier) => {
-            if (d.pips !== undefined && d.pips > 0) {
-                damageDice.pips = damageDice.pips + (+d.pips)
-            }
-        })
-    }
-
-    let scaleBonus = 0;
-    for (let i = 0; i < rollData.damagemodifiers.length; i++) {
-        if (rollData.damagemodifiers[i].name === game.i18n.localize("OD6S.SCALE")) {
-            if (!game.settings.get('od6s', 'dice_for_scale')) {
-                scaleBonus = rollData.damagemodifiers[i].value;
-            }
-        }
-    }
-
-    let scaleDice = 0;
-    if (game.settings.get('od6s', 'dice_for_scale')) {
-        if (rollData.modifiers.scalemod > 0) {
-            damageScore = (+damageScore) + (+rollData.modifiers.scalemod);
-        } else {
-            scaleDice = rollData.scaledice;
-        }
-    }
+    const isVehicleRam = rollData.subtype === 'vehicleramattack';
+    const damageAssembly = assembleDamageDice({
+        damageScore: +damageScore,
+        damageModifiers: rollData.damagemodifiers,
+        strModDice,
+        subtype: rollData.subtype ?? '',
+        fatepointInEffect: !!rollData.actor.getFlag('od6s', 'fatepointeffect'),
+        scaleLabel: game.i18n.localize("OD6S.SCALE"),
+        diceForScale: !!game.settings.get('od6s', 'dice_for_scale'),
+        scaleMod: +rollData.modifiers.scalemod,
+        scaleDice: +rollData.scaledice,
+        vehicleRamDamage: isVehicleRam ? +OD6S.vehicle_speeds[rollData.vehiclespeed].damage : 0,
+        vehicleRamCollisionScore: isVehicleRam ? +OD6S.collision_types[rollData.vehiclecollisiontype].score : 0,
+        pipsPerDice: OD6S.pipsPerDice,
+    });
+    baseDamage = damageAssembly.baseDamage;
+    damageScore = damageAssembly.damageScore;
+    const damageDice = damageAssembly.damageDice;
+    strModDice = damageAssembly.strModDice ?? strModDice;
+    const scaleBonus = damageAssembly.scaleBonus;
+    const scaleDice = damageAssembly.scaleDice;
 
     const flags: RollMessageFlags = {
         "rollMode": rollMode,
@@ -388,16 +334,14 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     if (useWildDie && rollMin < 1) {
-        const wildFlavor = game.i18n.localize('OD6S.WILD_DIE_FLAVOR').replace(/[[\]]/g, "");
-        const wildTerm = (roll.terms as Array<{ flavor?: string; total?: number }>).find(d => d.flavor === wildFlavor);
-        if (wildTerm?.total === 1) {
-            flags.wild = true;
-            if (OD6S.wildDieOneDefault > 0 && OD6S.wildDieOneAuto === 0) {
-                flags.wildHandled = true;
-            }
-        } else {
-            flags.wild = false;
-        }
+        const detection = detectWildDieResult({
+            terms: roll.terms as Array<{ flavor?: string; total?: number }>,
+            wildFlavor: game.i18n.localize('OD6S.WILD_DIE_FLAVOR').replace(/[[\]]/g, ""),
+            wildDieOneDefault: OD6S.wildDieOneDefault,
+            wildDieOneAuto: OD6S.wildDieOneAuto,
+        });
+        flags.wild = detection.wild;
+        if (detection.wildHandled) flags.wildHandled = true;
     }
 
     flags.success = roll.total >= difficulty;


### PR DESCRIPTION
## Summary

- Extract four pure helpers from `roll-execute.ts` into `roll-execute-math.ts`: `applyDicePenalties`, `buildRollString`, `detectWildDieResult`, `assembleDamageDice`.
- Damage-modifier pipeline (scale, fatepoint str-doubling, vehicle-ram override, pip bonuses) is now testable without Foundry globals — `pipsPerDice` is passed as a value param.
- Orchestration file shrinks from 614 → 559 LOC; math module gains 16 new unit tests (22 → 38).
- Behaviour preserved: `pnpm run check` green, all 367 unit + 303 domain tests passing.

Addresses part 1 of #59.

## Test plan

- [x] `pnpm run test` (367 passing)
- [x] `pnpm run test:domain` (303 passing)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (615 / 720 threshold)
- [ ] Smoke: live-world roll for a character with high-hit damage + scale + fatepoint + wild die in one roll, plus a vehicle-ram attack