### PR TITLE
feat(a11y): #80 chat-card aria, focus-visible, color-blind dice cues

### DIFF
--- a/scss/components/_chat.scss
+++ b/scss/components/_chat.scss
@@ -82,7 +82,8 @@
         line-height: 1;
         transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 
-        &:hover {
+        &:hover,
+        &:focus-visible {
           color: $c-accent-bright;
           border-color: $c-accent-border;
           background-color: $c-hover-bg;
@@ -90,12 +91,18 @@
           text-shadow: 0 0 6px rgba(201, 162, 39, 0.45);
         }
 
+        &:focus-visible {
+          outline: 2px solid $c-accent;
+          outline-offset: 1px;
+        }
+
         i {
           font-size: 0.85em;
         }
       }
 
-      .message-delete:hover {
+      .message-delete:hover,
+      .message-delete:focus-visible {
         color: $c-bad;
         border-color: rgba(226, 95, 99, 0.4);
         background-color: rgba(226, 95, 99, 0.08);
@@ -121,10 +128,16 @@
       color: $c-accent;
       transition: color 0.15s ease, text-shadow 0.15s ease;
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         color: $c-accent-bright;
         text-shadow: 0 0 6px rgba(201, 162, 39, 0.45);
         cursor: pointer;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $c-accent;
+        outline-offset: 1px;
       }
     }
   }
@@ -227,16 +240,22 @@
         border: 1px solid $c-border;
         border-radius: 2px;
 
+        // Non-color reinforcement for color-blind users:
+        // success → bold + underline, failure → bold + line-through.
         &.max,
         &.success {
           color: $c-good;
           border-color: rgba(78, 201, 122, 0.4);
+          font-weight: 700;
+          text-decoration: underline;
         }
 
         &.min,
         &.failure {
           color: $c-bad;
           border-color: rgba(226, 95, 99, 0.4);
+          font-weight: 700;
+          text-decoration: line-through;
         }
       }
     }
@@ -280,9 +299,15 @@
         cursor: pointer;
         transition: color 0.15s ease;
 
-        &:hover {
+        &:hover,
+        &:focus-visible {
           color: $c-accent-bright;
           text-shadow: 0 0 6px rgba(201, 162, 39, 0.4);
+        }
+
+        &:focus-visible {
+          outline: 2px solid $c-accent;
+          outline-offset: 1px;
         }
       }
     }
@@ -294,9 +319,15 @@
       transition: color 0.15s ease, transform 0.1s ease;
       flex: 0 0 auto;
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         color: $c-accent-bright;
         transform: scale(1.1);
+      }
+
+      &:focus-visible {
+        outline: 2px solid $c-accent;
+        outline-offset: 1px;
       }
     }
   }
@@ -419,11 +450,17 @@
       color: $c-text-muted;
       transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         color: $c-accent-bright;
         border-color: $c-accent-border;
         background-color: $c-hover-bg;
         cursor: pointer;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $c-accent;
