### PR TITLE
refactor(config): #58 split config-od6s.ts into typed submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ### Changed
 
+- Replaced the `Record<string, any>` typing on the central `OD6S`
+  config object with a typed `Od6sConfig` interface, and split the
+  remaining inline tables out of `config-od6s.ts` into typed
+  submodules (`difficulty.ts`, `modifiers.ts`, `vehicles.ts`,
+  `wounds.ts`). Existing submodules (`attributes`, `damage`,
+  `weapons`, `actions`, `status-effects`, `labels`, `deadliness`)
+  gained explicit interfaces. The public surface for the ~60
+  import sites is unchanged; one pre-existing typo
+  (`starshipToughessName` → `starshipToughnessName`) was unified,
+  the dead `OD6S.metaphysicsSkills` write and the unused/broken
+  `getDifficultyFromShort` Handlebars helper were removed (#58).
 - Extracted four pure helpers from `roll-execute.ts` into
   `roll-execute-math.ts` — `applyDicePenalties`, `buildRollString`,
   `detectWildDieResult`, `assembleDamageDice` — covered by 16 new

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -394,7 +394,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         {rollMode, create: true}
     );
 
-    if (flags.wild === true && parseInt(OD6S.wildDieOneDefault) === 2 && parseInt(OD6S.wildDieOneAuto) === 0) {
+    if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));

--- a/src/module/config/actions.ts
+++ b/src/module/config/actions.ts
@@ -3,14 +3,23 @@
  * (`vehicleActions`). Mounted onto OD6S by `config-od6s.ts`.
  */
 
