### PR TITLE
test(data): #131 cover WeaponData.migrateData and document migration policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,24 @@ override via `FOUNDRY_URL`, `FOUNDRY_USER`, `FOUNDRY_PASSWORD`.
 
 The probes are documented in [docs/test-runbook.md](docs/test-runbook.md).
 
+## Migrating data shape changes
+
+Two paths depending on what changed:
+
+- **Renaming, removing, or retyping a `system.*` field on a single
+  document type** → override `static migrateData(source)` on the
+  `TypeDataModel` subclass. Foundry calls it during construction
+  *before* validation, so old documents stop tripping the validator
+  the first time they load. Keep the body pure (just shuffle keys on
+  `source`) and extract it to an exported helper so it can be unit-
+  tested without Foundry globals — see `src/module/data/item/weapon.ts`
+  + `weapon.test.ts` for the worked example.
+- **Anything that needs to iterate documents, touch flags, edit
+  scenes, or update embedded effects** → add a step to
+  `MIGRATION_STEPS` in `src/module/system/migration.ts`. These run
+  once per world on upgrade, gated by the stored `migrationVersion`
+  setting.
+
 ## Code style
 
 - TypeScript across `src/module/`. The bundle is built with esbuild

--- a/src/module/data/item/weapon-migration.ts
+++ b/src/module/data/item/weapon-migration.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure migration body for `WeaponData.migrateData`. Lives in its own file so
+ * unit tests can import it without pulling the rest of `weapon.ts` (which
+ * touches the `foundry` global at module load).
+ *
+ * - `range.{short,medium,long}` were `NumberField`s pre-2.5.0; switched to
+ *   `StringField` so attribute-relative syntax (`AGI+2`) works again. Old
+ *   numeric values get re-stringified.
+ * - `subtype` schema initial is the raw i18n key (`OD6S.RANGED`). All
+ *   consumers (isRanged/isMuscle/isExplosive helpers, sheet `<option>`
+ *   values) operate on localized strings, so the stored value is normalized
+ *   to its localized form. `localize` is injected; production passes
+ *   `game.i18n.localize` if available, else nothing (which is a no-op that
+ *   runs again on the next construction once i18n is ready).
+ */
+export function migrateWeaponSource(
+  source: Record<string, unknown>,
+  localize?: (key: string) => string,
+): Record<string, unknown> {
+  if (source.range && typeof source.range === "object") {
+    const range = source.range as Record<string, unknown>;
+    for (const key of ["short", "medium", "long"]) {
+      if (typeof range[key] !== "string") range[key] = String(range[key] ?? "0");
+    }
+  }
+  if (typeof source.subtype === "string" && source.subtype.startsWith("OD6S.") && localize) {
+    const localized = localize(source.subtype);
+    if (localized && localized !== source.subtype) source.subtype = localized;
+  }
+  return source;
+}

--- a/src/module/data/item/weapon.test.ts
+++ b/src/module/data/item/weapon.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { migrateWeaponSource } from "./weapon-migration";
+
+describe("migrateWeaponSource", () => {
+  describe("range coercion (pre-#17 → 2.5.0+)", () => {
+    it("re-stringifies numeric range fields left over from the old NumberField schema", () => {
+      const source: Record<string, unknown> = {
+        range: { short: 5, medium: 10, long: 25 },
+      };
+      migrateWeaponSource(source);
+      expect(source.range).toEqual({ short: "5", medium: "10", long: "25" });
+    });
+
+    it("leaves attribute-relative range strings untouched", () => {
+      const source: Record<string, unknown> = {
+        range: { short: "AGI+2", medium: "AGI+4", long: "AGI+8" },
+      };
+      migrateWeaponSource(source);
+      expect(source.range).toEqual({ short: "AGI+2", medium: "AGI+4", long: "AGI+8" });
+    });
+
+    it("backfills missing keys with '0'", () => {
+      const source: Record<string, unknown> = { range: {} };
+      migrateWeaponSource(source);
+      expect(source.range).toEqual({ short: "0", medium: "0", long: "0" });
+    });
+
+    it("is a no-op when range is absent", () => {
+      const source: Record<string, unknown> = { damaged: 0 };
+      migrateWeaponSource(source);
+      expect(source.range).toBeUndefined();
+    });
+  });
+
+  describe("subtype localization (#42)", () => {
+    it("replaces a stored i18n key with its localized form", () => {
+      const source: Record<string, unknown> = { subtype: "OD6S.RANGED" };
+      migrateWeaponSource(source, (k) => (k === "OD6S.RANGED" ? "Ranged" : k));
+      expect(source.subtype).toBe("Ranged");
+    });
+
+    it("leaves an already-localized string untouched", () => {
+      const source: Record<string, unknown> = { subtype: "Ranged" };
+      migrateWeaponSource(source, () => "should-not-be-called");
+      expect(source.subtype).toBe("Ranged");
+    });
+
+    it("leaves the key in place if localize returns the key (i18n not ready yet)", () => {
+      const source: Record<string, unknown> = { subtype: "OD6S.RANGED" };
+      migrateWeaponSource(source, (k) => k);
+      expect(source.subtype).toBe("OD6S.RANGED");
+    });
+
+    it("is a no-op when localize is not provided", () => {
+      const source: Record<string, unknown> = { subtype: "OD6S.RANGED" };
+      migrateWeaponSource(source);
+      expect(source.subtype).toBe("OD6S.RANGED");
+    });
+
+    it("does not touch non-OD6S subtype strings", () => {
+      const source: Record<string, unknown> = { subtype: "custom-thing" };
+      migrateWeaponSource(source, () => "wrong");
+      expect(source.subtype).toBe("custom-thing");
+    });
+  });
+
+  it("returns the same source object so callers can pass through to super.migrateData", () => {
+    const source: Record<string, unknown> = { range: { short: 1, medium: 2, long: 3 } };
+    expect(migrateWeaponSource(source)).toBe(source);
+  });
+});

