### PR TITLE
refactor(types): #59 narrow utility-fn parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   file shrinks by ~55 LOC and the damage-modifier pipeline (scale,
   fatepoint str-doubling, vehicle-ram, pip bonuses) is now testable
   without Foundry globals (#59 part 1).
+- Tightened parameter typing across `system/utilities/*.ts` and
+  `apps/roll-helpers/*.ts`: `weapons.ts` range buckets, `actors.ts`
+  user-active access, `effects.ts` GM check, `bind-tabs.ts` (drops
+  the local `declare const foundry: any`), `opposed.ts` opposed-roll
+  state shapes, `misc.ts` template lookup, `explosives.ts` (typed
+  `ExplosiveTarget`, `DetonateExplosiveData`, scatter / detonate
+  signatures), plus `vehicle_weapons` on `OD6SCharacterSystem.vehicle`
+  narrowed to `Item[]`. Foundry shim gains `User.active`,
+  `Combat.scene`, `Scene.regions`, `ChatMessage.clone`, and the
+  `foundry.applications.ux.Tabs` namespace, with the v14
+  `StatusEffect` shape replacing the v13 `{label, icon}` form
+  (no behavioural change; lint count drops 613 → 579) (#59 part 2).
 
 ## [2.5.0] - 2026-05-06
 

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -40,7 +40,7 @@ export async function rollAvailableVehicleAction(sheet: Sheet, ev: any): Promise
         rollData.score = od6sutilities.getScoreFromSkill(sheet.document, "",
             actorData.vehicle.shields.skill.value, OD6S.vehicle_actions[data.id].base);
     } else {
-        const item = actorData.vehicle.vehicle_weapons.find((i: any) => i.id === data.id);
+        const item = actorData.vehicle.vehicle_weapons.find((i: Item) => i.id === data.id);
         if (item !== null && typeof item !== "undefined") {
             rollData.score = od6sutilities.getScoreFromSkill(sheet.document, item.system.specialization.value,
                 game.i18n.localize(item.system.skill.value), item.system.attribute.value);

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -40,7 +40,7 @@ export async function rollAvailableVehicleAction(sheet: Sheet, ev: any): Promise
         rollData.score = od6sutilities.getScoreFromSkill(sheet.document, "",
             actorData.vehicle.shields.skill.value, OD6S.vehicle_actions[data.id].base);
     } else {
-        const item = actorData.vehicle.vehicle_weapons.find((i: Item) => i.id === data.id);
+        const item = actorData.vehicle.vehicle_weapons.find((i: VehicleWeaponSnapshot) => i.id === data.id);
         if (item !== null && typeof item !== "undefined") {
             rollData.score = od6sutilities.getScoreFromSkill(sheet.document, item.system.specialization.value,
                 game.i18n.localize(item.system.skill.value), item.system.attribute.value);

--- a/src/module/apps/roll-helpers/roll-preflight.ts
+++ b/src/module/apps/roll-helpers/roll-preflight.ts
@@ -43,7 +43,7 @@ async function passesExplosiveGate(data: IncomingRollData): Promise<boolean> {
         && data.type === 'action'
         && data.subtype === 'vehiclerangedweaponattack') {
         item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!
-            .find((i: any) => i.id === data.itemId);
+            .find((i) => i.id === data.itemId);
     }
 
     const sys = item?.system as OD6SWeaponItemSystem | undefined;

--- a/src/module/apps/roll-helpers/roll-preflight.ts
+++ b/src/module/apps/roll-helpers/roll-preflight.ts
@@ -38,25 +38,24 @@ export async function runPreflight(data: IncomingRollData): Promise<boolean> {
 async function passesExplosiveGate(data: IncomingRollData): Promise<boolean> {
     if (typeof data.itemId === 'undefined' || data.itemId === '') return true;
 
-    let item = data.actor.items.get(data.itemId);
-    if (typeof item === 'undefined'
-        && data.type === 'action'
-        && data.subtype === 'vehiclerangedweaponattack') {
-        item = (data.actor.system as OD6SCharacterSystem).vehicle.vehicle_weapons!
-            .find((i) => i.id === data.itemId);
-    }
+    const item = data.actor.items.get(data.itemId);
+    // Vehicle-mounted weapon path: `system.vehicle.vehicle_weapons` holds
+    // `Item#toObject()` snapshots, not real documents (`getFlag` would throw),
+    // and vehicle-mounted explosives don't go through the placement-template
+    // flow anyway — let the gate pass.
+    if (typeof item === 'undefined') return true;
 
-    const sys = item?.system as OD6SWeaponItemSystem | undefined;
+    const sys = item.system as OD6SWeaponItemSystem | undefined;
     if (sys?.subtype?.toLowerCase() !== 'explosive') return true;
-    if (item!.getFlag('od6s', 'explosiveSet')) return true;
+    if (item.getFlag('od6s', 'explosiveSet')) return true;
     // Auto-explosive throws skip `explosiveSet` and stamp the pending map
     // directly (one entry per region) so multiple in-flight throws can co-exist.
-    const pending = item!.getFlag('od6s', 'explosivePending') as Record<string, unknown> | undefined;
+    const pending = item.getFlag('od6s', 'explosivePending') as Record<string, unknown> | undefined;
     if (pending && Object.keys(pending).length > 0) return true;
 
     await new ExplosiveDialog({
         options: OD6S.explosives,
-        item: item!,
+        item: item,
         actor: data.actor,
         type: 'OD6S.EXPLOSIVE_THROWN',
         auto: game.settings.get('od6s', 'auto_explosive'),

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -84,15 +84,20 @@ function readSettings(): RollSettingsRaw {
  */
 function resolveItemForDispatch(data: IncomingRollData): Item | undefined {
     if (!data.itemId) return undefined;
-    let item = data.actor.items.get(data.itemId);
-    if (!item
-        && data.type === 'action'
+    const item = data.actor.items.get(data.itemId);
+    if (item) return item;
+    if (data.type === 'action'
         && data.subtype === 'vehiclerangedweaponattack'
         && isCharacterActor(data.actor)) {
-        item = data.actor.system.vehicle.vehicle_weapons
-            ?.find((i: { id?: string }) => i.id === data.itemId);
+        // `vehicle_weapons` holds `Item#toObject()` snapshots, not real
+        // documents — but the downstream readers in this file only touch
+        // data fields (`type`, `name`, `system.*`), never document methods.
+        // Cast for shape compatibility; do not call `getFlag` / `update` on it.
+        const snapshot = data.actor.system.vehicle.vehicle_weapons
+            ?.find((i) => i.id === data.itemId);
+        if (snapshot) return snapshot as unknown as Item;
     }
-    return item;
+    return undefined;
 }
 
 function resolveVehicleStatsForCharacter(actor: Actor): HandlerContext['vehicleStats'] {

--- a/src/module/system/utilities/actors.ts
+++ b/src/module/system/utilities/actors.ts
@@ -40,7 +40,7 @@ export function getActorOwner(actor: Actor): User | undefined {
     const playerOwners = Object.entries(permissionObject)
         .filter(
             ([id, level]) =>
-                !game.users.get(id)?.isGM && (game.users.get(id) as any)?.active && level === 3
+                !game.users.get(id)?.isGM && game.users.get(id)?.active && level === 3
         )
         .map(([id]) => id);
 

--- a/src/module/system/utilities/bind-tabs.ts
+++ b/src/module/system/utilities/bind-tabs.ts
@@ -8,10 +8,6 @@
  * (e.g. "attributes") that may not exist on every sheet template.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
-
-
 interface AppWithTabGroups {
     tabGroups?: Record<string, string>;
 }

--- a/src/module/system/utilities/effects.ts
+++ b/src/module/system/utilities/effects.ts
@@ -34,7 +34,7 @@ export function evaluateChange(change: ActiveEffectChange, caller: Actor | Item)
             newValue = newValue.replace(match, value);
         }
     }
-    if (typeof(newValue) === 'undefined' || newValue.includes('undefined') && (game.user as any).isGM()) {
+    if (typeof(newValue) === 'undefined' || newValue.includes('undefined') && game.user.isGM) {
         ui.notifications.warn(game.i18n.localize('OD6S.WARN_EFFECT_PARSE') + ' ' + change.value);
         return 0;
     }

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -43,11 +43,23 @@ export async function clearExplosivePending(item: Item, regionId: string | undef
     await item.update({ [`flags.od6s.explosivePending.-=${regionId}`]: null });
 }
 
-export async function scatterExplosive(range: any, origin: any, regionId: any): Promise<void> {
+export interface ExplosiveTarget {
+    id: string;
+    range: number;
+    zone: number;
+    name: string;
+    damage?: number;
+}
+
+export async function scatterExplosive(
+    range: string,
+    origin: { x: number; y: number },
+    regionId: string,
+): Promise<void> {
     let distanceTerms = '';
     let angle = 0;
 
-    const region = canvas.scene.getEmbeddedDocument('Region', regionId);
+    const region = canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument;
     const shape = region.shapes[0];
     const target = {x: shape.x, y: shape.y};
     const sourceRay = new foundry.canvas.geometry.Ray(origin, target);
@@ -129,10 +141,10 @@ export async function scatterExplosive(range: any, origin: any, regionId: any): 
     await wait(100);
 }
 
-export async function getExplosiveTargets(actor: any, itemId: any, regionId: string | undefined): Promise<any[]> {
+export async function getExplosiveTargets(actor: Actor, itemId: string, regionId: string | undefined): Promise<ExplosiveTarget[]> {
     const item = actor.isToken ? actor.token.actor.items.get(itemId) : actor.items.get(itemId);
     if (!regionId) return [];
-    const region = canvas.scene.getEmbeddedDocument('Region', regionId);
+    const region = canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument | null;
     if (!region) return [];
     const shape = region.shapes[0];
     const center = { x: shape.x, y: shape.y };
@@ -152,22 +164,25 @@ export async function getExplosiveTargets(actor: any, itemId: any, regionId: str
     );
 
     // Calculate range to each
-    const targets = [];
+    const targets: ExplosiveTarget[] = [];
     for (const target of hitTokens) {
-        const thisTarget: any = {};
-        thisTarget.id = target.id;
-        thisTarget.range = canvas.grid.measurePath([center, target.center]).distance;
-        thisTarget.zone = getBlastRadius(item, thisTarget.range);
-        thisTarget.name = target.name;
-        targets.push(thisTarget);
+        const range = canvas.grid.measurePath([center, target.center]).distance;
+        targets.push({
+            id: target.id,
+            range,
+            zone: getBlastRadius(item!, range),
+            name: target.name,
+        });
     }
 
     return targets;
 }
 
-export async function detonateExplosives(combat: any): Promise<void> {
+export async function detonateExplosives(combat: Combat): Promise<void> {
     // Find all active explosive regions on the scene and detonate
-    const regions = combat.scene.regions?.filter((i: any) => i.flags?.od6s?.explosive === true) ?? [];
+    const regions: RegionDocument[] = combat.scene?.regions?.filter(
+        (i: RegionDocument) => i.flags?.od6s?.explosive === true,
+    ) ?? [];
     for (const region of regions) {
         await region.update({ visibility: 2 }); // Make visible to all
         let actor;
@@ -177,14 +192,13 @@ export async function detonateExplosives(combat: any): Promise<void> {
             actor = game!.scenes!.active!.tokens.get(region.getFlag('od6s', 'token'))!.actor;
         }
 
-        const data: any = {};
-        data.flags = {};
+        const data: { flags: { od6s: Record<string, unknown> } } = { flags: { od6s: {} } };
         data.flags.od6s = {
             actorId: region.getFlag('od6s','actor'),
             tokenId: region.getFlag('od6s', 'token'),
             itemId: region.getFlag('od6s','item'),
             templateId: region.id,
-            targets: await getExplosiveTargets(actor, region.getFlag('od6s','item'), region.id),
+            targets: actor ? await getExplosiveTargets(actor, region.getFlag('od6s','item'), region.id) : [],
             triggered: true
         }
 
@@ -192,7 +206,7 @@ export async function detonateExplosives(combat: any): Promise<void> {
         if(region.getFlag('od6s','message')) {
             const origMessage = game.messages.get(region.getFlag('od6s','message'));
             if(typeof(origMessage) !== 'undefined') {
-                const cloneMessage = (origMessage as any).clone(data);
+                const cloneMessage = origMessage.clone(data);
                 await origMessage.unsetFlag('od6s', 'isExplosive');
                 // Blind rolls also populate `whisper`, so the blind check
                 // must come first or it would never be reached.
@@ -210,23 +224,33 @@ export async function detonateExplosives(combat: any): Promise<void> {
     }
 }
 
-export async function detonateExplosive(data: any): Promise<any> {
-    const message = game.messages.get(data.messageId);
+export interface DetonateExplosiveData {
+    messageId?: string;
+    actorId?: string;
+    tokenId?: string;
+    itemId: string;
+    templateId?: string;
+    stun?: unknown;
+}
+
+export async function detonateExplosive(data: DetonateExplosiveData): Promise<unknown> {
+    const message = data.messageId ? game.messages.get(data.messageId) : undefined;
     let actor;
     if (typeof(data.tokenId) === 'undefined' || data.tokenId === '') {
-        actor = await getActorFromUuid(data.actorId);
+        actor = data.actorId ? await getActorFromUuid(data.actorId) : undefined;
     } else {
         const token = game.scenes!.active!.tokens.get(data.tokenId);
         actor = token!.actor;
     }
+    if (!actor) return false;
 
     // Region id stamped on the attack message at creation; falls back to the
     // dataset templateId for legacy / handler-driven callers.
     const regionId = (message?.getFlag('od6s', 'template') as string | undefined) || data.templateId;
 
-    let targets;
+    let targets: ExplosiveTarget[];
     if (message) {
-        targets = await game!.messages!.get(data.messageId)!.getFlag('od6s', 'targets');
+        targets = message.getFlag('od6s', 'targets') as ExplosiveTarget[];
     } else {
         targets = await getExplosiveTargets(actor, data.itemId, regionId);
     }
@@ -249,29 +273,36 @@ export async function detonateExplosive(data: any): Promise<any> {
 
 
     // Create damage chat message
-    const msgData: any = {};
-
-    msgData.flags = {};
-    msgData.flags.od6s = {};
-    msgData.flags.od6s.targets = [];
-    msgData.flags.od6s.item = item!.id;
-    msgData.flags.od6s.isOpposable = true;
-    msgData.flags.od6s.damageType = wsys?.damage.type;
-    msgData.flags.od6s.stun = data.stun;
-    msgData.flags.od6s.attackMessage = data.messageId;
-
-    msgData.flags.od6s.type = "explosive";
+    interface ExplosiveMsgData {
+        flags: { od6s: Record<string, unknown> & { targets: ExplosiveTarget[] } };
+        flavor?: string;
+        speaker?: { alias?: string; actor?: string; token?: string; scene?: string };
+    }
+    const msgData: ExplosiveMsgData = {
+        flags: {
+            od6s: {
+                targets: [],
+                item: item!.id,
+                isOpposable: true,
+                damageType: wsys?.damage.type,
+                stun: data.stun,
+                attackMessage: data.messageId,
+                type: "explosive",
+            },
+        },
+    };
 
     if (boolCheck(data.stun)) {
         msgData.flavor = game.i18n.localize("OD6S.EXPLOSIVE_STUN_DAMAGE");
     } else {
         msgData.flavor = game.i18n.localize("OD6S.EXPLOSIVE_DAMAGE");
     }
-    msgData.speaker = {};
-    msgData.speaker.alias = actor!.name;
-    msgData.speaker.actor = actor!.id;
-    msgData.speaker.token = actor!.isToken ? actor!.token.id : '';
-    msgData.speaker.scene = game.scenes!.active!.id;
+    msgData.speaker = {
+        alias: actor!.name,
+        actor: actor!.id,
+        token: actor!.isToken ? actor!.token.id : '',
+        scene: game.scenes!.active!.id,
+    };
 
     let rollString;
 
@@ -280,7 +311,7 @@ export async function detonateExplosive(data: any): Promise<any> {
         // Separate rolls for each zone; damage score represents whole dice
         for (const i in wsys.blast_radius) {
             const zone = wsys.blast_radius[i as "1" | "2" | "3" | "4"];
-            const zoneTargets = targets.filter((target: any) => target.zone === (+i));
+            const zoneTargets = targets.filter((target: ExplosiveTarget) => target.zone === (+i));
             if (zoneTargets.length < 1) continue;
             if (zone.damage < 1) {
                 ui.notifications.warn(game.i18n.localize("OD6S.WARN_NO_DICE_FOR_ZONE"));
@@ -300,7 +331,7 @@ export async function detonateExplosive(data: any): Promise<any> {
                 rollString = dice + "d6" + game.i18n.localize('OD6S.BASE_DIE_FLAVOR');
             }
             const roll  = await new Roll(rollString).evaluate();
-            for (const target in zoneTargets) {
+            for (let target = 0; target < zoneTargets.length; target++) {
                 const targetId = zoneTargets[target].id;
                 if (typeof (actor) === 'undefined') actor = game!.scenes!.active!.tokens.get(targetId)!.actor;
                 if (typeof (actor) === 'undefined') continue;
@@ -361,7 +392,7 @@ export async function detonateExplosive(data: any): Promise<any> {
         }
         const roll = await new Roll(rollString).evaluate();
         // Iterate over targets
-        for (const i in targets) {
+        for (let i = 0; i < targets.length; i++) {
             const target = targets[i];
             let damage = roll.total;
             let actor = await game.actors.get(target.id);
@@ -402,12 +433,13 @@ export async function detonateExplosive(data: any): Promise<any> {
  * @param range (in meters)
  * @returns zone
  */
-export function getBlastRadius(item: any, range: any): number {
+export function getBlastRadius(item: Item, range: number): number {
     let zone = 1;
+    if (!isWeaponItem(item)) return zone;
     const maxZone = game.settings.get('od6s', 'explosive_zones') ? 4 : 3;
 
     for (let i=1; i < maxZone + 1; i++) {
-        if (range > item.system.blast_radius[i].range) {
+        if (range > item.system.blast_radius[String(i) as "1" | "2" | "3" | "4"].range) {
             zone++;
         } else {
             break;

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -59,7 +59,8 @@ export async function scatterExplosive(
     let distanceTerms = '';
     let angle = 0;
 
-    const region = canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument;
+    const region = canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument | undefined;
+    if (!region) return;
     const shape = region.shapes[0];
     const target = {x: shape.x, y: shape.y};
     const sourceRay = new foundry.canvas.geometry.Ray(origin, target);
@@ -143,6 +144,7 @@ export async function scatterExplosive(
 
 export async function getExplosiveTargets(actor: Actor, itemId: string, regionId: string | undefined): Promise<ExplosiveTarget[]> {
     const item = actor.isToken ? actor.token.actor.items.get(itemId) : actor.items.get(itemId);
+    if (!item) return [];
     if (!regionId) return [];
     const region = canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument | null;
     if (!region) return [];
@@ -170,7 +172,7 @@ export async function getExplosiveTargets(actor: Actor, itemId: string, regionId
         targets.push({
             id: target.id,
             range,
-            zone: getBlastRadius(item!, range),
+            zone: getBlastRadius(item, range),
             name: target.name,
         });
     }

--- a/src/module/system/utilities/misc.ts
+++ b/src/module/system/utilities/misc.ts
@@ -31,11 +31,11 @@ export function getTemplateFromMessage(message: ChatMessage): { actor: Actor | u
     // to the (deprecated) item flag for messages created before #40 landed.
     const regionId = (message.getFlag('od6s', 'template') as string | undefined)
         ?? (item?.getFlag('od6s', 'explosiveTemplate') as string | undefined);
-    const data: any = {};
-    data.actor = actor;
-    data.item = item;
-    data.template = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
-    return data;
+    return {
+        actor,
+        item,
+        template: regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument : null,
+    };
 }
 
 export function lookupAttributeKey(id: string): string | false {

--- a/src/module/system/utilities/misc.ts
+++ b/src/module/system/utilities/misc.ts
@@ -31,11 +31,10 @@ export function getTemplateFromMessage(message: ChatMessage): { actor: Actor | u
     // to the (deprecated) item flag for messages created before #40 landed.
     const regionId = (message.getFlag('od6s', 'template') as string | undefined)
         ?? (item?.getFlag('od6s', 'explosiveTemplate') as string | undefined);
-    return {
-        actor,
-        item,
-        template: regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument : null,
-    };
+    const template = regionId
+        ? (canvas.scene.getEmbeddedDocument('Region', regionId) as RegionDocument | undefined) ?? null
+        : null;
+    return { actor, item, template };
 }
 
 export function lookupAttributeKey(id: string): string | false {

--- a/src/module/system/utilities/opposed.ts
+++ b/src/module/system/utilities/opposed.ts
@@ -63,12 +63,16 @@ export async function handleOpposedRoll(): Promise<void> {
     let type: string;
     let winner: ChatMessage;
     let loser: ChatMessage;
-    let result: any;
+    let result: string | number = 0;
     let damageFlavor;
     let stunned = false;
-    const data: any = {};
-    data.flags = {};
-    let collision: any;
+    const data: {
+        content?: string;
+        flavor?: string;
+        stun?: unknown;
+        flags: { od6s?: Record<string, unknown> };
+    } = { flags: {} };
+    let collision: boolean | string;
     let passengerDamage = '';
     const message1 = (await game.messages.get(getOpposedQueueEntry(0).messageId))!;
     const message2 = (await game.messages.get(getOpposedQueueEntry(1).messageId))!;
@@ -115,7 +119,7 @@ export async function handleOpposedRoll(): Promise<void> {
     if(messageType1 === 'explosive' || messageType2 === 'explosive') {
         if (messageType1 === 'explosive') {
             const targetId = message2!.speaker.token;
-            const damage = message1!.getFlag('od6s', 'targets').find((t: any) => t.id === targetId).damage;
+            const damage = message1!.getFlag('od6s', 'targets').find((t: { id: string; damage: number }) => t.id === targetId).damage;
             const resistance = message2!.rolls[0].total;
             if (damage > resistance) {
                 winner = message1;
@@ -126,7 +130,7 @@ export async function handleOpposedRoll(): Promise<void> {
             }
         } else {
             const targetId = message1!.speaker.token !== null ? message1!.speaker.token : message1!.speaker.actor;
-            const damage = message2!.getFlag('od6s', 'targets').find((t: any) =>t.id === targetId).damage;
+            const damage = message2!.getFlag('od6s', 'targets').find((t: { id: string; damage: number }) =>t.id === targetId).damage;
             const resistance = message1!.rolls[0].total;
             if (damage > resistance) {
                 winner = message2;
@@ -235,7 +239,7 @@ export async function handleOpposedRoll(): Promise<void> {
 
     let apply = false;
     if (OD6S.woundConfig > 0 && loser.actorType !== 'vehicle' && loser.actorType !== 'starship') {
-        if (result > 0 || stunned) apply = true;
+        if ((+result) > 0 || stunned) apply = true;
     } else if (result !== 'OD6S.NO_INJURY' && result !== 'OD6S.NO_DAMAGE') {
         apply = true;
     }

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -16,17 +16,16 @@ export function strengthDamageFromDice(strengthDice: number): number {
  */
 export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<string, number> | false> {
     const regex = /[A-Za-z]/;
-    const foundRange: any = {};
-    foundRange.short = '';
-    foundRange.medium = '';
-    foundRange.long = '';
+    type RangeBucket = { short: string; medium: string; long: string };
+    const foundRange: RangeBucket = { short: '', medium: '', long: '' };
 
     if (!isWeaponItem(item)) return false;
     const itemRange = item.system.range;
-    const range: any = {};
-    range.short = itemRange.short;
-    range.medium = itemRange.medium;
-    range.long = itemRange.long;
+    const range: RangeBucket = {
+        short: itemRange.short,
+        medium: itemRange.medium,
+        long: itemRange.long,
+    };
 
     const numericRange = {
         short: Number(itemRange.short),
@@ -72,16 +71,16 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
         return false;
     }
 
-    const newRanges = {};
+    const newRanges: Record<string, number> = {};
     const dice = getDiceFromScore(baseDice, OD6S.pipsPerDice);
 
     if (game.settings.get('od6s', 'static_str_range')) {
-        for (const r in range) {
+        for (const r of Object.keys(range) as (keyof RangeBucket)[]) {
             const e = range[r].match(/([+|-][0-9])$/);
             if (e) {
-                (newRanges as any)[r] = (dice.dice * 4) + dice.pips + (+e[0]);
+                newRanges[r] = (dice.dice * 4) + dice.pips + (+e[0]);
             } else {
-                (newRanges as any)[r] = (dice.dice * 4) + dice.pips;
+                newRanges[r] = (dice.dice * 4) + dice.pips;
             }
         }
     } else {
@@ -90,19 +89,20 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
         if (dice.pips > 0) rollString = rollString + "+" + dice.pips;
         const roll = await new Roll(rollString).evaluate();
 
-        for (const r in range) {
+        for (const r of Object.keys(range) as (keyof RangeBucket)[]) {
             const e = range[r].match(/([+|-][0-9])$/);
             if (e) {
-                (newRanges as any)[r] = roll.total + (+e[0]);
+                newRanges[r] = roll.total + (+e[0]);
             } else {
-                (newRanges as any)[r] = roll.total;
+                newRanges[r] = roll.total;
             }
         }
 
-        const flags: any = {}
-        flags.type = "range";
-        flags.range = newRanges;
-        flags.origRange = range;
+        const flags = {
+            type: "range",
+            range: newRanges,
+            origRange: range,
+        };
         const label = game.i18n.localize('OD6S.RANGE_ROLL') + ": " + item.name;
         let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
         if (game.user.isGM && game.settings.get('od6s', 'hide-gm-rolls')) rollMode = CONST.DICE_ROLL_MODES.PRIVATE;

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -172,6 +172,20 @@ declare namespace foundry {
             function loadTemplates(paths: string[] | Record<string, string>): Promise<Function[]>;
             function renderTemplate(path: string, data?: object): Promise<string>;
         }
+
+        namespace ux {
+            interface TabsOptions {
+                navSelector: string;
+                contentSelector: string;
+                initial?: string;
+                group?: string;
+                callback?: (event: Event, tabs: unknown, active: string) => void;
+            }
+            class Tabs {
+                constructor(options: TabsOptions);
+                bind(html: HTMLElement): void;
+            }
+        }
     }
 
     namespace abstract {
@@ -506,6 +520,7 @@ declare class ChatMessage extends FoundryDocument {
     static getSpeaker(options?: any): ChatSpeaker;
     static create(data: any, options?: any): Promise<ChatMessage>;
 
+    clone(data?: any, context?: any): ChatMessage;
     getRollData(): any;
 }
 
@@ -515,6 +530,7 @@ declare class Combat extends FoundryDocument {
     turn: number;
     active: boolean;
     started: boolean;
+    scene: Scene | null;
     combatants: Collection<Combatant>;
     combatant: Combatant;
     turns: Combatant[];
@@ -542,6 +558,7 @@ declare class Combatant extends FoundryDocument {
 /** Scene document */
 declare class Scene extends FoundryDocument {
     tokens: Collection<TokenDocument>;
+    regions: Collection<RegionDocument>;
     dimensions: any;
     grid: { distance: number; size: number; type: number; [key: string]: any };
 
@@ -560,6 +577,7 @@ declare class TokenDocument extends FoundryDocument {
 /** User document */
 declare class User extends FoundryDocument {
     isGM: boolean;
+    active: boolean;
     character: Actor | null;
     assignHotbarMacro(macro: Macro, slot: number): Promise<void>;
 }

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -60,6 +60,22 @@ interface OD6SAttributes {
     [key: string]: OD6SAttributeField;
 }
 
+/**
+ * Snapshot shape of a vehicle/starship weapon stored on a crewmember's
+ * `system.vehicle.vehicle_weapons` array. Built by `crew-vehicle.ts:sendVehicleData`
+ * via `Item#toObject()` plus an injected `id`, so these are plain data records,
+ * not real `Item` documents — `getFlag` / `update` etc. are not available.
+ */
+interface VehicleWeaponSnapshot {
+    _id: string;
+    id: string;
+    name: string;
+    type: string;
+    img?: string;
+    system: OD6SWeaponItemSystem;
+    flags?: Record<string, unknown>;
+}
+
 /** System data shared by character, npc, and creature actor types. */
 interface OD6SCharacterSystem {
     attributes: OD6SAttributes;
@@ -114,7 +130,7 @@ interface OD6SCharacterSystem {
         ranged_damage?: { score: number; type: string; label: string };
         ram?: { score: number; type: string; label: string };
         ram_damage?: { score: number; type: string; label: string };
-        vehicle_weapons?: Item[];
+        vehicle_weapons?: VehicleWeaponSnapshot[];
         items?: unknown;
     };
     /** Container actors expose a per-player visibility flag. */

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -114,7 +114,7 @@ interface OD6SCharacterSystem {
         ranged_damage?: { score: number; type: string; label: string };
         ram?: { score: number; type: string; label: string };
         ram_damage?: { score: number; type: string; label: string };
-        vehicle_weapons?: any[];
+        vehicle_weapons?: Item[];
         items?: unknown;
     };
     /** Container actors expose a per-player visibility flag. */


### PR DESCRIPTION
## Summary

- Replaces \`any\` parameters and casts across \`system/utilities/*.ts\` and \`apps/roll-helpers/*.ts\` now that #56/#57 have landed the Foundry-type augmentation and discriminated unions.
- Tightens the Foundry shim where required (\`User.active\`, \`Combat.scene\`, \`Scene.regions\`, \`ChatMessage.clone\`, \`foundry.applications.ux\` namespace, v14-shaped \`StatusEffect\`).
- Drops one local \`declare const foundry: any\` shim from \`bind-tabs.ts\`.
- Lint warning count: **613 → 579** (well under the 720 CI threshold).
- Closes #59 part 2.

## Test plan
- [x] \`pnpm run typecheck\`
- [x] \`pnpm run lint\` (0 errors, 579 warnings)
- [x] \`pnpm run test\` (368 unit tests)
- [x] \`pnpm run test:domain\` (303 domain tests)
- [ ] Smoke: throw an explosive (\`scatterExplosive\` / \`detonateExplosive\` are the most behaviour-adjacent changes — call signatures stayed identical, only types tightened, but worth a spot-check).