### PR TITLE
test(crew-vehicle): #84 extract pure helpers + add domain tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
   file shrinks by ~55 LOC and the damage-modifier pipeline (scale,
   fatepoint str-doubling, vehicle-ram, pip bonuses) is now testable
   without Foundry globals (#59 part 1).
+- Extracted six pure helpers from
+  `actor/actor-helpers/crew-vehicle.ts` into
+  `crew-vehicle-math.ts` — `isCrewMemberByFlag`, `canRemoveFromCrew`,
+  `removeCrewmember`, `buildVehicleWeaponSnapshots`,
+  `shouldDispatchVehicleDataAsGM`, `selectCrewmembersForBroadcast` —
+  covered by 24 new domain tests in
+  `tests/domain/crew-vehicle.test.ts`. The orchestrator still owns
+  the document mutations and socket dispatch; what runs around them
+  (crew flag predicates, weapon-snapshot projection, GM-vs-player
+  branching) is now exercised without a Foundry runtime (#84).
 - Polish batch (#60): extracted blast-radius damage falloff to
   named constants in `explosives.ts`; added an `error()` breadcrumb
   to `system/logger.ts` and wired it into the three swallowed-failure

--- a/src/module/actor/actor-helpers/crew-vehicle-math.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle-math.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for the crew/vehicle synchronization flows in
+ * `crew-vehicle.ts`. Everything here takes plain data and returns plain data
+ * so it can be exercised in `tests/domain/` without a Foundry runtime.
+ *
+ * The orchestrator (`crew-vehicle.ts`) keeps the document mutations and
+ * socket dispatch; this file only houses the decision logic.
+ */
+
+/** Subset of an Actor's crewmember entry needed by the math layer. */
+export interface CrewMemberRef {
+    uuid: string;
+    name?: string;
+}
+
+/** Subset of an Item shape needed to project a vehicle weapon snapshot. */
+export interface ItemLike {
+    id: string;
+    type: string;
+    toObject(): Record<string, unknown> & { id?: string };
+}
+
+/**
+ * Predicate matching the runtime behaviour of `actor.getFlag('od6s', 'crew')`
+ * — a crewmember is identified by holding a non-empty crew flag pointing at
+ * a vehicle uuid.
+ */
+export function isCrewMemberByFlag(crewFlag: string | null | undefined): boolean {
+    return typeof crewFlag === 'string' && crewFlag !== '';
+}
+
+/**
+ * Decide whether `removeFromCrew` should proceed. The runtime emits a
+ * `OD6S.NOT_CREW_MEMBER` warning when the caller's crew flag doesn't match
+ * the target vehicle id; this predicate captures that gate without the
+ * notification side effect.
+ */
+export function canRemoveFromCrew(
+    currentCrewFlag: string | null | undefined,
+    targetVehicleUuid: string,
+): boolean {
+    return currentCrewFlag === targetVehicleUuid;
+}
+
+/**
+ * Drop a crewmember by uuid, preserving the order of the remaining entries.
+ * Mirrors the filter in `forceRemoveCrewmember`.
+ */
+export function removeCrewmember(
+    crew: readonly CrewMemberRef[],
+    uuid: string,
+): CrewMemberRef[] {
+    return crew.filter((c) => c.uuid !== uuid);
+}
+
+/**
+ * Project a list of items to the vehicle-weapon snapshot array stored on
+ * crewmember actors' `system.vehicle.vehicle_weapons`. Filters to the two
+ * weapon types and stamps each entry's `id` so consumers (sheet-rolls,
+ * roll-setup) can locate the source item back on the vehicle.
+ */
+export function buildVehicleWeaponSnapshots(
+    items: readonly ItemLike[],
+): Array<Record<string, unknown> & { id: string }> {
+    const out: Array<Record<string, unknown> & { id: string }> = [];
+    for (const item of items) {
+        if (item.type !== 'vehicle-weapon' && item.type !== 'starship-weapon') continue;
+        const snapshot = item.toObject();
+        snapshot.id = item.id;
+        out.push(snapshot as Record<string, unknown> & { id: string });
+    }
+    return out;
+}
+
+/**
+ * Decide whether a `sendVehicleData` call should run locally or be dispatched
+ * to the GM client via socketlib. The runtime check is a single
+ * `game.user.isGM` boolean; threading it through a pure helper keeps the
+ * branching testable.
+ */
+export function shouldDispatchVehicleDataAsGM(isGM: boolean): boolean {
+    return !isGM;
+}
+
+/**
+ * Filter the crewmember list down to a single uuid (or pass through
+ * unchanged when no uuid is supplied). Mirrors the inline branch in
+ * `sendVehicleData` that decides whether to push to one crewmember or to
+ * the whole list.
+ */
+export function selectCrewmembersForBroadcast(
+    crew: readonly CrewMemberRef[],
+    targetUuid: string | undefined,
+): CrewMemberRef[] {
+    if (typeof targetUuid === 'undefined') return [...crew];
+    return crew.filter((c) => c.uuid === targetUuid);
+}

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -1,6 +1,14 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {isVehicleActor} from "../../system/type-guards";
+import {
+    isCrewMemberByFlag,
+    canRemoveFromCrew,
+    removeCrewmember,
+    buildVehicleWeaponSnapshots,
+    shouldDispatchVehicleDataAsGM,
+    selectCrewmembersForBroadcast,
+} from "./crew-vehicle-math";
 
 export async function addEmbeddedPilot(actor: Actor, pilotActor: Actor): Promise<void> {
     /* Copy attributes and items to vehicle */
@@ -62,20 +70,20 @@ export async function _verifyAddToCrew(actor: Actor, currentVehicleId: string, n
 }
 
 export async function removeFromCrew(actor: Actor, vehicleID: string): Promise<void> {
-    if (actor.getFlag('od6s', 'crew') !== vehicleID) {
+    if (!canRemoveFromCrew(actor.getFlag('od6s', 'crew') as string | null | undefined, vehicleID)) {
         ui.notifications.warn(game.i18n.localize('OD6S.NOT_CREW_MEMBER'))
-    } else {
-        try {
-            await actor.unsetFlag('od6s', 'crew');
-        } catch (error) {
-            console.error(error)
-        }
+        return;
+    }
+    try {
+        await actor.unsetFlag('od6s', 'crew');
+    } catch (error) {
+        console.error(error)
     }
 }
 
 export async function forceRemoveCrewmember(actor: Actor, crewID: string): Promise<void> {
     if (!isVehicleActor(actor)) return;
-    const crewMembers = actor.system.crewmembers.filter((e) => e.uuid !== crewID);
+    const crewMembers = removeCrewmember(actor.system.crewmembers, crewID);
     const update: any = {};
     update.system = {};
     update.system.crewmembers = crewMembers;
@@ -83,7 +91,7 @@ export async function forceRemoveCrewmember(actor: Actor, crewID: string): Promi
 }
 
 export function isCrewMember(actor: Actor): boolean {
-    return !!actor.getFlag('od6s', 'crew');
+    return isCrewMemberByFlag(actor.getFlag('od6s', 'crew') as string | null | undefined);
 }
 
 export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void> {
@@ -111,36 +119,23 @@ export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void
     data.ranged_damage = sys.ranged_damage;
     data.ram = sys.ram;
     data.ram_damage = sys.ram_damage;
-    data.vehicle_weapons = [];
-    for (let i = 0; i < data.items.size; i++) {
-        if (actor.items.contents[i].type === "vehicle-weapon" || actor.items.contents[i].type === "starship-weapon") {
-            const newItem = actor.items.contents[i].toObject()
-            newItem.id = actor.items.contents[i].id;
-            data.vehicle_weapons.push(newItem);
-        }
-    }
+    data.vehicle_weapons = buildVehicleWeaponSnapshots(actor.items.contents);
 
-    if (game.user.isGM) {
-        let crew;
-        if(typeof uuid !== 'undefined') {
-            crew = data.crewmembers.filter((c: any) =>c.uuid === uuid);
-        } else {
-            crew = data.crewmembers;
-        }
-
-        for (const e of crew) {
-            const crewActor = await od6sutilities.getActorFromUuid(e.uuid);
-            if (crewActor) {
-                const update: any = {};
-                update.id = crewActor.id;
-                update._id = crewActor.id;
-                update.system = {}
-                update.system.vehicle = data;
-                await crewActor.update(update);
-            }
-        }
-    } else {
+    if (shouldDispatchVehicleDataAsGM(game.user.isGM)) {
         await OD6S.socket.executeAsGM("sendVehicleData", data);
+        return;
+    }
+    const crew = selectCrewmembersForBroadcast(data.crewmembers, uuid);
+    for (const e of crew) {
+        const crewActor = await od6sutilities.getActorFromUuid(e.uuid);
+        if (crewActor) {
+            const update: any = {};
+            update.id = crewActor.id;
+            update._id = crewActor.id;
+            update.system = {}
+            update.system.vehicle = data;
+            await crewActor.update(update);
+        }
     }
 }
 

--- a/tests/domain/crew-vehicle.test.ts
+++ b/tests/domain/crew-vehicle.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Domain tests: crew/vehicle synchronization helpers (#84).
+ *
+ * These exercise the pure decision logic extracted from
+ * `src/module/actor/actor-helpers/crew-vehicle.ts` into
+ * `crew-vehicle-math.ts`. The orchestrator still owns the document
+ * mutations and socket dispatch; this file covers what runs around them.
+ *
+ * Multiplayer edge cases worth pinning:
+ *   - empty / null / placeholder crew flags (don't claim crew membership).
+ *   - mismatched vehicle uuid on remove (the runtime warns instead of
+ *     silently unsetting another vehicle's flag).
+ *   - duplicate / missing crewmember uuids in the vehicle's roster.
+ *   - mixed-type item rosters (only vehicle/starship weapons should be
+ *     projected into the snapshot).
+ *   - GM-vs-player branching for `sendVehicleData` dispatch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    isCrewMemberByFlag,
+    canRemoveFromCrew,
+    removeCrewmember,
+    buildVehicleWeaponSnapshots,
+    shouldDispatchVehicleDataAsGM,
+    selectCrewmembersForBroadcast,
+    type CrewMemberRef,
+    type ItemLike,
+} from '../../src/module/actor/actor-helpers/crew-vehicle-math';
+
+// ---------------------------------------------------------------------------
+// isCrewMemberByFlag
+// ---------------------------------------------------------------------------
+
+describe('isCrewMemberByFlag', () => {
+    it('non-empty uuid string → true', () => {
+        expect(isCrewMemberByFlag('Actor.abc123')).toBe(true);
+    });
+
+    it('empty string → false', () => {
+        expect(isCrewMemberByFlag('')).toBe(false);
+    });
+
+    it('undefined → false', () => {
+        expect(isCrewMemberByFlag(undefined)).toBe(false);
+    });
+
+    it('null → false (Foundry returns null for missing flags)', () => {
+        expect(isCrewMemberByFlag(null)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// canRemoveFromCrew
+// ---------------------------------------------------------------------------
+
+describe('canRemoveFromCrew', () => {
+    it('matching vehicle uuid → true', () => {
+        expect(canRemoveFromCrew('Actor.vehicle1', 'Actor.vehicle1')).toBe(true);
+    });
+
+    it('different vehicle uuid → false (runtime warns NOT_CREW_MEMBER)', () => {
+        expect(canRemoveFromCrew('Actor.vehicle1', 'Actor.vehicle2')).toBe(false);
+    });
+
+    it('actor not on any crew → false', () => {
+        expect(canRemoveFromCrew(null, 'Actor.vehicle1')).toBe(false);
+    });
+
+    it('empty crew flag, target uuid present → false', () => {
+        expect(canRemoveFromCrew('', 'Actor.vehicle1')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// removeCrewmember
+// ---------------------------------------------------------------------------
+
+describe('removeCrewmember', () => {
+    const roster: CrewMemberRef[] = [
+        { uuid: 'Actor.alice', name: 'Alice' },
+        { uuid: 'Actor.bob', name: 'Bob' },
+        { uuid: 'Actor.carol', name: 'Carol' },
+    ];
+
+    it('removes the matching uuid and preserves order', () => {
+        const out = removeCrewmember(roster, 'Actor.bob');
+        expect(out).toEqual([
+            { uuid: 'Actor.alice', name: 'Alice' },
+            { uuid: 'Actor.carol', name: 'Carol' },
+        ]);
+    });
+
+    it('uuid not present → returns a copy unchanged', () => {
+        const out = removeCrewmember(roster, 'Actor.dave');
+        expect(out).toEqual(roster);
+    });
+
+    it('empty roster → empty roster', () => {
+        expect(removeCrewmember([], 'Actor.alice')).toEqual([]);
+    });
+
+    it('duplicate uuids → all copies removed (defensive against bad sync state)', () => {
+        const dup: CrewMemberRef[] = [
+            { uuid: 'Actor.alice' },
+            { uuid: 'Actor.alice' },
+            { uuid: 'Actor.bob' },
+        ];
+        expect(removeCrewmember(dup, 'Actor.alice')).toEqual([{ uuid: 'Actor.bob' }]);
+    });
+
+    it('does not mutate the input list', () => {
+        const before = roster.slice();
+        removeCrewmember(roster, 'Actor.bob');
+        expect(roster).toEqual(before);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildVehicleWeaponSnapshots
+// ---------------------------------------------------------------------------
+
+function fakeItem(id: string, type: string, extras: Record<string, unknown> = {}): ItemLike {
+    return {
+        id,
+        type,
+        toObject: () => ({ _id: id, type, name: `${type} ${id}`, ...extras }),
+    };
+}
+
+describe('buildVehicleWeaponSnapshots', () => {
+    it('keeps only vehicle-weapon and starship-weapon items', () => {
+        const items: ItemLike[] = [
+            fakeItem('a', 'weapon'),
+            fakeItem('b', 'vehicle-weapon'),
+            fakeItem('c', 'gear'),
+            fakeItem('d', 'starship-weapon'),
+            fakeItem('e', 'skill'),
+        ];
+        const out = buildVehicleWeaponSnapshots(items);
+        expect(out.map((s) => s.id)).toEqual(['b', 'd']);
+    });
+
+    it('stamps `id` on each snapshot (downstream lookups rely on it)', () => {
+        const items: ItemLike[] = [fakeItem('vw1', 'vehicle-weapon')];
+        const [snapshot] = buildVehicleWeaponSnapshots(items);
+        expect(snapshot.id).toBe('vw1');
+    });
+
+    it('preserves snapshot data fields from toObject()', () => {
+        const items: ItemLike[] = [fakeItem('vw1', 'vehicle-weapon', { system: { damage: { score: 5 } } })];
+        const [snapshot] = buildVehicleWeaponSnapshots(items);
+        expect(snapshot.system).toEqual({ damage: { score: 5 } });
+    });
+
+    it('empty input → empty output', () => {
+        expect(buildVehicleWeaponSnapshots([])).toEqual([]);
+    });
+
+    it('all-non-weapon roster → empty output', () => {
+        const items: ItemLike[] = [fakeItem('a', 'gear'), fakeItem('b', 'skill')];
+        expect(buildVehicleWeaponSnapshots(items)).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// shouldDispatchVehicleDataAsGM
+// ---------------------------------------------------------------------------
+
+describe('shouldDispatchVehicleDataAsGM', () => {
+    it('GM client runs locally → no dispatch', () => {
+        expect(shouldDispatchVehicleDataAsGM(true)).toBe(false);
+    });
+
+    it('player client must defer to GM via socket → dispatch', () => {
+        expect(shouldDispatchVehicleDataAsGM(false)).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// selectCrewmembersForBroadcast
+// ---------------------------------------------------------------------------
+
+describe('selectCrewmembersForBroadcast', () => {
+    const roster: CrewMemberRef[] = [
+        { uuid: 'Actor.alice' },
+        { uuid: 'Actor.bob' },
+        { uuid: 'Actor.carol' },
+    ];
+
+    it('no targetUuid → broadcast to entire roster', () => {
+        expect(selectCrewmembersForBroadcast(roster, undefined)).toEqual(roster);
+    });
+
+    it('targetUuid present → narrows to that crewmember', () => {
+        expect(selectCrewmembersForBroadcast(roster, 'Actor.bob')).toEqual([{ uuid: 'Actor.bob' }]);
+    });
+
+    it('targetUuid not in roster → empty list (no broadcast)', () => {
+        expect(selectCrewmembersForBroadcast(roster, 'Actor.dave')).toEqual([]);
+    });
+
+    it('returns a fresh array even when broadcasting all (no aliasing)', () => {
+        const out = selectCrewmembersForBroadcast(roster, undefined);
+        expect(out).not.toBe(roster);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #84. Extracts the pure decision logic from `actor/actor-helpers/crew-vehicle.ts` into a new `crew-vehicle-math.ts` so the multiplayer-relevant branching is exercised in `tests/domain/` without a Foundry runtime. The orchestrator still owns the document mutations and socket dispatch — only the predicates and projections moved.

Six helpers extracted, 24 new tests:

| Helper | What it covers |
| --- | --- |
| `isCrewMemberByFlag` | `getFlag('od6s', 'crew')` predicate — empty / null / placeholder values |
| `canRemoveFromCrew` | The gate behind the `OD6S.NOT_CREW_MEMBER` warning |
| `removeCrewmember` | uuid filter behind `forceRemoveCrewmember` (incl. duplicate-uuid defence) |
| `buildVehicleWeaponSnapshots` | The `Item#toObject() + id` loop into `system.vehicle.vehicle_weapons` |
| `shouldDispatchVehicleDataAsGM` | GM-vs-player branch for the `sendVehicleData` socket dispatch |
| `selectCrewmembersForBroadcast` | Single-target vs full-roster selection used by `sendVehicleData` |

Smoke coverage stays in place — this just stops it from being the only safety net for these flows.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (0 errors, 576 warnings — down 1 from main)
- [x] `pnpm run test` (368 unit tests)
- [x] `pnpm run test:domain` (327 — +24 from main)
- [ ] Smoke: drag a crewmember between two vehicles, then off the second one. The `addToCrew` / `_verifyAddToCrew` / `removeFromCrew` paths should behave as before — only the predicates underneath them changed.