+        outline-offset: 1px;
       }
 
       i {

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -11,7 +11,8 @@ function tagRollMode(msg: any, html: HTMLElement) {
     if (mode === 'public') return;
 
     const label = game.i18n.localize(`OD6S.ROLL_BADGE_${mode.toUpperCase()}`);
-    html.setAttribute('aria-label', `${label} — ${msg.alias ?? ''}`.trim());
+    const alias = (msg.alias ?? msg.speaker?.alias ?? '').trim();
+    html.setAttribute('aria-label', alias ? `${label} — ${alias}` : label);
 
     const header = html.querySelector('.message-header');
     if (!header || header.querySelector('.od6s-roll-badge')) return;

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -7,14 +7,18 @@ import {deriveRollMode} from "./chat-mode";
 function tagRollMode(msg: any, html: HTMLElement) {
     const mode = deriveRollMode(msg);
     html.classList.add(`od6s-roll-${mode}`);
+    if (!html.hasAttribute('role')) html.setAttribute('role', 'article');
     if (mode === 'public') return;
+
+    const label = game.i18n.localize(`OD6S.ROLL_BADGE_${mode.toUpperCase()}`);
+    html.setAttribute('aria-label', `${label} — ${msg.alias ?? ''}`.trim());
 
     const header = html.querySelector('.message-header');
     if (!header || header.querySelector('.od6s-roll-badge')) return;
 
     const badge = document.createElement('span');
     badge.classList.add('od6s-roll-badge', `od6s-roll-badge--${mode}`);
-    badge.textContent = game.i18n.localize(`OD6S.ROLL_BADGE_${mode.toUpperCase()}`);
+    badge.textContent = label;
 
     const sender = header.querySelector('.message-sender');
     if (sender) sender.after(badge);

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -36,6 +36,14 @@ export function registerChatLogListeners() {
             await message!.setFlag('od6s','targets',targets);
         })
 
+        // Keyboard activation for role="button" elements that aren't native <button>s.
+        delegateEvent(html, "keydown", ".modifiers-button, .damage-modifiers-button", (ev: any) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+                ev.preventDefault();
+                (ev.currentTarget as HTMLElement).click();
+            }
+        })
+
         delegateEvent(html, "click", ".modifiers-button", async (ev: any) => {
             const content = document.getElementById("modifiers-display-" + ev.currentTarget.dataset.messageId);
             if (content!.style.display === "block") {

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -36,13 +36,23 @@ export function registerChatLogListeners() {
             await message!.setFlag('od6s','targets',targets);
         })
 
-        // Keyboard activation for role="button" elements that aren't native <button>s.
-        delegateEvent(html, "keydown", ".modifiers-button, .damage-modifiers-button", (ev: any) => {
-            if (ev.key === 'Enter' || ev.key === ' ') {
-                ev.preventDefault();
-                (ev.currentTarget as HTMLElement).click();
-            }
-        })
+        // Keyboard activation for chat-card controls that aren't native <button>s
+        // (header anchors without href, plus role="button" <div>/<span> nodes).
+        // The selector mirrors the elements we make focusable via tabindex/role
+        // in the chat templates.
+        delegateEvent(
+            html,
+            "keydown",
+            ".message-delete, .message-reveal, .message-oppose-button, " +
+                ".modifiers-button, .damage-modifiers-button, " +
+                ".edit-difficulty, .edit-damage, .choose-target",
+            (ev: any) => {
+                if (ev.key === 'Enter' || ev.key === ' ') {
+                    ev.preventDefault();
+                    (ev.currentTarget as HTMLElement).click();
+                }
+            },
+        )
 
         delegateEvent(html, "click", ".modifiers-button", async (ev: any) => {
             const content = document.getElementById("modifiers-display-" + ev.currentTarget.dataset.messageId);

--- a/src/templates/chat/damageresult.html
+++ b/src/templates/chat/damageresult.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/damageresult.html
+++ b/src/templates/chat/damageresult.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/explosive.html
+++ b/src/templates/chat/explosive.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}
@@ -38,7 +38,7 @@
     <div class="message-oppose" style="text-align: right"
 				data-message-id="{{../message._id}}" data-target="{{target.id}}">
         {{#if ../user.isGM}}
-        <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}" aria-label="{{localize "OD6S.OPPOSE"}}">&nbsp<i
+        <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.OPPOSE"}}">&nbsp;<i
                 class="fas fa-exchange-alt" aria-hidden="true"></i></a>
         {{/if}}
     </div>

--- a/src/templates/chat/explosive.html
+++ b/src/templates/chat/explosive.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}
@@ -38,8 +38,8 @@
     <div class="message-oppose" style="text-align: right"
 				data-message-id="{{../message._id}}" data-target="{{target.id}}">
         {{#if ../user.isGM}}
-        <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}">&nbsp<i
-                class="fas fa-exchange-alt"></i></a>
+        <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}" aria-label="{{localize "OD6S.OPPOSE"}}">&nbsp<i
+                class="fas fa-exchange-alt" aria-hidden="true"></i></a>
         {{/if}}
     </div>
     {{/each}}

--- a/src/templates/chat/generic.html
+++ b/src/templates/chat/generic.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/generic.html
+++ b/src/templates/chat/generic.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/opposed.html
+++ b/src/templates/chat/opposed.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/opposed.html
+++ b/src/templates/chat/opposed.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/range.html
+++ b/src/templates/chat/range.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/range.html
+++ b/src/templates/chat/range.html
@@ -3,7 +3,7 @@
     <span class="message-metadata">
           <time class="message-timestamp">{{timeSince message.timestamp}}</time>
         {{#if user.isGM}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
       </span>
     {{#if message.flavor}}

--- a/src/templates/chat/roll.html
+++ b/src/templates/chat/roll.html
@@ -5,10 +5,11 @@
         {{#if user.isGM}}
             {{# if (eq message.flags.od6s.isVisible false)}}
                 <a class="button message-reveal" data-message-id="{{message._id}}"
-                   title="{{localize 'OD6S.REVEAL_DIFFICULTY'}}">
-                        <i class="fas fa-eye"></i></a>
+                   title="{{localize 'OD6S.REVEAL_DIFFICULTY'}}"
+                   aria-label="{{localize 'OD6S.REVEAL_DIFFICULTY'}}">
+                        <i class="fas fa-eye" aria-hidden="true"></i></a>
             {{/if}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
         </span>
     {{#if message.flavor}}
@@ -99,8 +100,11 @@
                                     "OD6S.DIFFICULTY"}}: {{message.flags.od6s.difficulty}}</div>
                             <div class="modifiers-button"
                                  data-message-id="{{message._id}}"
-                                 title="{{localize "OD6S.SHOW_MODIFIERS"}}">
-                                <i class="fas fa-plus modifier-button"></i>
+                                 title="{{localize "OD6S.SHOW_MODIFIERS"}}"
+                                 role="button"
+                                 tabindex="0"
+                                 aria-label="{{localize "OD6S.SHOW_MODIFIERS"}}">
+                                <i class="fas fa-plus modifier-button" aria-hidden="true"></i>
                             </div>
                         </div>
                         <div class="modifiers-display" id="modifiers-display-{{message._id}}">
@@ -178,8 +182,11 @@
                     {{#if message.flags.od6s.damageModifiers.length}}
                             <div class="damage-modifiers-button"
                                  data-message-id="{{message._id}}"
-                                 title="{{localize "OD6S.SHOW_MODIFIERS"}}">
-                                <i class="fas fa-plus modifier-button"></i>
+                                 title="{{localize "OD6S.SHOW_MODIFIERS"}}"
+                                 role="button"
+                                 tabindex="0"
+                                 aria-label="{{localize "OD6S.SHOW_MODIFIERS"}}">
+                                <i class="fas fa-plus modifier-button" aria-hidden="true"></i>
                             </div>
                         </div>
                         <div class="damage-modifiers-display" id="damage-modifiers-display-{{message._id}}">
@@ -233,8 +240,8 @@
         {{#unless message.flags.od6s.isOpposed}}
             <div class="message-oppose" style="text-align: right"
                  data-message-id="{{message._id}}">
-                <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}"><i
-                        class="fas fa-exchange-alt"></i></a>
+                <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}" aria-label="{{localize "OD6S.OPPOSE"}}"><i
+                        class="fas fa-exchange-alt" aria-hidden="true"></i></a>
             </div>
         {{/unless}}
     {{/if}}

--- a/src/templates/chat/roll.html
+++ b/src/templates/chat/roll.html
@@ -6,10 +6,11 @@
             {{# if (eq message.flags.od6s.isVisible false)}}
                 <a class="button message-reveal" data-message-id="{{message._id}}"
                    title="{{localize 'OD6S.REVEAL_DIFFICULTY'}}"
+                   role="button" tabindex="0"
                    aria-label="{{localize 'OD6S.REVEAL_DIFFICULTY'}}">
                         <i class="fas fa-eye" aria-hidden="true"></i></a>
             {{/if}}
-            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <a class="button message-delete" data-action="deleteMessage" title="{{localize "OD6S.DELETE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.DELETE"}}"><i class="fas fa-trash" aria-hidden="true"></i></a>
         {{/if}}
         </span>
     {{#if message.flavor}}
@@ -18,10 +19,12 @@
         </span>
         {{#unless message.flags.od6s.isExplosive}}
             {{#if (isAttack message.flags.od6s.subtype) }}
-                {{localize "OD6S.ATTACKING"}}&nbsp
+                {{localize "OD6S.ATTACKING"}}&nbsp;
                 {{#if user.isGM}}
                 <span class="choose-target" title="{{localize "OD6S.CHANGE_TARGET"}}"
-                      data-message-id="{{message._id}}">
+                      data-message-id="{{message._id}}"
+                      role="button" tabindex="0"
+                      aria-label="{{localize "OD6S.CHANGE_TARGET"}}">
                 {{else}}
                 <span>
                 {{/if}}
@@ -96,7 +99,7 @@
                     {{#if message.flags.od6s.modifiers.length}}
                         <div class="flexrow">
                             <div{{#if user.isGM}}
-                            class="edit-difficulty" data-message-id="{{message._id}}"{{/if}}>{{localize
+                            class="edit-difficulty" data-message-id="{{message._id}}" role="button" tabindex="0" aria-label="{{localize "OD6S.EDIT_DIFFICULTY"}}"{{/if}}>{{localize
                                     "OD6S.DIFFICULTY"}}: {{message.flags.od6s.difficulty}}</div>
                             <div class="modifiers-button"
                                  data-message-id="{{message._id}}"
@@ -118,7 +121,7 @@
                     {{else}}
                         {{#unless (eq message.flags.od6s.type 'simple')}}
                             <div{{#if user.isGM}}
-                            class="edit-difficulty" data-message-id="{{message._id}}"{{/if}}>{{localize
+                            class="edit-difficulty" data-message-id="{{message._id}}" role="button" tabindex="0" aria-label="{{localize "OD6S.EDIT_DIFFICULTY"}}"{{/if}}>{{localize
                                     "OD6S.DIFFICULTY"}}: {{message.flags.od6s.difficulty}}</div>
                         {{/unless}}
                     {{/if}}
@@ -173,7 +176,7 @@
                     <div class="damage-display flexrow">
                         <div{{#if (isGmOrOwner message.speaker.actor)}}
                         class="edit-damage" data-message-id="{{message._id}}"
-                        data-damage="{{message.flags.od6s.damageScore}}"{{/if}}>
+                        data-damage="{{message.flags.od6s.damageScore}}" role="button" tabindex="0" aria-label="{{localize "OD6S.EDIT_DAMAGE"}}"{{/if}}>
                             {{message.flags.od6s.damageDice.dice}}D+{{
                         message.flags.od6s.damageDice.pips}}{{#if (ne message.flags.od6s.damageScaleBonus 0)}}
                             {{~showScaleDamage message.flags.od6s.damageScaleBonus}}
@@ -240,7 +243,7 @@
         {{#unless message.flags.od6s.isOpposed}}
             <div class="message-oppose" style="text-align: right"
                  data-message-id="{{message._id}}">
-                <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}" aria-label="{{localize "OD6S.OPPOSE"}}"><i
+                <a class="button message-oppose-button" title="{{localize "OD6S.OPPOSE"}}" role="button" tabindex="0" aria-label="{{localize "OD6S.OPPOSE"}}"><i
                         class="fas fa-exchange-alt" aria-hidden="true"></i></a>
             </div>
         {{/unless}}


### PR DESCRIPTION
## Summary
Addresses the chat-accessibility punch-list from #80:

- **Aria/icons**: icon-only buttons in `src/templates/chat/*.html` get `aria-label` from existing localized strings; their inner `<i>` gets `aria-hidden="true"` so screen readers announce the action rather than icon-font noise.
- **Keyboard activation**: `.modifiers-button` / `.damage-modifiers-button` are now `role="button"` + `tabindex="0"`, with a delegated `keydown` handler in `chat-log-listeners.ts` that activates them on Enter/Space (they were click-only).
- **Semantics on the message**: `tagRollMode` sets `role="article"` on every chat message and an `aria-label` combining the roll-mode label and speaker alias for non-public rolls, complementing the visible badge from #77.
- **Focus-visible**: hover styles for header buttons, oppose, choose-target, edit-difficulty/-damage, and the modifier toggles are mirrored under `:focus-visible` with an accent outline (WCAG 2.4.7).
- **Color-blind dice cues**: `.roll.max/.success` get bold + underline, `.roll.min/.failure` bold + line-through, so the success/failure signal no longer depends on green vs red alone.

Closes #80

## Test plan
- [x] `pnpm run check` (lint + typecheck + unit + domain)
- [ ] Manual: tab through a roll chat card, confirm focus rings appear and modifier toggles activate via Enter/Space
- [ ] Manual: VoiceOver/NVDA reads "Private — Alias" / "GM — Alias" on whispered rolls and announces "Delete", "Reveal Difficulty to players", "Oppose" on icon buttons
- [ ] Manual: with a color-blindness simulator (e.g. deuteranopia), success/failure dice are still distinguishable via underline/strike-through