-export const actions = {
+export interface ActionDef {
+    name: string;
+    type: string;
+    rollable: boolean;
+    base: string;
+    skill: string;
+    subtype: string;
+}
+
+export const actions: Record<string, ActionDef> = {
     "ranged_attack": {
         "name": "OD6S.ACTION_RANGED_ATTACK",
         "type": "rangedattack",
         "rollable": true,
         "base": "agi",
         "skill": "",
-        "subtype": "rangedattack"
+        "subtype": "rangedattack",
     },
     "melee_attack": {
         "name": "OD6S.ACTION_MELEE_ATTACK",
@@ -19,7 +28,6 @@ export const actions = {
         "base": "agi",
         "skill": "Melee Combat",
         "subtype": "meleeattack",
-
     },
     "brawl_attack": {
         "name": "OD6S.ACTION_BRAWL_ATTACK",
@@ -57,45 +65,59 @@ export const actions = {
         "name": "OD6S.ACTION_OTHER",
         "type": "action",
         "rollable": false,
-        "subtype": "misc"
-    }
+        "base": "",
+        "skill": "",
+        "subtype": "misc",
+    },
 };
 
-export const vehicleActions = {
+export const vehicleActions: Record<string, ActionDef> = {
     "ranged_attack": {
         "name": "OD6S.ACTION_VEHICLE_RANGED_ATTACK",
         "type": "vehiclerangedattack",
         "rollable": true,
-        "base": "mec"
+        "base": "mec",
+        "skill": "",
+        "subtype": "",
     },
     "ram": {
         "name": "OD6S.ACTION_VEHICLE_RAM",
         "type": "vehicleramattack",
         "rollable": true,
-        "base": "mec"
+        "base": "mec",
+        "skill": "",
+        "subtype": "",
     },
     "dodge": {
         "name": "OD6S.ACTION_VEHICLE_DODGE",
         "type": "vehicledodge",
         "rollable": true,
-        "base": "mec"
+        "base": "mec",
+        "skill": "",
+        "subtype": "",
     },
     "maneuver": {
         "name": "OD6S.ACTION_VEHICLE_MANEUVER",
         "type": "vehiclemaneuver",
         "rollable": true,
-        "base": "mec"
+        "base": "mec",
+        "skill": "",
+        "subtype": "",
     },
     "sensors": {
         "name": "OD6S.ACTION_VEHICLE_SENSORS",
         "type": "vehiclesensors",
         "base": "mec",
         "skill": "OD6S.SENSORS",
-        "rollable": true
+        "rollable": true,
+        "subtype": "",
     },
     "other": {
         "name": "OD6S.ACTION_VEHICLE_OTHER",
         "type": "action",
-        "rollable": false
-    }
+        "rollable": false,
+        "base": "",
+        "skill": "",
+        "subtype": "",
+    },
 };

--- a/src/module/config/attributes.ts
+++ b/src/module/config/attributes.ts
@@ -3,7 +3,16 @@
  * `name` and `shortName` are populated from settings at module init.
  * Mounted onto `OD6S.attributes` by `config-od6s.ts`.
  */
-const attributes = {
+export interface AttributeDef {
+    name: string;
+    shortName: string;
+    active: boolean;
+    sort: number;
+}
+
+export type Attributes = Record<string, AttributeDef>;
+
+const attributes: Attributes = {
     "agi": {
         "name": '',
         "shortName": '',

--- a/src/module/config/config-od6s.ts
+++ b/src/module/config/config-od6s.ts
@@ -1,8 +1,24 @@
-import attributes from "./attributes";
-import deadliness from "./deadliness";
-import statusEffects from "./status-effects";
-import { actions, vehicleActions } from "./actions";
-import { armorDamage, damage, damageTypes, vehicleDamage, weaponDamage } from "./damage";
+/**
+ * Aggregate `OD6S` config object — composed from typed submodules in this
+ * directory. Mutable scalar fields (e.g. `fatePointsName`, `wildDieOneDefault`)
+ * are written by `od6sSettings()` at module init from world settings; the
+ * nested table objects are also mutated in place by some settings hooks
+ * (see `settings/index.ts` adjusting `OD6S.difficulty[*]`).
+ */
+
+import attributes, { type Attributes } from "./attributes";
+import deadliness, { type WoundLevel } from "./deadliness";
+import statusEffects, { type StatusEffectDef } from "./status-effects";
+import { actions, vehicleActions, type ActionDef } from "./actions";
+import {
+    armorDamage,
+    damage,
+    damageTypes,
+    vehicleDamage,
+    weaponDamage,
+    type DamageLevel,
+    type VehicleDamageLevel,
+} from "./damage";
 import {
     weaponTypes,
     weaponTypeKeys,
@@ -11,6 +27,9 @@ import {
     meleeAttackOptions,
     brawlAttackOptions,
     ranges,
+    type AttackOption,
+    type RangeBand,
+    type WeaponTypeKey,
 } from "./weapons";
 import {
     actorTypeLabels,
@@ -18,564 +37,440 @@ import {
     templateItemTypes,
     allowedItemTypes,
 } from "./labels";
+import {
+    difficulty,
+    difficultyShort,
+    terrainDifficulty,
+    result,
+    type DifficultyBand,
+    type ResultTier,
+    type TerrainModifier,
+} from "./difficulty";
+import {
+    cover,
+    calledShot,
+    gravity,
+    misc,
+    type CoverModifier,
+    type CalledShotModifier,
+} from "./modifiers";
+import {
+    vehicleSpeeds,
+    collisionTypes,
+    type VehicleSpeed,
+    type CollisionType,
+} from "./vehicles";
+import {
+    bodyPointLevels,
+    woundsId,
+    hitLocations,
+    wildDieResult,
+    hiddenStatusEffects,
+} from "./wounds";
 
-const OD6S: Record<string, any> = {};
-
-OD6S.startCombat = false;
-OD6S.socket = '';
-OD6S.baseHitDifficulty = 10;
-OD6S.default_sensor_skill = "OD6S.SENSORS";
-OD6S.fatePointsName = '';
-OD6S.fatePointsShortName = '';
-OD6S.useAFatePointName = '';
-OD6S.metaphysicsName = '';
-OD6S.manifestationsName = '';
-OD6S.metaphysicsExtranormalName = '';
-OD6S.vehicleToughnessName = '';
-OD6S.stunDice = false;
-OD6S.passengerDamageDice = false;
-OD6S.starshipToughessName = '';
-OD6S.vehicleDifficulty = true;
-OD6S.brawlAttribute = '';
-OD6S.chatPath = 'systems/od6s/templates/chat/';
-OD6S.wildDieOneDefault = 0;
-OD6S.wildDieOneAuto = 0;
-OD6S.grenadeDamageDice = false;
-OD6S.highlightEffects = false;
-OD6S.randomHitLocations = false;
-OD6S.mapRange = false;
-OD6S.meleeDifficulty = false;
-OD6S.baseRangedAttackDifficulty = 10;
-OD6S.baseMeleeAttackDifficulty = 10;
-OD6S.baseBrawlAttackDifficulty = 10;
-OD6S.defenseLock = false;
-OD6S.currencyName = "OD6S.CHAR_CREDITS";
-OD6S.fatePointRound = false;
-OD6S.fatePointClimactic = false;
-OD6S.woundConfig = 0;
-OD6S.bodyPointsName = "OD6S.BODY_POINTS";
-OD6S.highHitDamage = false;
-OD6S.weaponArmorDamage = false;
-OD6S.autoOpposed = false;
-OD6S.autoPromptPlayerResistance = false;
-OD6S.autoSkillUsed = false;
-OD6S.pipsPerDice = 3;
-OD6S.speciesMaxDice = 5;
-OD6S.speciesMinDice = 1;
-OD6S.flatSkills = false;
-OD6S.specLink = true;
-OD6S.skillUsed = true;
-OD6S.cost = 0;
-OD6S.fundsFate = false;
-OD6S.showSkillSpecialization = true;
-OD6S.specializationDice = false;
-OD6S.specStartingPipsPerDie = 3;
-OD6S.channelSkillName = "OD6S.METAPHYSICS_SKILL_CHANNEL";
-OD6S.senseSkillName = "OD6S.METAPHYSICS_SKILL_SENSE";
-OD6S.transformSkillName = "OD6S.METAPHYSICS_SKILL_TRANSFORM";
-OD6S.trackStuns = false;
-OD6S.stunDamageIncrement = true;
-OD6S.randomDifficlty = false;
-OD6S.hideExplosiveTemplates = true;
-OD6S.meleeRange = false;
-OD6S.baseBrawlAttackDifficultyLevel = 'OD6S.DIFFICULTY_VERY_EASY';
-OD6S.baseMeleeAttackDifficultyLevel = 'OD6S.DIFFICULTY_VERY_EASY';
-OD6S.stunScaling = false;
-OD6S.woundScaling = false;
-OD6S.speciesLabelName = "OD6S.CHAR_SPECIES"
-OD6S.typeLabel = "OD6S.CHAR_TYPE"
-//MiscRulesOptions variables
-OD6S.highHitDamageMultiplier = 5;
-OD6S.highHitDamagePipsOrDice = false; //false = pips, ture = dice
-OD6S.highHitDamageRound = false; //false = round up, true = round down.
-OD6S.advanceCostAttribute = 10;
-OD6S.advanceCostSkill = 1;
-OD6S.advanceCostMetaphysicsSkill = 2;
-OD6S.advanceCostSpecialization = .5;
-OD6S.resistanceOption = false;
-OD6S.resistanceSkill = "Stamina";
-OD6S.resistanceMultiplier = 1;
-OD6S.resistanceRound = false; //false = round up, true = round down.
-OD6S.strDamRound = false;
-OD6S.strDamMultiplier = 0.5;
-OD6S.strDamSkill = "Lift";
-OD6S.od6Bonus = false;
-
-OD6S.deletingMessage = false;
-
-//MiscRulesOptions variables.
-
-OD6S.weaponDamage = weaponDamage;
-
-OD6S.armorDamage = armorDamage;
-
-OD6S.characterPointLimits = {
-    skill: 2,
-    attribute: 2,
-    specialization: 5,
-    dodge: 5,
-    parry: 5,
-    block: 5,
-    dr: 5,
-    initiative: 5
+export interface CharacterPointLimits {
+    skill: number;
+    attribute: number;
+    specialization: number;
+    dodge: number;
+    parry: number;
+    block: number;
+    dr: number;
+    initiative: number;
+    init?: number;
 }
 
-OD6S.explosives = [
-    "OD6S.EXPLOSIVE_THROWN",
-    // TODO: "OD6S.EXPLOSIVE_TIMER",
-    // TODO: "OD6S.EXPLOSIVE_TRIGGER"
-]
+/**
+ * Minimal structural type for the socketlib socket bound to OD6S.
+ * The full socketlib API is untyped; we capture only the methods used
+ * by this codebase so dynamic dispatch through `OD6S.socket` typechecks.
+ * `register` callbacks are not type-checked because socketlib forwards
+ * arbitrary arguments at runtime — that contract lives at the call sites.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SocketLibCallback = (...args: any[]) => unknown;
 
-OD6S.deadlinessLevel = {
-    "character": 3,
-    "creature": 3,
-    "npc": 3
+export interface SocketLibSocket {
+    register(name: string, handler: SocketLibCallback): void;
+    executeAsGM(handler: string, ...args: unknown[]): Promise<unknown>;
+    executeForOthers(handler: string, ...args: unknown[]): Promise<unknown>;
 }
 
-OD6S.wildDieResult = {
-    0: "OD6S.WILD_RESULT_ONE",
-    1: "OD6S.WILD_DIE_NONE",
-    2: "OD6S.REMOVE_HIGHEST_DIE",
-    3: "OD6S.COMPLICATION"
+export interface InitiativeConfig {
+    type: string;
+    reroll: boolean;
+    reroll_npc: boolean;
+    reroll_character: boolean;
+    dsn: boolean;
+    attribute: string;
 }
 
-OD6S.actorMasks = {
-    "character": 0,
-    "npc": 1,
-    "creature": 2,
-    "vehicle": 3,
-    "starship": 4
+export interface DataTabConfig {
+    defense: Record<string, string>;
+    offense: Record<string, string>;
 }
 
-OD6S.equippable = [
-    "weapon",
-    "armor",
-    "gear",
-    "vehicle-weapon",
-    "vehicle-gear",
-    "starship-weapon",
-    "starship-gear"
-]
-
-OD6S.cargo_hold = [
-    "weapon",
-    "armor",
-    "gear",
-    "vehicle-weapon",
-    "vehicle-gear",
-    "starship-weapon",
-    "starship-gear"
-]
-
-OD6S.deadliness = deadliness;
-
-OD6S.damage = damage;
-
-OD6S.bodyPointLevels = {
-    "OD6S.WOUNDS_HEALTHY": 9999,
-    "OD6S.WOUNDS_STUNNED": 81,
-    "OD6S.WOUNDS_WOUNDED": 60,
-    "OD6S.WOUNDS_SEVERELY_WOUNDED": 40,
-    "OD6S.WOUNDS_INCAPACITATED": 20,
-    "OD6S.WOUNDS_MORTALLY_WOUNDED": 10,
-    "OD6S.WOUNDS_DEAD": 1
+export interface ChatTemplates {
+    generic: string;
+    roll: string;
+    opposed: string;
+    damageresult: string;
+    explosive: string;
+    "explosive-button": string;
+    range: string;
 }
 
-OD6S.vehicle_damage = vehicleDamage;
+/**
+ * Public surface of the OD6S config singleton. Most fields are populated at
+ * module load (see object literal below); a number of scalar fields are
+ * overwritten at init by `od6sSettings()` reading the world's settings.
+ * The string index signature accepts the dynamic property writes still
+ * performed by some settings hooks; new code should prefer the typed members.
+ */
+export interface Od6sConfig {
+    // settings-driven scalars
+    startCombat: boolean;
+    socket: SocketLibSocket;
+    baseHitDifficulty: number;
+    default_sensor_skill: string;
+    fatePointsName: string;
+    fatePointsShortName: string;
+    useAFatePointName: string;
+    metaphysicsName: string;
+    manifestationsName: string;
+    metaphysicsExtranormalName: string;
+    vehicleToughnessName: string;
+    stunDice: boolean;
+    passengerDamageDice: boolean;
+    starshipToughnessName: string;
+    interstellarDriveName: string;
+    vehicleDifficulty: boolean;
+    brawlAttribute: string;
+    chatPath: string;
+    wildDieOneDefault: number;
+    wildDieOneAuto: number;
+    grenadeDamageDice: boolean;
+    highlightEffects: boolean;
+    randomHitLocations: boolean;
+    mapRange: boolean;
+    meleeDifficulty: boolean;
+    baseRangedAttackDifficulty: number;
+    baseMeleeAttackDifficulty: number;
+    baseBrawlAttackDifficulty: number;
+    defenseLock: boolean;
+    currencyName: string;
+    fatePointRound: boolean;
+    fatePointClimactic: boolean;
+    woundConfig: number;
+    bodyPointsName: string;
+    highHitDamage: boolean;
+    weaponArmorDamage: boolean;
+    autoOpposed: boolean;
+    autoPromptPlayerResistance: boolean;
+    autoSkillUsed: boolean;
+    pipsPerDice: number;
+    speciesMaxDice: number;
+    speciesMinDice: number;
+    flatSkills: boolean;
+    specLink: boolean;
+    skillUsed: boolean;
+    cost: number | string;
+    fundsFate: boolean;
+    showSkillSpecialization: boolean;
+    specializationDice: boolean;
+    specStartingPipsPerDie: number;
+    channelSkillName: string;
+    senseSkillName: string;
+    transformSkillName: string;
+    trackStuns: boolean;
+    stunDamageIncrement: boolean;
+    randomDifficlty: boolean;
+    hideExplosiveTemplates: boolean;
+    meleeRange: boolean;
+    baseBrawlAttackDifficultyLevel: string;
+    baseMeleeAttackDifficultyLevel: string;
+    stunScaling: boolean;
+    woundScaling: boolean;
+    speciesLabelName: string;
+    typeLabel: string;
+    highHitDamageMultiplier: number;
+    highHitDamagePipsOrDice: boolean;
+    highHitDamageRound: boolean;
+    advanceCostAttribute: number;
+    advanceCostSkill: number;
+    advanceCostMetaphysicsSkill: number;
+    advanceCostSpecialization: number;
+    resistanceOption: boolean;
+    resistanceSkill: string;
+    resistanceMultiplier: number;
+    resistanceRound: boolean;
+    strDamRound: boolean;
+    strDamMultiplier: number;
+    strDamSkill: string;
+    od6Bonus: boolean;
+    deletingMessage: boolean;
+    initialAttributes: number;
+    initialSkills: number;
+    initialCharacterPoints: number;
+    initialFatePoints: number;
+    initialMove: number;
 
-OD6S.vehicle_speeds = {
-    "stopped": {
-        "name": "OD6S.VEHICLE_SPEED_STOPPED",
-        "damage": 6,
-        "mod": 0
-    },
-    "cautious": {
-        "name": "OD6S.VEHICLE_SPEED_CAUTIOUS",
-        "damage": 12,
-        "mod": 0
-    },
-    "cruise": {
-        "name": "OD6S.VEHICLE_SPEED_CRUISE",
-        "damage": 18,
-        "mod": 0
-    },
-    "high": {
-        "name": "OD6S.VEHICLE_SPEED_HIGH",
-        "damage": 24,
-        "mod": 5
-    },
-    "all_out": {
-        "name": "OD6S.VEHICLE_SPEED_ALL_OUT",
-        "damage": 30,
-        "mod": 10
-    }
+    // typed tables (composed from submodules)
+    weaponDamage: Record<number, DamageLevel>;
+    armorDamage: Record<number, DamageLevel>;
+    characterPointLimits: CharacterPointLimits;
+    explosives: string[];
+    deadlinessLevel: Record<string, number>;
+    wildDieResult: Record<number, string>;
+    actorMasks: Record<string, number>;
+    equippable: string[];
+    cargo_hold: string[];
+    deadliness: Record<number, Record<string, WoundLevel>>;
+    damage: Record<string, number>;
+    bodyPointLevels: Record<string, number>;
+    vehicle_damage: Record<string, VehicleDamageLevel>;
+    vehicle_speeds: Record<string, VehicleSpeed>;
+    collision_types: Record<string, CollisionType>;
+    weaponTypes: readonly string[];
+    weaponTypeKeys: readonly WeaponTypeKey[];
+    meleeDifficulties: readonly string[];
+    actions: Record<string, ActionDef>;
+    vehicle_actions: Record<string, ActionDef>;
+    difficulty: Record<string, DifficultyBand>;
+    difficultyShort: Record<string, string>;
+    terrain_difficulty: Record<string, TerrainModifier>;
+    result: Record<string, ResultTier>;
+    cover: Record<string, Record<string, CoverModifier>>;
+    calledShot: Record<string, CalledShotModifier>;
+    gravity: Record<string, CoverModifier>;
+    misc: Record<string, CoverModifier>;
+    rangedAttackOptions: Record<string, AttackOption>;
+    meleeAttackOptions: Record<string, AttackOption>;
+    brawlAttackOptions: Record<string, AttackOption>;
+    attributes: Attributes;
+    ranges: Record<string, RangeBand>;
+    damageTypes: Record<string, string>;
+    cyberneticsLocations: readonly string[];
+    allowedItemTypes: Record<string, string[]>;
+    actorTypeLabels: Record<string, string>;
+    templateItemTypes: Record<string, string[]>;
+    itemLabels: Record<string, string>;
+    chatTemplates: ChatTemplates;
+    data_tab: DataTabConfig;
+    hiddenStatusEffects: readonly string[];
+    statusEffects: StatusEffectDef[];
+    hitLocations: Record<string, string>;
+    initiative: InitiativeConfig;
+    woundsId: Record<string, string>;
+
+    // escape hatch — settings/handlebars helpers still write/read by string key
+    [key: string]: unknown;
 }
 
-OD6S.collision_types = {
-    "head_on": {
-        "name": "OD6S.VEHICLE_HEAD_ON",
-        "score": 9
-    },
-    "sidewipe": {
-        "name": "OD6S.VEHICLE_SIDESWIPE",
-        "score": -9
-    },
-    "rear_end": {
-        "name": "OD6S.VEHICLE_REAR_END",
-        "score": -9
-    },
-    "t_bone": {
-        "name": "OD6S.VEHICLE_T_BONE",
-        "score": 0
-    }
-}
+const chatPath = "systems/od6s/templates/chat/";
 
-OD6S.weaponTypes = weaponTypes;
-OD6S.weaponTypeKeys = weaponTypeKeys;
-OD6S.meleeDifficulties = meleeDifficulties;
+const OD6S: Od6sConfig = {
+    startCombat: false,
+    // Bound by the `socketlib.ready` hook in src/module/socketlib.ts before
+    // any consumer accesses it; pre-init reads would be a programming error.
+    socket: undefined as unknown as SocketLibSocket,
+    baseHitDifficulty: 10,
+    default_sensor_skill: "OD6S.SENSORS",
+    fatePointsName: "",
+    fatePointsShortName: "",
+    useAFatePointName: "",
+    metaphysicsName: "",
+    manifestationsName: "",
+    metaphysicsExtranormalName: "",
+    vehicleToughnessName: "",
+    stunDice: false,
+    passengerDamageDice: false,
+    starshipToughnessName: "",
+    interstellarDriveName: "",
+    vehicleDifficulty: true,
+    brawlAttribute: "",
+    chatPath,
+    wildDieOneDefault: 0,
+    wildDieOneAuto: 0,
+    grenadeDamageDice: false,
+    highlightEffects: false,
+    randomHitLocations: false,
+    mapRange: false,
+    meleeDifficulty: false,
+    baseRangedAttackDifficulty: 10,
+    baseMeleeAttackDifficulty: 10,
+    baseBrawlAttackDifficulty: 10,
+    defenseLock: false,
+    currencyName: "OD6S.CHAR_CREDITS",
+    fatePointRound: false,
+    fatePointClimactic: false,
+    woundConfig: 0,
+    bodyPointsName: "OD6S.BODY_POINTS",
+    highHitDamage: false,
+    weaponArmorDamage: false,
+    autoOpposed: false,
+    autoPromptPlayerResistance: false,
+    autoSkillUsed: false,
+    pipsPerDice: 3,
+    speciesMaxDice: 5,
+    speciesMinDice: 1,
+    flatSkills: false,
+    specLink: true,
+    skillUsed: true,
+    cost: 0,
+    fundsFate: false,
+    showSkillSpecialization: true,
+    specializationDice: false,
+    specStartingPipsPerDie: 3,
+    channelSkillName: "OD6S.METAPHYSICS_SKILL_CHANNEL",
+    senseSkillName: "OD6S.METAPHYSICS_SKILL_SENSE",
+    transformSkillName: "OD6S.METAPHYSICS_SKILL_TRANSFORM",
+    trackStuns: false,
+    stunDamageIncrement: true,
+    randomDifficlty: false,
+    hideExplosiveTemplates: true,
+    meleeRange: false,
+    baseBrawlAttackDifficultyLevel: "OD6S.DIFFICULTY_VERY_EASY",
+    baseMeleeAttackDifficultyLevel: "OD6S.DIFFICULTY_VERY_EASY",
+    stunScaling: false,
+    woundScaling: false,
+    speciesLabelName: "OD6S.CHAR_SPECIES",
+    typeLabel: "OD6S.CHAR_TYPE",
+    highHitDamageMultiplier: 5,
+    highHitDamagePipsOrDice: false,
+    highHitDamageRound: false,
+    advanceCostAttribute: 10,
+    advanceCostSkill: 1,
+    advanceCostMetaphysicsSkill: 2,
+    advanceCostSpecialization: 0.5,
+    resistanceOption: false,
+    resistanceSkill: "Stamina",
+    resistanceMultiplier: 1,
+    resistanceRound: false,
+    strDamRound: false,
+    strDamMultiplier: 0.5,
+    strDamSkill: "Lift",
+    od6Bonus: false,
+    deletingMessage: false,
+    initialAttributes: 54,
+    initialSkills: 21,
+    initialCharacterPoints: 5,
+    initialFatePoints: 1,
+    initialMove: 10,
 
-OD6S.actions = actions;
-
-OD6S.vehicle_actions = vehicleActions;
-
-OD6S.difficulty = {
-    "OD6S.DIFFICULTY_UNKNOWN": {
-        "min": 0,
-        "max": 0,
-        "dice": 0
+    weaponDamage,
+    armorDamage,
+    characterPointLimits: {
+        skill: 2,
+        attribute: 2,
+        specialization: 5,
+        dodge: 5,
+        parry: 5,
+        block: 5,
+        dr: 5,
+        initiative: 5,
     },
-    "OD6S.DIFFICULTY_CUSTOM": {
-        "min": 0,
-        "max": 0,
-        "dice": 0
+    explosives: [
+        "OD6S.EXPLOSIVE_THROWN",
+        // TODO: "OD6S.EXPLOSIVE_TIMER",
+        // TODO: "OD6S.EXPLOSIVE_TRIGGER"
+    ],
+    deadlinessLevel: { character: 3, creature: 3, npc: 3 },
+    wildDieResult,
+    actorMasks: { character: 0, npc: 1, creature: 2, vehicle: 3, starship: 4 },
+    equippable: [
+        "weapon",
+        "armor",
+        "gear",
+        "vehicle-weapon",
+        "vehicle-gear",
+        "starship-weapon",
+        "starship-gear",
+    ],
+    cargo_hold: [
+        "weapon",
+        "armor",
+        "gear",
+        "vehicle-weapon",
+        "vehicle-gear",
+        "starship-weapon",
+        "starship-gear",
+    ],
+    deadliness,
+    damage,
+    bodyPointLevels,
+    vehicle_damage: vehicleDamage,
+    vehicle_speeds: vehicleSpeeds,
+    collision_types: collisionTypes,
+    weaponTypes,
+    weaponTypeKeys,
+    meleeDifficulties,
+    actions,
+    vehicle_actions: vehicleActions,
+    difficulty,
+    difficultyShort,
+    terrain_difficulty: terrainDifficulty,
+    result,
+    cover,
+    calledShot,
+    gravity,
+    misc,
+    rangedAttackOptions,
+    meleeAttackOptions,
+    brawlAttackOptions,
+    attributes,
+    ranges,
+    damageTypes,
+    cyberneticsLocations: [
+        "OD6S.HEAD",
+        "OD6S.RIGHT_ARM",
+        "OD6S.LEFT_ARM",
+        "OD6S.BODY",
+        "OD6S.RIGHT_LEG",
+        "OD6S.LEFT_LEG",
+    ],
+    allowedItemTypes,
+    actorTypeLabels,
+    templateItemTypes,
+    itemLabels,
+    chatTemplates: {
+        generic: chatPath + "generic.html",
+        roll: chatPath + "roll.html",
+        opposed: chatPath + "opposed.html",
+        damageresult: chatPath + "damageresult.html",
+        explosive: chatPath + "explosive.html",
+        "explosive-button": chatPath + "explosive-button.html",
+        range: chatPath + "range.html",
     },
-    "OD6S.DIFFICULTY_AUTOMATIC": {
-        "min": 0,
-        "max": 0,
-        "dice": 0
-    },
-    "OD6S.DIFFICULTY_VERY_EASY": {
-        "min": 1,
-        "max": 5,
-        "dice": 1
-    },
-    "OD6S.DIFFICULTY_EASY": {
-        "min": 6,
-        "max": 10,
-        "dice": 2
-    },
-    "OD6S.DIFFICULTY_MODERATE": {
-        "min": 11,
-        "max": 15,
-        "dice": 4
-    },
-    "OD6S.DIFFICULTY_DIFFICULT": {
-        "min": 16,
-        "max": 20,
-        "dice": 6
-    },
-    "OD6S.DIFFICULTY_VERY_DIFFICULT": {
-        "min": 21,
-        "max": 25,
-        "dice": 8
-    },
-    "OD6S.DIFFICULTY_HEROIC": {
-        "min": 26,
-        "max": 30,
-        "dice": 9
-    },
-    "OD6S.DIFFICULTY_LEGENDARY": {
-        "min": 31,
-        "max": 40,
-        "dice": 10
-    }
-}
-
-OD6S.difficultyShort = {
-    "VE": "OD6S.DIFFICULTY_VERY_EASY",
-    "E": "OD6S.DIFFICULTY_EASY",
-    "M": "OD6S.DIFFICULTY_MODERATE",
-    "D": "OD6S.DIFFICULTY_DIFFICULT",
-    "VD": "OD6S.DIFFICULTY_VERY_DIFFICULT",
-    "H": "OD6S.DIFFICULTY_HEROIC",
-    "L": "OD6S.DIFFICULTY_LEGENDARY"
-}
-
-OD6S.terrain_difficulty = {
-    "OD6S.TERRAIN_EASY": {
-        "mod": 0
-    },
-    "OD6S.TERRAIN_MODERATE": {
-        "mod": 5
-    },
-    "OD6S.TERRAIN_ROUGH": {
-        "mod": 10
-    },
-    "OD6S.TERRAIN_VERY_ROUGH": {
-        "mod": 15
-    },
-    "OD6S.TERRAIN_HAZARDOUS": {
-        "mod": 20
-    },
-    "OD6S.TERRAIN_VERY_HAZARDOUS": {
-        "mod": 25
-    }
-}
-
-OD6S.result = {
-    "OD6S.FAILURE": {
-        "description": "OD6S.FAILURE",
-        "difference": -1
-    },
-    "OD6S.RESULT_MINIMAL": {
-        "description": "OD6S.RESULT_MINIMAL_DESCRIPTION",
-        "difference": 0
-    },
-    "OD6S.RESULT_SOLID": {
-        "description": "OD6S.RESULT_SOLID_DESCRIPTION",
-        "difference": 1
-    },
-    "OD6S.RESULT_GOOD": {
-        "description": "OD6S.RESULT_GOOD_DESCRIPTION",
-        "difference": 5
-    },
-    "OD6S.RESULT_SUPERIOR": {
-        "description": "OD6S.RESULT_SUPERIOR_DESCRIPTION",
-        "difference": 9
-    },
-    "OD6S.RESULT_SPECTACULAR": {
-        "description": "OD6S.RESULT_SPECTACULAR_DESCRIPTION",
-        "difference": 13
-    },
-    "OD6S.RESULT_INCREDIBLE": {
-        "description": "OD6S.RESULT_INCREDIBLE_DESCRIPTION",
-        "difference": 16
-    }
-}
-
-OD6S.cover = {
-    "OD6S.COVER_SMOKE": {
-        "OD6S.NONE": {
-            "modifier": 0
+    data_tab: {
+        defense: {
+            dodge: "OD6S.DODGE",
+            parry: "OD6S.PARRY",
+            block: "OD6S.BLOCK",
         },
-        "OD6S.COVER_LIGHT_SMOKE": {
-            "modifier": 3
-        },
-        "OD6S.COVER_THICK_SMOKE": {
-            "modifier": 6
-        },
-        "OD6S.COVER_VERY_THICK_SMOKE": {
-            "modifier": 12
-        },
-    },
-    "OD6S.COVER_LIGHT": {
-        "OD6S.COVER_LIGHT_NONE": {
-            "modifier": 0
-        },
-        "OD6S.COVER_POOR_LIGHT": {
-            "modifier": 3
-        },
-        "OD6S.COVER_MOONLIGHT_NIGHT": {
-            "modifier": 6
-        },
-        "OD6S.COVER_COMPLETE_DARKNESS": {
-            "modifier": 12
+        offense: {
+            ranged: "OD6S.RANGED",
+            melee: "OD6S.MELEE",
+            brawl: "OD6S.BRAWL",
+            initiative: "OD6S.INITIATIVE",
+            strengthdamage: "OD6S.STRENGTH_DAMAGE",
+            pr: "OD6S.PHYSICAL_RESISTANCE",
+            er: "OD6S.ENERGY_RESISTANCE",
+            move: "OD6S.MOVE",
         },
     },
-    "OD6S.COVER": {
-        "OD6S.NONE": {
-            "modifier": 0
-        },
-        "OD6S.COVER_QUARTER": {
-            "modifier": 3
-        },
-        "OD6S.COVER_HALF": {
-            "modifier": 6
-        },
-        "OD6S.COVER_THREE_QUARTERS": {
-            "modifier": 12
-        },
-        "OD6S.COVER_FULL": {
-            "modifier": 0
-        }
-    }
-}
-
-
-// Other modifiers besides range and cover
-OD6S.calledShot = {
-    "OD6S.CALLED_SHOT_NONE": {
-        "modifier": 0,
-        "damage": 0
+    hiddenStatusEffects,
+    statusEffects,
+    hitLocations,
+    initiative: {
+        type: "roll",
+        reroll: false,
+        reroll_npc: false,
+        reroll_character: false,
+        dsn: false,
+        attribute: "per",
     },
-    "OD6S.CALLED_SHOT_LARGE": {
-        "modifier": 3,
-        "damage": 0
-
-    },
-    "OD6S.CALLED_SHOT_MEDIUM": {
-        "modifier": 12,
-        "damage": 0
-    },
-    "OD6S.CALLED_SHOT_SMALL": {
-        "modifier": 24,
-        "damage": 0
-    },
-    "OD6S.CALLED_SHOT_HEAD": {
-        "modifier": 5,
-        "damage": 12,
-    },
-    "OD6S.CALLED_SHOT_HEART": {
-        "modifier": 15,
-        "damage": 12,
-    },
-    "OD6S.CALLED_SHOT_TORSO": {
-        "modifier": 0,
-        "damage": 0,
-    },
-    "OD6S.CALLED_SHOT_ARM": {
-        "modifier": 5,
-        "damage": -2,
-    },
-    "OD6S.CALLED_SHOT_LEG": {
-        "modifier": 5,
-        "damage": -1,
-    },
-    "OD6S.CALLED_SHOT_HAND": {
-        "modifier": 15,
-        "damage": -2,
-    }
-}
-
-OD6S.gravity = {
-    "OD6S.GRAVITY_STANDARD": {
-        "modifier": 0
-    },
-    "OD6S.GRAVITY_LOW": {
-        "modifier": -3
-    },
-    "OD6S.GRAVITY_NONE": {
-        "modifier": -6
-    },
-    "OD6S.GRAVITY_HEAVY": {
-        "modifier": 9
-    }
-}
-
-// Other modifiers from conditions, etc.
-OD6S.misc = {
-    "OD6S.MISC": {
-        "modifier": 0
-    }
-}
-
-// attack: subtraction or addition to hit difficulty (negative numbers are in effect a bonus)
-// damage: bonus or penalty to damage
-// multi: whether an attack needs a ROF selection by the character for number of shots in a round
-OD6S.rangedAttackOptions = rangedAttackOptions;
-OD6S.meleeAttackOptions = meleeAttackOptions;
-OD6S.brawlAttackOptions = brawlAttackOptions;
-
-OD6S.attributes = attributes;
-
-OD6S.ranges = ranges;
-
-OD6S.damageTypes = damageTypes;
-
-OD6S.cyberneticsLocations = [
-    "OD6S.HEAD",
-    "OD6S.RIGHT_ARM",
-    "OD6S.LEFT_ARM",
-    "OD6S.BODY",
-    "OD6S.RIGHT_LEG",
-    "OD6S.LEFT_LEG"
-]
-
-OD6S.allowedItemTypes = allowedItemTypes;
-OD6S.actorTypeLabels = actorTypeLabels;
-OD6S.templateItemTypes = templateItemTypes;
-OD6S.itemLabels = itemLabels;
-
-OD6S.chatTemplates = {
-    "generic": OD6S.chatPath + "generic.html",
-    "roll": OD6S.chatPath + "roll.html",
-    "opposed": OD6S.chatPath + "opposed.html",
-    "damageresult": OD6S.chatPath + "damageresult.html",
-    "explosive": OD6S.chatPath + "explosive.html",
-    "explosive-button": OD6S.chatPath + "explosive-button.html",
-    "range": OD6S.chatPath + "range.html"
-}
-
-OD6S.data_tab = {
-    "defense": {
-        "dodge": "OD6S.DODGE",
-        "parry": "OD6S.PARRY",
-        "block": "OD6S.BLOCK"
-    },
-    "offense": {
-        "ranged": "OD6S.RANGED",
-        "melee": "OD6S.MELEE",
-        "brawl": "OD6S.BRAWL",
-        "initiative": "OD6S.INITIATIVE",
-        "strengthdamage": "OD6S.STRENGTH_DAMAGE",
-        "pr": "OD6S.PHYSICAL_RESISTANCE",
-        "er": "OD6S.ENERGY_RESISTANCE",
-        "move": "OD6S.MOVE"
-    }
-}
-
-OD6S.hiddenStatusEffects = [
-  "stunned",
-  "wounded",
-  "severely_wounded",
-  "incapacitated",
-  "mortally_wounded"
-]
-
-OD6S.statusEffects = statusEffects;
-
-OD6S.hitLocations = {
-    0: "OD6S.LOCATION_RIGHT_HAND",
-    1: "OD6S.LOCATION_LEFT_HAND",
-    2: "OD6S.LOCATION_RIGHT_LEG",
-    3: "OD6S.LOCATION_RIGHT_FOOT",
-    4: "OD6S.LOCATION_LEFT_LEG",
-    5: "OD6S.LOCATION_LEFT_FOOT",
-    6: "OD6S.LOCATION_ABDOMEN",
-    7: "OD6S.LOCATION_CHEST",
-    8: "OD6S.LOCATION_CHEST",
-    9: "OD6S.LOCATION_HEAD"
-}
-
-OD6S.initiative = {
-    "type": "roll",
-    "reroll": false,
-    "reroll_npc": false,
-    "reroll_character": false,
-    "dsn": false,
-    "attribute": "per",
-}
-
-OD6S.woundsId = {
-  'OD6S.WOUNDS_HEALTHY': 'healthy',
-  'OD6S.WOUNDS_STUNNED': 'stunned',
-  'OD6S.WOUNDS_WOUNDED': 'wounded',
-  'OD6S.WOUNDS_SEVERELY_WOUNDED': 'severely_wounded',
-  'OD6S.WOUNDS_INCAPACITATED': 'incapacitated',
-  'OD6S.WOUNDS_MORTALLY_WOUNDED': 'mortally_wounded',
-  'OD6S.WOUNDS_DEAD': 'dead'
-}
-
-OD6S.initialAttributes = 54
-OD6S.initialSkills = 21
-OD6S.initialCharacterPoints = 5
-OD6S.initialFatePoints = 1
-OD6S.initialMove = 10
-
-OD6S.metaphysicsSkills = [
-  OD6S.CONFIG_CUSTOMIZE_METAPHYSICS_SKILL_CHANNEL,
-  OD6S.CONFIG_CUSTOMIZE_METAPHYSICS_SKILL_SENSE,
-  OD6S.CONFIG_CUSTOMIZE_METAPHYSICS_SKILL_TRANSFORM
-]
+    woundsId,
+};
 
 export default OD6S;

--- a/src/module/config/config-od6s.ts
+++ b/src/module/config/config-od6s.ts
@@ -43,6 +43,7 @@ import {
     terrainDifficulty,
     result,
     type DifficultyBand,
+    type DifficultyKey,
     type ResultTier,
     type TerrainModifier,
 } from "./difficulty";
@@ -77,7 +78,6 @@ export interface CharacterPointLimits {
     block: number;
     dr: number;
     initiative: number;
-    init?: number;
 }
 
 /**
@@ -237,7 +237,7 @@ export interface Od6sConfig {
     actions: Record<string, ActionDef>;
     vehicle_actions: Record<string, ActionDef>;
     difficulty: Record<string, DifficultyBand>;
-    difficultyShort: Record<string, string>;
+    difficultyShort: Record<string, DifficultyKey>;
     terrain_difficulty: Record<string, TerrainModifier>;
     result: Record<string, ResultTier>;
     cover: Record<string, Record<string, CoverModifier>>;

--- a/src/module/config/damage.ts
+++ b/src/module/config/damage.ts
@@ -4,7 +4,13 @@
  * Mounted onto OD6S by `config-od6s.ts`.
  */
 
-export const weaponDamage = {
+export interface DamageLevel {
+    label: string;
+    woundLevel?: string;
+    penalty: number;
+}
+
+export const weaponDamage: Record<number, DamageLevel> = {
     0: {
         label: "OD6S.NO_DAMAGE",
         penalty: 0
@@ -27,7 +33,7 @@ export const weaponDamage = {
     }
 };
 
-export const armorDamage = {
+export const armorDamage: Record<number, DamageLevel> = {
     0: {
         label: "OD6S.NO_DAMAGE",
         woundLevel: "",
@@ -52,7 +58,7 @@ export const armorDamage = {
     }
 };
 
-export const damage = {
+export const damage: Record<string, number> = {
     "OD6S.WOUNDS_STUNNED": 1,
     "OD6S.WOUNDS_WOUNDED": 4,
     "OD6S.WOUNDS_INCAPACITATED": 9,
@@ -60,7 +66,13 @@ export const damage = {
     "OD6S.WOUNDS_DEAD": 16
 };
 
-export const vehicleDamage = {
+export interface VehicleDamageLevel {
+    damage: number;
+    passenger_damage: string;
+    passenger_damage_dice: number;
+}
+
+export const vehicleDamage: Record<string, VehicleDamageLevel> = {
     "OD6S.NO_DAMAGE": {
         "damage": 0,
         "passenger_damage": "OD6S.PASSENGER_NO_DAMAGE",
@@ -93,7 +105,7 @@ export const vehicleDamage = {
     }
 };
 
-export const damageTypes = {
+export const damageTypes: Record<string, string> = {
     "p": "OD6S.PHYSICAL",
     "e": "OD6S.ENERGY"
 };

--- a/src/module/config/deadliness.ts
+++ b/src/module/config/deadliness.ts
@@ -3,7 +3,13 @@
  * a wound count to a wound-level description, penalty, and core wound name.
  * Mounted onto `OD6S.deadliness` by `config-od6s.ts`.
  */
-const deadliness = {
+export interface WoundLevel {
+    description: string;
+    penalty: number;
+    core: string;
+}
+
+const deadliness: Record<number, Record<string, WoundLevel>> = {
     1: {
         0: {
             "description": "OD6S.WOUNDS_HEALTHY",

--- a/src/module/config/difficulty.ts
+++ b/src/module/config/difficulty.ts
@@ -1,0 +1,76 @@
+/**
+ * Difficulty bands used by the roll dialog and target-number lookup, plus
+ * the short-code aliases referenced by item difficulty tags and the terrain
+ * modifier table layered onto vehicle/movement rolls. Result tiers describe
+ * how far a roll exceeded its target.
+ * Mounted onto `OD6S` by `config-od6s.ts`.
+ */
+
+export interface DifficultyBand {
+    min: number;
+    max: number;
+    dice: number;
+}
+
+export type DifficultyKey =
+    | "OD6S.DIFFICULTY_UNKNOWN"
+    | "OD6S.DIFFICULTY_CUSTOM"
+    | "OD6S.DIFFICULTY_AUTOMATIC"
+    | "OD6S.DIFFICULTY_VERY_EASY"
+    | "OD6S.DIFFICULTY_EASY"
+    | "OD6S.DIFFICULTY_MODERATE"
+    | "OD6S.DIFFICULTY_DIFFICULT"
+    | "OD6S.DIFFICULTY_VERY_DIFFICULT"
+    | "OD6S.DIFFICULTY_HEROIC"
+    | "OD6S.DIFFICULTY_LEGENDARY";
+
+export const difficulty: Record<DifficultyKey, DifficultyBand> = {
+    "OD6S.DIFFICULTY_UNKNOWN": { min: 0, max: 0, dice: 0 },
+    "OD6S.DIFFICULTY_CUSTOM": { min: 0, max: 0, dice: 0 },
+    "OD6S.DIFFICULTY_AUTOMATIC": { min: 0, max: 0, dice: 0 },
+    "OD6S.DIFFICULTY_VERY_EASY": { min: 1, max: 5, dice: 1 },
+    "OD6S.DIFFICULTY_EASY": { min: 6, max: 10, dice: 2 },
+    "OD6S.DIFFICULTY_MODERATE": { min: 11, max: 15, dice: 4 },
+    "OD6S.DIFFICULTY_DIFFICULT": { min: 16, max: 20, dice: 6 },
+    "OD6S.DIFFICULTY_VERY_DIFFICULT": { min: 21, max: 25, dice: 8 },
+    "OD6S.DIFFICULTY_HEROIC": { min: 26, max: 30, dice: 9 },
+    "OD6S.DIFFICULTY_LEGENDARY": { min: 31, max: 40, dice: 10 },
+};
+
+export const difficultyShort: Record<string, DifficultyKey> = {
+    VE: "OD6S.DIFFICULTY_VERY_EASY",
+    E: "OD6S.DIFFICULTY_EASY",
+    M: "OD6S.DIFFICULTY_MODERATE",
+    D: "OD6S.DIFFICULTY_DIFFICULT",
+    VD: "OD6S.DIFFICULTY_VERY_DIFFICULT",
+    H: "OD6S.DIFFICULTY_HEROIC",
+    L: "OD6S.DIFFICULTY_LEGENDARY",
+};
+
+export interface TerrainModifier {
+    mod: number;
+}
+
+export const terrainDifficulty: Record<string, TerrainModifier> = {
+    "OD6S.TERRAIN_EASY": { mod: 0 },
+    "OD6S.TERRAIN_MODERATE": { mod: 5 },
+    "OD6S.TERRAIN_ROUGH": { mod: 10 },
+    "OD6S.TERRAIN_VERY_ROUGH": { mod: 15 },
+    "OD6S.TERRAIN_HAZARDOUS": { mod: 20 },
+    "OD6S.TERRAIN_VERY_HAZARDOUS": { mod: 25 },
+};
+
+export interface ResultTier {
+    description: string;
+    difference: number;
+}
+
+export const result: Record<string, ResultTier> = {
+    "OD6S.FAILURE": { description: "OD6S.FAILURE", difference: -1 },
+    "OD6S.RESULT_MINIMAL": { description: "OD6S.RESULT_MINIMAL_DESCRIPTION", difference: 0 },
+    "OD6S.RESULT_SOLID": { description: "OD6S.RESULT_SOLID_DESCRIPTION", difference: 1 },
+    "OD6S.RESULT_GOOD": { description: "OD6S.RESULT_GOOD_DESCRIPTION", difference: 5 },
+    "OD6S.RESULT_SUPERIOR": { description: "OD6S.RESULT_SUPERIOR_DESCRIPTION", difference: 9 },
+    "OD6S.RESULT_SPECTACULAR": { description: "OD6S.RESULT_SPECTACULAR_DESCRIPTION", difference: 13 },
+    "OD6S.RESULT_INCREDIBLE": { description: "OD6S.RESULT_INCREDIBLE_DESCRIPTION", difference: 16 },
+};

--- a/src/module/config/labels.ts
+++ b/src/module/config/labels.ts
@@ -3,7 +3,7 @@
  * Mounted onto `OD6S` by `config-od6s.ts`.
  */
 
-export const actorTypeLabels = {
+export const actorTypeLabels: Record<string, string> = {
     "character": "ACTOR.TypeCharacter",
     "creature": "ACTOR.TypeCreature",
     "npc": "ACTOR.TypeNpc",
@@ -11,7 +11,7 @@ export const actorTypeLabels = {
     "vehicle": "ACTOR.TypeVehicle",
 };
 
-export const itemLabels = {
+export const itemLabels: Record<string, string> = {
     "skill": "OD6S.SKILL",
     "specialization": "OD6S.SPECIALIZATION",
     "advantage": "OD6S.ADVANTAGE",
@@ -32,7 +32,7 @@ export const itemLabels = {
     "vehicle-weapon": "ITEM.TypeVehicle-weapon",
 };
 
-export const templateItemTypes = {
+export const templateItemTypes: Record<string, string[]> = {
     "character-template": [
         "skill",
         "specialability",
@@ -60,7 +60,7 @@ export const templateItemTypes = {
     ],
 };
 
-export const allowedItemTypes = {
+export const allowedItemTypes: Record<string, string[]> = {
     "container": [
         "armor",
         "weapon",

--- a/src/module/config/modifiers.ts
+++ b/src/module/config/modifiers.ts
@@ -1,0 +1,61 @@
+/**
+ * Situational modifiers layered onto attack rolls: cover/concealment buckets,
+ * called-shot location penalties (with optional damage adjustment), gravity
+ * conditions, and the catch-all `misc` bucket left for ad-hoc modifiers.
+ * Mounted onto `OD6S` by `config-od6s.ts`.
+ */
+
+export interface CoverModifier {
+    modifier: number;
+}
+
+export const cover: Record<string, Record<string, CoverModifier>> = {
+    "OD6S.COVER_SMOKE": {
+        "OD6S.NONE": { modifier: 0 },
+        "OD6S.COVER_LIGHT_SMOKE": { modifier: 3 },
+        "OD6S.COVER_THICK_SMOKE": { modifier: 6 },
+        "OD6S.COVER_VERY_THICK_SMOKE": { modifier: 12 },
+    },
+    "OD6S.COVER_LIGHT": {
+        "OD6S.COVER_LIGHT_NONE": { modifier: 0 },
+        "OD6S.COVER_POOR_LIGHT": { modifier: 3 },
+        "OD6S.COVER_MOONLIGHT_NIGHT": { modifier: 6 },
+        "OD6S.COVER_COMPLETE_DARKNESS": { modifier: 12 },
+    },
+    "OD6S.COVER": {
+        "OD6S.NONE": { modifier: 0 },
+        "OD6S.COVER_QUARTER": { modifier: 3 },
+        "OD6S.COVER_HALF": { modifier: 6 },
+        "OD6S.COVER_THREE_QUARTERS": { modifier: 12 },
+        "OD6S.COVER_FULL": { modifier: 0 },
+    },
+};
+
+export interface CalledShotModifier {
+    modifier: number;
+    damage: number;
+}
+
+export const calledShot: Record<string, CalledShotModifier> = {
+    "OD6S.CALLED_SHOT_NONE": { modifier: 0, damage: 0 },
+    "OD6S.CALLED_SHOT_LARGE": { modifier: 3, damage: 0 },
+    "OD6S.CALLED_SHOT_MEDIUM": { modifier: 12, damage: 0 },
+    "OD6S.CALLED_SHOT_SMALL": { modifier: 24, damage: 0 },
+    "OD6S.CALLED_SHOT_HEAD": { modifier: 5, damage: 12 },
+    "OD6S.CALLED_SHOT_HEART": { modifier: 15, damage: 12 },
+    "OD6S.CALLED_SHOT_TORSO": { modifier: 0, damage: 0 },
+    "OD6S.CALLED_SHOT_ARM": { modifier: 5, damage: -2 },
+    "OD6S.CALLED_SHOT_LEG": { modifier: 5, damage: -1 },
+    "OD6S.CALLED_SHOT_HAND": { modifier: 15, damage: -2 },
+};
+
+export const gravity: Record<string, CoverModifier> = {
+    "OD6S.GRAVITY_STANDARD": { modifier: 0 },
+    "OD6S.GRAVITY_LOW": { modifier: -3 },
+    "OD6S.GRAVITY_NONE": { modifier: -6 },
+    "OD6S.GRAVITY_HEAVY": { modifier: 9 },
+};
+
+export const misc: Record<string, CoverModifier> = {
+    "OD6S.MISC": { modifier: 0 },
+};

--- a/src/module/config/settings/character-points.ts
+++ b/src/module/config/settings/character-points.ts
@@ -94,6 +94,6 @@ export function registerCharacterPointSettings() {
         type: Number,
         default: 5,
         requiresReload: true,
-        onChange: (value: number) => (value ? OD6S.characterPointLimits.init = value : 2)
+        onChange: (value: number) => (value ? OD6S.characterPointLimits.initiative = value : 2)
     })
 }

--- a/src/module/config/status-effects.ts
+++ b/src/module/config/status-effects.ts
@@ -2,7 +2,14 @@
  * Status effects displayed in the token HUD and applied via wound/stun automation.
  * Mounted onto `OD6S.statusEffects` by `config-od6s.ts`.
  */
-const statusEffects = [
+export interface StatusEffectDef {
+    id: string;
+    name: string;
+    img: string;
+    hud?: boolean;
+}
+
+const statusEffects: StatusEffectDef[] = [
     {
         id: "dead",
         name: "EFFECT.StatusDead",

--- a/src/module/config/vehicles.ts
+++ b/src/module/config/vehicles.ts
@@ -1,0 +1,31 @@
+/**
+ * Vehicle scale tables: speed bands (used for both ramming damage and
+ * to-hit modifiers) and ramming collision-type scores.
+ * Mounted onto `OD6S` by `config-od6s.ts`.
+ */
+
+export interface VehicleSpeed {
+    name: string;
+    damage: number;
+    mod: number;
+}
+
+export const vehicleSpeeds: Record<string, VehicleSpeed> = {
+    stopped: { name: "OD6S.VEHICLE_SPEED_STOPPED", damage: 6, mod: 0 },
+    cautious: { name: "OD6S.VEHICLE_SPEED_CAUTIOUS", damage: 12, mod: 0 },
+    cruise: { name: "OD6S.VEHICLE_SPEED_CRUISE", damage: 18, mod: 0 },
+    high: { name: "OD6S.VEHICLE_SPEED_HIGH", damage: 24, mod: 5 },
+    all_out: { name: "OD6S.VEHICLE_SPEED_ALL_OUT", damage: 30, mod: 10 },
+};
+
+export interface CollisionType {
+    name: string;
+    score: number;
+}
+
+export const collisionTypes: Record<string, CollisionType> = {
+    head_on: { name: "OD6S.VEHICLE_HEAD_ON", score: 9 },
+    sidewipe: { name: "OD6S.VEHICLE_SIDESWIPE", score: -9 },
+    rear_end: { name: "OD6S.VEHICLE_REAR_END", score: -9 },
+    t_bone: { name: "OD6S.VEHICLE_T_BONE", score: 0 },
+};

--- a/src/module/config/weapons.ts
+++ b/src/module/config/weapons.ts
@@ -3,7 +3,25 @@
  * Mounted onto `OD6S` by `config-od6s.ts`.
  */
 
-export const weaponTypes = [
+export interface WeaponTypeKey {
+    key: string;
+    name: string;
+}
+
+export interface AttackOption {
+    attack: number;
+    damage: number;
+    multi?: boolean;
+}
+
+export interface RangeBand {
+    name: string;
+    difficulty: number;
+    map: string;
+    item: string;
+}
+
+export const weaponTypes: readonly string[] = [
     "OD6S.RANGED",
     "OD6S.MELEE",
     "OD6S.MISSILE",
@@ -11,7 +29,7 @@ export const weaponTypes = [
     "OD6S.EXPLOSIVE",
 ];
 
-export const weaponTypeKeys = [
+export const weaponTypeKeys: readonly WeaponTypeKey[] = [
     { "key": "OD6S.RANGED", "name": "Ranged" },
     { "key": "OD6S.MELEE", "name": "Melee" },
     { "key": "OD6S.MISSILE", "name": "Missile" },
@@ -19,7 +37,7 @@ export const weaponTypeKeys = [
     { "key": "OD6S.EXPLOSIVE", "name": "Explosive" },
 ];
 
-export const meleeDifficulties = [
+export const meleeDifficulties: readonly string[] = [
     "OD6S.DIFFICULTY_VERY_EASY",
     "OD6S.DIFFICULTY_EASY",
     "OD6S.DIFFICULTY_MODERATE",
@@ -28,7 +46,7 @@ export const meleeDifficulties = [
     "OD6S.DIFFICULTY_HEROIC",
 ];
 
-export const rangedAttackOptions = {
+export const rangedAttackOptions: Record<string, AttackOption> = {
     "OD6S.ATTACK_STANDARD": {
         "attack": 0,
         "damage": 0,
@@ -56,7 +74,7 @@ export const rangedAttackOptions = {
     },
 };
 
-export const meleeAttackOptions = {
+export const meleeAttackOptions: Record<string, AttackOption> = {
     "OD6S.ATTACK_STANDARD": { "attack": 0, "damage": 0, "multi": false },
     "OD6S.ATTACK_ALL_OUT": { "attack": -6, "damage": 3 },
     "OD6S.ATTACK_LUNGE": { "attack": 3, "damage": -3 },
@@ -64,7 +82,7 @@ export const meleeAttackOptions = {
     "OD6S.ATTACK_PUSH": { "attack": 3, "damage": 0 },
 };
 
-export const brawlAttackOptions = {
+export const brawlAttackOptions: Record<string, AttackOption> = {
     "OD6S.ATTACK_STANDARD": { "attack": 0, "damage": 0, "multi": false },
     "OD6S.ATTACK_ALL_OUT": { "attack": -6, "damage": 3 },
     "OD6S.ATTACK_GRAB": { "attack": 9, "damage": 0 },
@@ -75,7 +93,7 @@ export const brawlAttackOptions = {
     "OD6S.ATTACK_TACKLE": { "attack": 3, "damage": 0 },
 };
 
-export const ranges = {
+export const ranges: Record<string, RangeBand> = {
     "OD6S.RANGE_POINT_BLANK_SHORT": {
         "name": "OD6S.RANGE_POINT_BLANK",
         "difficulty": -5,

--- a/src/module/config/wounds.ts
+++ b/src/module/config/wounds.ts
@@ -1,0 +1,54 @@
+/**
+ * Wound-track adjacent tables: body-point thresholds, wound-level → effect-id
+ * map, hit-location 1d10 lookup, wild-die-result options, and the list of
+ * status effects that the system applies automatically (hidden from the HUD).
+ * Mounted onto `OD6S` by `config-od6s.ts`.
+ */
+
+export const bodyPointLevels: Record<string, number> = {
+    "OD6S.WOUNDS_HEALTHY": 9999,
+    "OD6S.WOUNDS_STUNNED": 81,
+    "OD6S.WOUNDS_WOUNDED": 60,
+    "OD6S.WOUNDS_SEVERELY_WOUNDED": 40,
+    "OD6S.WOUNDS_INCAPACITATED": 20,
+    "OD6S.WOUNDS_MORTALLY_WOUNDED": 10,
+    "OD6S.WOUNDS_DEAD": 1,
+};
+
+export const woundsId: Record<string, string> = {
+    "OD6S.WOUNDS_HEALTHY": "healthy",
+    "OD6S.WOUNDS_STUNNED": "stunned",
+    "OD6S.WOUNDS_WOUNDED": "wounded",
+    "OD6S.WOUNDS_SEVERELY_WOUNDED": "severely_wounded",
+    "OD6S.WOUNDS_INCAPACITATED": "incapacitated",
+    "OD6S.WOUNDS_MORTALLY_WOUNDED": "mortally_wounded",
+    "OD6S.WOUNDS_DEAD": "dead",
+};
+
+export const hitLocations: Record<string, string> = {
+    0: "OD6S.LOCATION_RIGHT_HAND",
+    1: "OD6S.LOCATION_LEFT_HAND",
+    2: "OD6S.LOCATION_RIGHT_LEG",
+    3: "OD6S.LOCATION_RIGHT_FOOT",
+    4: "OD6S.LOCATION_LEFT_LEG",
+    5: "OD6S.LOCATION_LEFT_FOOT",
+    6: "OD6S.LOCATION_ABDOMEN",
+    7: "OD6S.LOCATION_CHEST",
+    8: "OD6S.LOCATION_CHEST",
+    9: "OD6S.LOCATION_HEAD",
+};
+
+export const wildDieResult: Record<number, string> = {
+    0: "OD6S.WILD_RESULT_ONE",
+    1: "OD6S.WILD_DIE_NONE",
+    2: "OD6S.REMOVE_HIGHEST_DIE",
+    3: "OD6S.COMPLICATION",
+};
+
+export const hiddenStatusEffects: readonly string[] = [
+    "stunned",
+    "wounded",
+    "severely_wounded",
+    "incapacitated",
+    "mortally_wounded",
+];

--- a/src/module/od6s.ts
+++ b/src/module/od6s.ts
@@ -133,7 +133,7 @@ Hooks.once('init', async function () {
     CONFIG.Combat.documentClass = OD6SCombat;
     CONFIG.ui.combat = OD6SCombatTracker;
     CONFIG.ui.compendium = OD6SCompendiumDirectory;
-    CONFIG.statusEffects = OD6S.statusEffects as unknown as StatusEffect[];
+    CONFIG.statusEffects = OD6S.statusEffects;
     CONFIG.Dice.terms["w"] = WildDie;
     CONFIG.Dice.terms["b"] = CharacterPointDie;
     CONFIG.Token.objectClass = OD6SToken;

--- a/src/module/od6s.ts
+++ b/src/module/od6s.ts
@@ -133,7 +133,7 @@ Hooks.once('init', async function () {
     CONFIG.Combat.documentClass = OD6SCombat;
     CONFIG.ui.combat = OD6SCombatTracker;
     CONFIG.ui.compendium = OD6SCompendiumDirectory;
-    CONFIG.statusEffects = OD6S.statusEffects;
+    CONFIG.statusEffects = OD6S.statusEffects as unknown as StatusEffect[];
     CONFIG.Dice.terms["w"] = WildDie;
     CONFIG.Dice.terms["b"] = CharacterPointDie;
     CONFIG.Token.objectClass = OD6SToken;

--- a/src/module/system/handlebars/combat.ts
+++ b/src/module/system/handlebars/combat.ts
@@ -249,10 +249,6 @@ export function registerCombatHelpers() {
         return OD6S.difficultyShort;
     })
 
-    Handlebars.registerHelper('getDifficultyFromShort', function () {
-        return OD6S.difficulty.filter()
-    })
-
     Handlebars.registerHelper('getRanges', function () {
         return OD6S.ranges;
     })

--- a/src/module/system/handlebars/config-helpers.ts
+++ b/src/module/system/handlebars/config-helpers.ts
@@ -2,15 +2,17 @@
  * Configuration getter Handlebars helpers.
  */
 import OD6S from "../../config/config-od6s";
+import type { AttributeDef } from "../../config/attributes";
 import {od6sutilities} from "../utilities";
 import {getAttributeName, getAttributeShortName} from "../../macros";
 
 export function registerConfigHelpers() {
     Handlebars.registerHelper('getConfig', function (key, subKey) {
+        const value = OD6S[key];
         if (typeof subKey !== 'undefined' && subKey !== '') {
-            return OD6S[key][subKey];
+            return (value as Record<string, unknown>)[subKey];
         }
-        return OD6S[key];
+        return value;
     })
 
     Handlebars.registerHelper('getSystemConfig', function (config) {
@@ -206,7 +208,7 @@ export function registerConfigHelpers() {
     })
 
     Handlebars.registerHelper('getAttributes', function () {
-        const active: Record<string, OD6SAttributeField> = {};
+        const active: Record<string, AttributeDef> = {};
         for (const attribute in OD6S.attributes) {
             if (OD6S.attributes[attribute].active) active[attribute] = OD6S.attributes[attribute];
         }
@@ -298,7 +300,6 @@ export function registerConfigHelpers() {
         if (type === "item-group") {
             for (const [key, items] of Object.entries(OD6S.allowedItemTypes)) {
                 if (actorTypes.includes(key)) {
-                    // @ts-expect-error
                     for (const i of items) {
                         if (OD6S.templateItemTypes['item-group'].includes(i)) {
                             templateItems.push(i);

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -1066,8 +1066,9 @@ interface ChatSpeaker {
 
 interface StatusEffect {
     id: string;
-    label: string;
-    icon: string;
+    name: string;
+    img: string;
+    hud?: boolean;
     [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary

- Replaces `Record<string, any>` on the central `OD6S` object with a typed `Od6sConfig` interface, and splits the remaining inline tables out of `config-od6s.ts` into focused submodules with explicit interfaces (new: `difficulty.ts`, `modifiers.ts`, `vehicles.ts`, `wounds.ts`; expanded: `attributes`, `damage`, `weapons`, `actions`, `status-effects`, `labels`, `deadliness`).
- `config-od6s.ts` is now a thin composer that assembles `OD6S` from the typed submodules. Public surface used by the ~60 import sites is unchanged — pure structural refactor.
- Drive-by while the file was open: unify the `starshipToughessName` / `starshipToughnessName` typo, drop the dead `OD6S.metaphysicsSkills` write, drop the unused/broken `getDifficultyFromShort` Handlebars helper.

Closes #58.

## Test plan

- [x] `pnpm run check` (lint + typecheck + unit + domain) — 0 errors, 613 lint warnings (under the 720 CI gate), 368 unit + 303 domain tests passing.
- [ ] Smoke test against a live Foundry world (not run locally; CI / manual).