--- a/src/module/data/item/weapon.ts
+++ b/src/module/data/item/weapon.ts
@@ -1,6 +1,7 @@
 import { baseSchema } from "./fields/base";
 import { equipmentSchema } from "./fields/equipment";
 import { equipSchema } from "./fields/equip";
+import { migrateWeaponSource } from "./weapon-migration";
 
 const fields = foundry.data.fields;
 
@@ -15,25 +16,9 @@ function blastZoneSchema() {
 
 export default class WeaponData extends foundry.abstract.TypeDataModel {
   static migrateData(source: Record<string, unknown>) {
-    if (source.range && typeof source.range === "object") {
-      const range = source.range as Record<string, unknown>;
-      for (const key of ["short", "medium", "long"]) {
-        if (typeof range[key] !== "string") range[key] = String(range[key] ?? "0");
-      }
-    }
-    // Normalize subtype to the localized form. Helpers (isRanged,
-    // isMuscle, isExplosive) and the weapon-sheet <option> values all
-    // operate on localized strings, but the schema's initial is the
-    // raw i18n key — so a brand-new weapon's stored subtype never
-    // matches any rendered option until the user manually picks one.
-    // localize() is a no-op when called before i18n is ready (returns
-    // the key); we re-run it on every construction so the value
-    // self-heals once i18n is up.
-    if (typeof source.subtype === "string" && source.subtype.startsWith("OD6S.")) {
-      const localized = (game as { i18n?: { localize?: (k: string) => string } } | undefined)
-        ?.i18n?.localize?.(source.subtype);
-      if (localized && localized !== source.subtype) source.subtype = localized;
-    }
+    const localize = (game as { i18n?: { localize?: (k: string) => string } } | undefined)
+      ?.i18n?.localize?.bind((game as { i18n?: unknown }).i18n);
+    migrateWeaponSource(source, localize);
     return super.migrateData(source);
   }
 

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -2,6 +2,21 @@
  * System data migration for world upgrades.
  * Runs once per version bump via the system version stored in world settings.
  *
+ * Two-tier migration policy
+ * -------------------------
+ * 1. **Per-document field-shape changes** (rename a `system.*` field, change
+ *    a default, switch a field type): override `static migrateData(source)`
+ *    on the relevant `TypeDataModel` subclass. Foundry calls it during
+ *    construction, *before* validation, so old documents load cleanly the
+ *    first time the world opens. See `data/item/weapon.ts` for an example
+ *    (range NumberField → StringField, subtype i18n-key → localized).
+ *
+ * 2. **Cross-document, flag-level, or scene-level changes** stay in this
+ *    file as a `MIGRATION_STEPS` entry. These run once per world via the
+ *    stored `migrationVersion` setting and can iterate `game.actors`,
+ *    `game.scenes.tokens`, etc. — things `migrateData` can't reach because
+ *    it only sees one document's `source` object.
+ *
  * To audit before/after document state, persist the debug flag *before*
  * reloading the world (otherwise migrations fire on the `ready` hook before
  * you can touch the console):

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -8,8 +8,10 @@
  *    a default, switch a field type): override `static migrateData(source)`
  *    on the relevant `TypeDataModel` subclass. Foundry calls it during
  *    construction, *before* validation, so old documents load cleanly the
- *    first time the world opens. See `data/item/weapon.ts` for an example
- *    (range NumberField → StringField, subtype i18n-key → localized).
+ *    first time the world opens. See `src/module/data/item/weapon.ts` for
+ *    an example (range NumberField → StringField, subtype i18n-key →
+ *    localized) and `src/module/data/item/weapon-migration.ts` +
+ *    `weapon.test.ts` for the pure-helper / unit-test pattern.
  *
  * 2. **Cross-document, flag-level, or scene-level changes** stay in this
  *    file as a `MIGRATION_STEPS` entry. These run once per world via the


### PR DESCRIPTION
## Summary

Scope-corrected from the issue plan after a full audit of `src/module/data/`:

- **Audit finding:** of 6 commits touching DataModels since 2.0, only `weapon.ts` has had persisted field-shape changes (range `NumberField` → `StringField` in #25, subtype i18n-key → localized in #43). Both already had `migrateData` overrides — the gap was no test coverage. The other 24 models have not had field renames, removals, or type changes; adding empty `super.migrateData` passthroughs would be boilerplate without value.
- **Coverage:** extract the weapon migration body to a pure `weapon-migration.ts` helper (unit tests can't import `weapon.ts` — transitively pulls the `foundry` global at module load) and add `weapon.test.ts` with frozen pre-migration fixtures for both branches plus the no-op cases.
- **Policy:** document the per-document (`migrateData`) vs world-level (`MIGRATION_STEPS`) split in `system/migration.ts` and `CONTRIBUTING.md`. The weapon test serves as the worked template for the next field shape change.

## Why this is the right shape

The issue's original plan — *"Add migrateData to each model with a real change"* — is satisfied by the audit (one model, already done). What was missing was the **infrastructure** that makes the next migration cheap: a colocated unit-test pattern that doesn't need Foundry mocks, and explicit policy guidance for which file new migrations belong in.

## Test plan

- [x] `pnpm run check` — 0 errors, 569 lint warnings, 382 unit (was 372) + 327 domain tests pass.
- New `weapon.test.ts` covers: range numeric→string coercion, attribute-relative range pass-through, missing-keys backfill, range-absent no-op, subtype localize replace, already-localized pass-through, i18n-not-ready no-op, missing-localize no-op, non-OD6S subtype pass-through, and source-object identity.

Closes #131