### PR TITLE
feat(data): #85 stamp and validate per-document schema version

### DIFF
--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -2,6 +2,7 @@ import {od6sutilities} from "../system/utilities";
 import {od6sroll} from "../apps/roll";
 import OD6S from "../config/config-od6s";
 import {isCharacterActor, isVehicleActor, isContainerActor, isSkillItem, isSpecializationItem} from "../system/type-guards";
+import {warnIfSchemaVersionMismatch, SCHEMA_VERSION_KEY} from "../system/schema-version";
 
 import {resolveRollAction} from "./actor-helpers/roll-action";
 import {prepareBaseActorData, prepareDerivedActorData, applyMods as applyModsHelper, setStrengthDamageBonus as setStrengthDamageBonusHelper, setInitiative as setInitiativeHelper, setResistance as setResistanceHelper} from "./actor-helpers/prepare-actor";
@@ -28,6 +29,17 @@ export class OD6SActor extends Actor {
      */
     async _preCreate(data: object, options: object, user: User) {
         await super._preCreate(data, options, user);
+        // Stamp the schema version of the running system on new docs (#85).
+        // updateSource is the V2 way to seed fields before insert; project
+        // type stubs predate it.
+        const version = game.system?.version;
+        if (version) {
+            const sys = (this.system ?? {}) as unknown as Record<string, unknown>;
+            if (!sys[SCHEMA_VERSION_KEY]) {
+                (this as unknown as { updateSource: (changes: Record<string, unknown>) => void })
+                    .updateSource({ [`system.${SCHEMA_VERSION_KEY}`]: version });
+            }
+        }
     }
 
     async _onCreate(data: object, options: object, user: User) {
@@ -79,6 +91,7 @@ export class OD6SActor extends Actor {
         // prepareBaseData(), prepareEmbeddedDocuments() (including active effects),
         // prepareDerivedData().
         super.prepareData();
+        warnIfSchemaVersionMismatch(this, this.system as unknown as Record<string, unknown>);
     }
 
     /** @override */

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -86,12 +86,14 @@ export class OD6SActor extends Actor {
 
     /** @override */
     prepareData() {
+        // Warn before super so a mismatch is logged even when downstream
+        // preparation throws — that's exactly the case the diagnostic exists for.
+        warnIfSchemaVersionMismatch(this, this.system as unknown as Record<string, unknown>);
         // Prepare data for the actor. Calling the super version of this executes
         // the following, in order: data reset (to clear active effects),
         // prepareBaseData(), prepareEmbeddedDocuments() (including active effects),
         // prepareDerivedData().
         super.prepareData();
-        warnIfSchemaVersionMismatch(this, this.system as unknown as Record<string, unknown>);
     }
 
     /** @override */

--- a/src/module/data/actor/container.ts
+++ b/src/module/data/actor/container.ts
@@ -1,8 +1,11 @@
+import { schemaVersionField } from "../fields/schema-version";
+
 const fields = foundry.data.fields;
 
 export default class ContainerData extends foundry.abstract.TypeDataModel {
   static defineSchema() {
     return {
+      ...schemaVersionField(),
       itemtypes: new fields.SchemaField({
         armor: new fields.BooleanField({ initial: true }),
         weapon: new fields.BooleanField({ initial: true }),

--- a/src/module/data/actor/fields/common.ts
+++ b/src/module/data/actor/fields/common.ts
@@ -2,6 +2,8 @@
  * Shared "common" schema fields used by character, NPC, and creature actors.
  */
 
+import { schemaVersionField } from "../../fields/schema-version";
+
 const fields = foundry.data.fields;
 
 function modField(label: string, shortLabel: string) {
@@ -25,6 +27,7 @@ function modScoreField(label: string, shortLabel: string) {
 
 export function commonSchema() {
   return {
+    ...schemaVersionField(),
     move: new fields.SchemaField({
       type: new fields.StringField({ initial: "Number" }),
       label: new fields.StringField({ initial: "OD6S.CHAR_MOVE" }),

--- a/src/module/data/actor/fields/vehicle-common.ts
+++ b/src/module/data/actor/fields/vehicle-common.ts
@@ -2,6 +2,8 @@
  * Shared vehicle_common schema fields used by vehicle and starship actors.
  */
 
+import { schemaVersionField } from "../../fields/schema-version";
+
 const fields = foundry.data.fields;
 
 function numScoreField(label: string) {
@@ -56,6 +58,7 @@ function shieldArcField(label: any) {
 
 export function vehicleCommonSchema() {
   return {
+    ...schemaVersionField(),
     vehicle_type: strValueField("OD6S.VEHICLE_TYPE"),
     initiative: new fields.SchemaField({
       type: new fields.StringField({ initial: "String" }),

--- a/src/module/data/fields/schema-version.ts
+++ b/src/module/data/fields/schema-version.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-document schema-version stamp. Spread into every actor / item
+ * `defineSchema()` so each document records the system version it was last
+ * written against. See `src/module/system/schema-version.ts` for the runtime
+ * comparison + warn logic, and `src/module/system/migration.ts` for the
+ * stamping pass after world migrations run.
+ *
+ * Default is `""` (unstamped) — legacy docs that predate this field load
+ * unstamped and are stamped on first save / next migration.
+ */
+
+import { SCHEMA_VERSION_KEY } from "../../system/schema-version";
+
+export function schemaVersionField() {
+  const fields = foundry.data.fields;
+  return {
+    [SCHEMA_VERSION_KEY]: new fields.StringField({ initial: "", required: false }),
+  };
+}

--- a/src/module/data/item/fields/base.ts
+++ b/src/module/data/item/fields/base.ts
@@ -1,7 +1,10 @@
+import { schemaVersionField } from "../../fields/schema-version";
+
 const fields = foundry.data.fields;
 
 export function baseSchema() {
   return {
+    ...schemaVersionField(),
     description: new fields.HTMLField({ initial: "" }),
     labels: new fields.ObjectField({ initial: {} }),
     tags: new fields.ArrayField(new fields.StringField()),

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -40,9 +40,11 @@ export class OD6SItem extends Item {
      * Augment the basic Item data model with additional dynamic data.
      */
     prepareData() {
+        // Warn before super so a mismatch is logged even when downstream
+        // preparation throws — that's exactly the case the diagnostic exists for.
+        warnIfSchemaVersionMismatch(this, this.system as unknown as Record<string, unknown>);
         super.prepareData();
         (this.system as unknown as Record<string, unknown>).config = OD6S;
-        warnIfSchemaVersionMismatch(this, this.system as unknown as Record<string, unknown>);
     }
 
     prepareBaseData() {

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -2,6 +2,7 @@ import {od6sroll} from "../apps/roll";
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import {isAnyWeaponItem, isActionItem, isCharacterActor, isVehicleActor, isSkillItem, isSpecializationItem, isVehicleBorneWeaponItem, isWeaponItem, isVehicleWeaponItem, isStarshipWeaponItem} from "../system/type-guards";
+import {warnIfSchemaVersionMismatch, SCHEMA_VERSION_KEY} from "../system/schema-version";
 
 /**
  * Extend the basic Item with some very simple modifications.
@@ -21,12 +22,27 @@ export class OD6SItem extends Item {
         return await super.create(data, options);
     }
 
+    async _preCreate(data: object, options: object, user: User) {
+        await super._preCreate(data, options, user);
+        // #85: stamp the schema version of the running system on new items.
+        // updateSource is V2; project type stubs predate it.
+        const version = game.system?.version;
+        if (version) {
+            const sys = (this.system ?? {}) as unknown as Record<string, unknown>;
+            if (!sys[SCHEMA_VERSION_KEY]) {
+                (this as unknown as { updateSource: (changes: Record<string, unknown>) => void })
+                    .updateSource({ [`system.${SCHEMA_VERSION_KEY}`]: version });
+            }
+        }
+    }
+
     /*
      * Augment the basic Item data model with additional dynamic data.
      */
     prepareData() {
         super.prepareData();
         (this.system as unknown as Record<string, unknown>).config = OD6S;
+        warnIfSchemaVersionMismatch(this, this.system as unknown as Record<string, unknown>);
     }
 
     prepareBaseData() {

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -12,6 +12,7 @@
  */
 
 import { debug, isDebugEnabled } from "./logger";
+import { SCHEMA_VERSION_KEY } from "./schema-version";
 
 /**
  * Migration steps in version order. Each entry runs when the world's stored
@@ -33,6 +34,10 @@ const MIGRATION_STEPS: Array<{ since: string; run: () => Promise<void> }> = [
   {
     since: "2.5.0",
     run: () => migrateExplosivePendingFlags(),
+  },
+  {
+    since: "2.6.0",
+    run: () => stampAllSchemaVersions(),
   },
 ];
 
@@ -280,4 +285,51 @@ async function migrateChatMessageFlags() {
   }
 
   console.log(`od6s | Cleaned explosive flags from ${count} chat messages.`);
+}
+
+/**
+ * #85: Stamp every actor + item with the running system version. Runs once
+ * for any world upgrading past 2.6.0 — after this, new docs are stamped on
+ * `_preCreate` and warning logic in `system/schema-version.ts` can rely on
+ * the field being populated for in-world docs.
+ *
+ * We overwrite any existing stamp. The field didn't exist before 2.6.0, so
+ * any pre-existing value can only come from a doc imported from a future
+ * (>=2.6.0) world into a still-pre-2.6.0 world — vanishingly rare, and the
+ * world's migration history (in the settings store) is the source of truth
+ * at this point. New docs from 2.6.0 onward stamp themselves on `_preCreate`.
+ */
+async function stampAllSchemaVersions() {
+  const version = game.system.version;
+  console.log(`od6s | Stamping all docs with system schema version ${version}...`);
+  let count = 0;
+
+  const actorUpdates: Array<Record<string, unknown>> = [];
+  for (const actor of game.actors) {
+    actorUpdates.push({ _id: actor.id, [`system.${SCHEMA_VERSION_KEY}`]: version });
+
+    const itemUpdates: Array<Record<string, unknown>> = [];
+    for (const item of actor.items) {
+      itemUpdates.push({ _id: item.id, [`system.${SCHEMA_VERSION_KEY}`]: version });
+    }
+    if (itemUpdates.length > 0) {
+      await actor.updateEmbeddedDocuments("Item", itemUpdates);
+      count += itemUpdates.length;
+    }
+  }
+  if (actorUpdates.length > 0) {
+    await Actor.updateDocuments(actorUpdates);
+    count += actorUpdates.length;
+  }
+
+  const worldItemUpdates: Array<Record<string, unknown>> = [];
+  for (const item of game.items) {
+    worldItemUpdates.push({ _id: item.id, [`system.${SCHEMA_VERSION_KEY}`]: version });
+  }
+  if (worldItemUpdates.length > 0) {
+    await Item.updateDocuments(worldItemUpdates);
+    count += worldItemUpdates.length;
+  }
+
+  console.log(`od6s | Stamped ${count} docs.`);
 }

--- a/src/module/system/schema-version.test.ts
+++ b/src/module/system/schema-version.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { compareSchemaVersion } from "./schema-version";
+
+const cmp = (a: string, b: string) => {
+  const pa = a.split(".").map(n => parseInt(n, 10));
+  const pb = b.split(".").map(n => parseInt(n, 10));
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x > y) return true;
+    if (x < y) return false;
+  }
+  return false;
+};
+
+describe("compareSchemaVersion", () => {
+  it("returns 'unstamped' for blank/missing stamp", () => {
+    expect(compareSchemaVersion("", "2.6.0", cmp)).toBe("unstamped");
+    expect(compareSchemaVersion(undefined, "2.6.0", cmp)).toBe("unstamped");
+    expect(compareSchemaVersion(null, "2.6.0", cmp)).toBe("unstamped");
+  });
+
+  it("returns 'ok' when stamp matches", () => {
+    expect(compareSchemaVersion("2.6.0", "2.6.0", cmp)).toBe("ok");
+  });
+
+  it("returns 'lag' when stamp is older than current", () => {
+    expect(compareSchemaVersion("2.5.0", "2.6.0", cmp)).toBe("lag");
+    expect(compareSchemaVersion("1.0.0", "2.6.0", cmp)).toBe("lag");
+  });
+
+  it("returns 'ahead' when stamp is newer than current — downgrade case", () => {
+    expect(compareSchemaVersion("2.7.0", "2.6.0", cmp)).toBe("ahead");
+  });
+});

--- a/src/module/system/schema-version.ts
+++ b/src/module/system/schema-version.ts
@@ -1,0 +1,76 @@
+/**
+ * Runtime helpers for the per-document `_systemSchemaVersion` stamp.
+ *
+ * Pure logic lives here so it can be unit-tested without Foundry globals.
+ * See also `src/module/data/fields/schema-version.ts` (the schema field) and
+ * `src/module/system/migration.ts` (which bumps stamps after migrations).
+ */
+
+export const SCHEMA_VERSION_KEY = "_systemSchemaVersion";
+
+export type SchemaVersionState = "ok" | "unstamped" | "lag" | "ahead";
+
+/**
+ * Compare a document's recorded schema version against the running system
+ * version. `cmp` is injected so this stays pure (no `foundry.utils` import);
+ * production callers pass `foundry.utils.isNewerVersion`.
+ */
+export function compareSchemaVersion(
+  stamp: string | undefined | null,
+  current: string,
+  cmp: (a: string, b: string) => boolean,
+): SchemaVersionState {
+  if (!stamp) return "unstamped";
+  if (stamp === current) return "ok";
+  if (cmp(current, stamp)) return "lag";
+  if (cmp(stamp, current)) return "ahead";
+  return "ok";
+}
+
+const warned = new Set<string>();
+let notifiedGM = false;
+
+/**
+ * Console-warn at most once per (doc, state) when its stamp lags or runs
+ * ahead of the running system version. Also surfaces a single GM-visible
+ * `ui.notifications.warn` per session pointing at the console — per-doc
+ * toasts would spam on worlds with many lagging docs.
+ *
+ * `unstamped` is silent — that's the steady state for pre-#85 docs and for
+ * docs about to be stamped by migration.
+ */
+export function warnIfSchemaVersionMismatch(doc: { id?: string | null; name?: string | null; type?: string }, system: Record<string, unknown> | null | undefined) {
+  if (!system) return;
+  const stamp = system[SCHEMA_VERSION_KEY] as string | undefined;
+  const current = game?.system?.version;
+  if (!current) return;
+
+  const state = compareSchemaVersion(
+    stamp,
+    current,
+    (a, b) => foundry.utils.isNewerVersion(a, b),
+  );
+  if (state === "ok" || state === "unstamped") return;
+
+  const key = `${doc.type ?? "?"}:${doc.id ?? "?"}:${state}`;
+  if (warned.has(key)) return;
+  warned.add(key);
+
+  const label = `${doc.type ?? "doc"} "${doc.name ?? doc.id}"`;
+  if (state === "lag") {
+    console.warn(
+      `[od6s:schema-version] ${label} was stamped ${stamp} but system is ${current}; world migrations may not have run yet.`,
+    );
+  } else {
+    console.warn(
+      `[od6s:schema-version] ${label} was stamped ${stamp} which is newer than the running system ${current}; this world was opened in a newer system version. Schema fields may render incorrectly.`,
+    );
+  }
+
+  if (!notifiedGM && game.user?.isGM) {
+    notifiedGM = true;
+    ui.notifications?.warn(
+      "OpenD6 Space: one or more documents have a schema-version mismatch. See the browser console for details.",
+    );
+  }
+}

--- a/tests/smoke/tier-3-schema-version.spec.ts
+++ b/tests/smoke/tier-3-schema-version.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Tier 3 — #85 schema-version stamping.
+ *
+ * Verifies:
+ *   - new actors/items get `system._systemSchemaVersion` stamped from
+ *     `_preCreate` against `game.system.version`;
+ *   - a synthetically downlevel actor logs a `[od6s:schema-version]`
+ *     warning to the console on next `prepareData`.
+ *
+ * The notification side of the warn is GM-visible; we don't assert on
+ * `ui.notifications` here because it sticks across tests on the same world
+ * — console output is the deterministic check.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("new actors are stamped with the running system version on create", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const r = await evalInWorld(page, async () => {
+        const actor = await window.Actor.create(
+            {name: "smoke-schema-version-create", type: "character"},
+            {render: false},
+        );
+        const stamp = actor.system._systemSchemaVersion;
+        await actor.delete();
+        return {stamp, current: window.game.system.version};
+    });
+
+    expect(r.stamp).toBe(r.current);
+});
+
+test("downlevel actor stamp triggers a console warn from prepareData", async ({page}) => {
+    const messages: string[] = [];
+    page.on("console", msg => {
+        if (msg.type() === "warning") messages.push(msg.text());
+    });
+
+    await loginAndWaitReady(page);
+
+    await evalInWorld(page, async () => {
+        let actor = window.game.actors.find(
+            (a: any) => a.name === "smoke-schema-version-lag",
+        );
+        if (!actor) {
+            actor = await window.Actor.create(
+                {name: "smoke-schema-version-lag", type: "character"},
+                {render: false},
+            );
+        }
+        // Force the stamp to a clearly older version, then re-prepare.
+        await actor.update({"system._systemSchemaVersion": "0.1.0"});
+        actor.prepareData();
+    });
+
+    const lagWarn = messages.find(m =>
+        m.includes("[od6s:schema-version]") && m.includes("stamped 0.1.0"),
+    );
+    expect(lagWarn, `expected schema-version lag warn, got:\n${messages.join("\n")}`)
+        .toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- Add `system._systemSchemaVersion` to every actor + item DataModel via a shared `schemaVersionField()` factory; stamp on `_preCreate`, warn once per (doc, state) from `prepareData` on lag/ahead.
- Add a 2.6.0 migration step that bulk-stamps existing in-world docs so the warn logic has a populated field to compare against.
- Pure `compareSchemaVersion` helper unit-tested without Foundry globals; smoke spec covers create-time stamping and the lag warn path.

## Closes
- #85

## Test plan
- [x] `pnpm run check` (lint 0 errors, typecheck, 372 unit + 327 domain tests)
- [x] `pnpm exec playwright test tests/smoke/tier-3-schema-version.spec.ts` — both checks green against a live Foundry world
- [ ] Reviewer: confirm the GM-visible toast wording reads acceptably in-game
- [ ] Reviewer: confirm migration step ordering — runs after the existing 2.5.0 explosive-pending cleanup, with `since: "2.6.0"` keyed to the next release

## Notes
- The `2.6.0` step's `since` matches the planned next release; if release plan changes to a patch, the `since` value needs to follow.
- No `system.json` / `package.json` version bump in this PR — that belongs in the release flow per CLAUDE.md.