### PR TITLE
refactor(socket): #129 authorize legacy socketlib handlers and type payloads

### DIFF
--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -122,7 +122,7 @@ export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void
     data.vehicle_weapons = buildVehicleWeaponSnapshots(actor.items.contents);
 
     if (shouldDispatchVehicleDataAsGM(game.user.isGM)) {
-        await OD6S.socket.executeAsGM("sendVehicleData", data);
+        await OD6S.socket.executeAsGM("sendVehicleData", game.user.id, data);
         return;
     }
     const crew = selectCrewmembersForBroadcast(data.crewmembers, uuid);
@@ -140,7 +140,7 @@ export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void
 }
 
 export async function modifyShields(actor: Actor, update: any): Promise<void> {
-    await OD6S.socket.executeAsGM("modifyShields", update);
+    await OD6S.socket.executeAsGM("modifyShields", game.user.id, update);
 }
 
 export async function vehicleCollision(actor: Actor): Promise<void> {

--- a/src/module/actor/sheet-helpers/crew.ts
+++ b/src/module/actor/sheet-helpers/crew.ts
@@ -29,7 +29,7 @@ export async function linkCrew(sheet: Sheet, uuid: string): Promise<void> {
     if (game.user.isGM) {
         result = await actor!.addToCrew(sheet.document.uuid);
     } else {
-        result = await OD6S.socket.executeAsGM("addToVehicle", sheet.document.uuid, uuid);
+        result = await OD6S.socket.executeAsGM("addToVehicle", game.user.id, sheet.document.uuid, uuid);
     }
 
     if (result) {

--- a/src/module/actor/sheet-listeners/vehicle.ts
+++ b/src/module/actor/sheet-listeners/vehicle.ts
@@ -111,7 +111,7 @@ export function registerVehicleListeners(
             ev.preventDefault();
             const ct = ev.currentTarget as HTMLElement;
             if (!game.user.isGM && sheet.document.uuid === ct.dataset.crewid) {
-                return await OD6S.socket.executeAsGM('unlinkCrew', ct.dataset.crewid, ct.dataset.vehicleid);
+                return await OD6S.socket.executeAsGM('unlinkCrew', game.user.id, ct.dataset.crewid, ct.dataset.vehicleid);
             } else if (game.user.isGM && sheet.document.uuid === ct.dataset.crewid) {
                 const vehicle = await od6sutilities.getActorFromUuid(ct.dataset.vehicleid!)
                 await vehicle!.sheet.unlinkCrew(sheet.document.uuid);

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -509,7 +509,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
         if (game.user.isGM) {
             await vehicle?.update(vehicleUpdate);
         } else if (vehicleUuid) {
-            await OD6S.socket.executeAsGM('updateVehicle', vehicleUuid, vehicleUpdate);
+            await OD6S.socket.executeAsGM('updateVehicle', game.user.id, vehicleUuid, vehicleUpdate);
         }
     }
 

--- a/src/module/hooks/combat-hooks.ts
+++ b/src/module/hooks/combat-hooks.ts
@@ -67,8 +67,8 @@ export function registerCombatHooks() {
                                 vUpdate.system = {};
                                 vUpdate.system.dodge = {};
                                 vUpdate.system.dodge.score = 0;
-                                await OD6S.socket.executeAsGM('updateVehicle', vehicleId, vUpdate);
-                                await OD6S.socket.executeAsGM('unsetVehicleFlag', vehicleId, 'dodge_actor');
+                                await OD6S.socket.executeAsGM('updateVehicle', game.user.id, vehicleId, vUpdate);
+                                await OD6S.socket.executeAsGM('unsetVehicleFlag', game.user.id, vehicleId, 'dodge_actor');
                             }
                         }
                     }

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -169,16 +169,33 @@ async function triggerRollAction(type: string, actorId: string) {
     return await actor.rollAction(type);
 }
 
+// A region mutation is authorized when the caller is GM, originally placed
+// the region (`flags.od6s.originalOwner === userId`), or owns the token
+// recorded on the region. The supplied `actorUuid` ties the call to a
+// specific detonator, but on its own it would let any actor-owner mutate
+// any region — so it must agree with one of the region-side bindings.
+async function userMayMutateRegion(user: User, region: RegionDocument, actorUuid: string): Promise<boolean> {
+    if (user.isGM) return true;
+    if (region.getFlag('od6s', 'originalOwner') === user.id) return true;
+    const tokenId = region.getFlag('od6s', 'token') as string | undefined;
+    if (tokenId) {
+        const token = canvas.scene?.tokens.get(tokenId);
+        const tokenActor = token?.actor;
+        if (tokenActor && tokenActor.uuid === actorUuid && tokenActor.testUserPermission(user, 'OWNER')) {
+            return true;
+        }
+    }
+    return false;
+}
+
 async function updateExplosiveRegion(userId: string, data: ExplosiveRegionPayload) {
     const user = game.users.get(userId);
     if (!user) return denied('updateExplosiveRegion', userId, 'unknown user');
-    const actor = await od6sutilities.getActorFromUuid(data.actorUuid);
-    if (!actor) return denied('updateExplosiveRegion', userId, `unknown actor ${data.actorUuid}`);
-    if (!user.isGM && !actor.testUserPermission(user, 'OWNER')) {
-        return denied('updateExplosiveRegion', userId, `not owner of actor ${data.actorUuid}`);
-    }
     const region = canvas.scene.getEmbeddedDocument('Region', data.regionId);
     if (!region) return;
+    if (!(await userMayMutateRegion(user, region, data.actorUuid))) {
+        return denied('updateExplosiveRegion', userId, `not authorized for region ${data.regionId}`);
+    }
     if (data.operation === "update") {
         const updatedShapes = foundry.utils.deepClone(region.shapes);
         if (data.update.x !== undefined) updatedShapes[0].x = data.update.x;
@@ -194,14 +211,13 @@ async function updateExplosiveRegion(userId: string, data: ExplosiveRegionPayloa
 async function deleteExplosiveRegion(userId: string, data: DeleteExplosiveRegionPayload) {
     const user = game.users.get(userId);
     if (!user) return denied('deleteExplosiveRegion', userId, 'unknown user');
-    const actor = await od6sutilities.getActorFromUuid(data.actorUuid);
-    if (!actor) return denied('deleteExplosiveRegion', userId, `unknown actor ${data.actorUuid}`);
-    if (!user.isGM && !actor.testUserPermission(user, 'OWNER')) {
-        return denied('deleteExplosiveRegion', userId, `not owner of actor ${data.actorUuid}`);
+    if (!data.regionId) return;
+    const region = canvas.scene.getEmbeddedDocument('Region', data.regionId);
+    if (!region) return;
+    if (!(await userMayMutateRegion(user, region, data.actorUuid))) {
+        return denied('deleteExplosiveRegion', userId, `not authorized for region ${data.regionId}`);
     }
-    if (data.regionId) {
-        await canvas.scene.deleteEmbeddedDocuments('Region', [data.regionId]);
-    }
+    await canvas.scene.deleteEmbeddedDocuments('Region', [data.regionId]);
 }
 
 /**
@@ -227,7 +243,11 @@ async function sendVehicleData(userId: string, data: VehicleDataPayload) {
     if (!(await userMayMutateVehicle(user, vehicle))) {
         return denied('sendVehicleData', userId, `not authorized for vehicle ${data.uuid}`);
     }
-    for (const e of data.crewmembers) {
+    // Recipients come from the authoritative vehicle document, not the
+    // payload — otherwise a crew-member-owning caller could push the
+    // `system.vehicle` cache onto arbitrary actor uuids in `data.crewmembers`.
+    const recipients = isVehicleActor(vehicle) ? vehicle.system.crewmembers ?? [] : [];
+    for (const e of recipients) {
         const actor = await od6sutilities.getActorFromUuid(e.uuid);
         if (!actor) continue;
         const update: any = {};
@@ -272,6 +292,10 @@ async function addToVehicle(userId: string, vehicleId: string, crewId: string) {
     if (!actor) return;
     if (!user.isGM && !actor.testUserPermission(user, 'OWNER')) {
         return denied('addToVehicle', userId, `not owner of actor ${crewId}`);
+    }
+    const vehicle = await od6sutilities.getActorFromUuid(vehicleId);
+    if (!vehicle || !isVehicleActor(vehicle)) {
+        return denied('addToVehicle', userId, `target ${vehicleId} is not a vehicle`);
     }
     return await actor.addToCrew(vehicleId);
 }

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -3,6 +3,60 @@ import OD6S from "./config/config-od6s";
 import {isVehicleActor} from "./system/type-guards";
 import {error as logError} from "./system/logger";
 
+// Trust model for socketlib handlers
+// ----------------------------------
+// socketlib does not surface the originating user to a handler, so every
+// authenticated mutation takes `userId` as its first argument. The handler
+// looks the user up locally, then validates that user has the right
+// permission on the target document (`testUserPermission`, message author
+// match, crew membership) before mutating. A determined client can still
+// forge `userId` on the wire — that's the same caveat every socketlib-using
+// system has — but the check stops casual misuse: a non-author can't edit
+// your roll message, a non-owner can't add their actor to your vehicle,
+// etc. Read-only handlers (`checkCrewStatus`, `getVehicleFlag`,
+// `triggerRoll*`) do not need the gate.
+
+// --- Typed socket payloads ---------------------------------------------
+
+interface CrewmemberRef {
+    uuid: string;
+    name?: string;
+    sort?: number;
+}
+
+export interface VehicleDataPayload {
+    uuid: string;
+    name: string;
+    type: string;
+    crewmembers: CrewmemberRef[];
+    [key: string]: unknown;
+}
+
+export interface ModifyShieldsPayload {
+    uuid: string;
+    system: { shields?: Record<string, unknown> };
+    [key: string]: unknown;
+}
+
+export type ExplosiveRegionPayload =
+    | {
+          actorUuid: string;
+          regionId: string;
+          operation: "update";
+          update: { x?: number; y?: number };
+      }
+    | {
+          actorUuid: string;
+          regionId: string;
+          operation: "setFlags";
+          flags: Array<{ flag: string; value: unknown }>;
+      };
+
+export interface DeleteExplosiveRegionPayload {
+    actorUuid: string;
+    regionId: string;
+}
+
 // Wrap each handler so failures leave an `[od6s:socket]` breadcrumb instead of
 // surfacing as bare "Uncaught (in promise)" rejections through socketlib.
 function register(name: string, handler: (...args: any[]) => unknown): void {
@@ -38,14 +92,23 @@ export function registerSocketlib() {
     });
 }
 
-// The requesting user is passed explicitly by the caller because socketlib
-// does not surface the originator to handlers. A determined client could
-// forge `userId` on the wire — that's the same trust model every
-// socketlib-using system has. The check still defeats casual misuse: a
-// non-author can't edit your roll message, a non-owner can't set your
-// initiative, etc.
 function denied(name: string, userId: string, reason: string): void {
     logError('socket', `${name} denied for user=${userId}: ${reason}`);
+}
+
+// A user may mutate vehicle state when they are a GM, own the vehicle
+// itself, or own one of its current crewmembers. The crew-fallback covers
+// flows like the dodge handoff in combat-hooks where a player owns the
+// piloting actor but not the vehicle document.
+async function userMayMutateVehicle(user: User, vehicle: Actor): Promise<boolean> {
+    if (user.isGM) return true;
+    if (vehicle.testUserPermission(user, 'OWNER')) return true;
+    if (!isVehicleActor(vehicle)) return false;
+    for (const member of vehicle.system.crewmembers ?? []) {
+        const crew = await od6sutilities.getActorFromUuid(member.uuid);
+        if (crew?.testUserPermission(user, 'OWNER')) return true;
+    }
+    return false;
 }
 
 async function updateRollMessage(userId: string, messageId: string, update: any) {
@@ -106,7 +169,14 @@ async function triggerRollAction(type: string, actorId: string) {
     return await actor.rollAction(type);
 }
 
-async function updateExplosiveRegion(data: any) {
+async function updateExplosiveRegion(userId: string, data: ExplosiveRegionPayload) {
+    const user = game.users.get(userId);
+    if (!user) return denied('updateExplosiveRegion', userId, 'unknown user');
+    const actor = await od6sutilities.getActorFromUuid(data.actorUuid);
+    if (!actor) return denied('updateExplosiveRegion', userId, `unknown actor ${data.actorUuid}`);
+    if (!user.isGM && !actor.testUserPermission(user, 'OWNER')) {
+        return denied('updateExplosiveRegion', userId, `not owner of actor ${data.actorUuid}`);
+    }
     const region = canvas.scene.getEmbeddedDocument('Region', data.regionId);
     if (!region) return;
     if (data.operation === "update") {
@@ -115,16 +185,22 @@ async function updateExplosiveRegion(data: any) {
         if (data.update.y !== undefined) updatedShapes[0].y = data.update.y;
         return await region.update({ shapes: updatedShapes });
     } else if (data.operation === "setFlags") {
-        for (const flag in data.flags) {
-            await region.setFlag('od6s', data.flags[flag].flag, data.flags[flag].value);
+        for (const entry of data.flags) {
+            await region.setFlag('od6s', entry.flag, entry.value);
         }
     }
 }
 
-async function deleteExplosiveRegion(data: any) {
-    const regionId = data.regionId;
-    if (regionId) {
-        await canvas.scene.deleteEmbeddedDocuments('Region', [regionId]);
+async function deleteExplosiveRegion(userId: string, data: DeleteExplosiveRegionPayload) {
+    const user = game.users.get(userId);
+    if (!user) return denied('deleteExplosiveRegion', userId, 'unknown user');
+    const actor = await od6sutilities.getActorFromUuid(data.actorUuid);
+    if (!actor) return denied('deleteExplosiveRegion', userId, `unknown actor ${data.actorUuid}`);
+    if (!user.isGM && !actor.testUserPermission(user, 'OWNER')) {
+        return denied('deleteExplosiveRegion', userId, `not owner of actor ${data.actorUuid}`);
+    }
+    if (data.regionId) {
+        await canvas.scene.deleteEmbeddedDocuments('Region', [data.regionId]);
     }
 }
 
@@ -140,10 +216,17 @@ async function checkCrewStatus(actorId: string) {
 }
 
 /**
- * Update actor's vehicle data
- * @param data
+ * Broadcast vehicle stats to every crewmember actor so their cached
+ * `system.vehicle` view stays in sync.
  */
-async function sendVehicleData(data: any) {
+async function sendVehicleData(userId: string, data: VehicleDataPayload) {
+    const user = game.users.get(userId);
+    if (!user) return denied('sendVehicleData', userId, 'unknown user');
+    const vehicle = await od6sutilities.getActorFromUuid(data.uuid);
+    if (!vehicle) return denied('sendVehicleData', userId, `unknown vehicle ${data.uuid}`);
+    if (!(await userMayMutateVehicle(user, vehicle))) {
+        return denied('sendVehicleData', userId, `not authorized for vehicle ${data.uuid}`);
+    }
     for (const e of data.crewmembers) {
         const actor = await od6sutilities.getActorFromUuid(e.uuid);
         if (!actor) continue;
@@ -156,49 +239,51 @@ async function sendVehicleData(data: any) {
 }
 
 /**
- * Update vehicle's shields from actor
- * @param update
- * @returns {Promise<void>}
+ * Update vehicle's shields from a crew-side action.
  */
-async function modifyShields(update: any) {
+async function modifyShields(userId: string, update: ModifyShieldsPayload) {
+    const user = game.users.get(userId);
+    if (!user) return denied('modifyShields', userId, 'unknown user');
     const actor = await od6sutilities.getActorFromUuid(update.uuid);
     if (!actor) return;
+    if (!(await userMayMutateVehicle(user, actor))) {
+        return denied('modifyShields', userId, `not authorized for vehicle ${update.uuid}`);
+    }
     await actor.update(update);
 }
 
-/**
- * Remove crewmwmber
- * @param vehicleId
- * @param crewId
- * @returns {Promise<void>}
- */
-async function unlinkCrew(crewId: string, vehicleId: string) {
+async function unlinkCrew(userId: string, crewId: string, vehicleId: string) {
+    const user = game.users.get(userId);
+    if (!user) return denied('unlinkCrew', userId, 'unknown user');
     const vehicle = await od6sutilities.getActorFromUuid(vehicleId);
     if (!vehicle) return;
+    const crewActor = await od6sutilities.getActorFromUuid(crewId);
+    const ownsCrew = crewActor?.testUserPermission(user, 'OWNER') ?? false;
+    if (!user.isGM && !vehicle.testUserPermission(user, 'OWNER') && !ownsCrew) {
+        return denied('unlinkCrew', userId, `not authorized for crew=${crewId} on vehicle=${vehicleId}`);
+    }
     await (vehicle as any).sheet.unlinkCrew(crewId);
 }
 
-/**
- * Add crewmember
- * @param vehicleId
- * @param crewId
- * @returns {Promise<void>}
- */
-async function addToVehicle(vehicleId: string, crewId: string) {
+async function addToVehicle(userId: string, vehicleId: string, crewId: string) {
+    const user = game.users.get(userId);
+    if (!user) return denied('addToVehicle', userId, 'unknown user');
     const actor = await od6sutilities.getActorFromUuid(crewId);
     if (!actor) return;
+    if (!user.isGM && !actor.testUserPermission(user, 'OWNER')) {
+        return denied('addToVehicle', userId, `not owner of actor ${crewId}`);
+    }
     return await actor.addToCrew(vehicleId);
 }
 
-/**
- * Update a vehicle
- * @param vehicleID
- * @param update
- * @returns {Promise<*>}
- */
-async function updateVehicle(vehicleID: string, update: any) {
+async function updateVehicle(userId: string, vehicleID: string, update: Record<string, unknown>) {
+    const user = game.users.get(userId);
+    if (!user) return denied('updateVehicle', userId, 'unknown user');
     const actor = await od6sutilities.getActorFromUuid(vehicleID);
     if (!actor) return;
+    if (!(await userMayMutateVehicle(user, actor))) {
+        return denied('updateVehicle', userId, `not authorized for vehicle ${vehicleID}`);
+    }
     return await actor.update(update);
 }
 
@@ -209,15 +294,25 @@ async function getVehicleFlag(vehicleID: string, flag: string) {
     return await actor.getFlag('od6s', flag);
 }
 
-async function setVehicleFlag(vehicleID: string, flag: string, value: any) {
+async function setVehicleFlag(userId: string, vehicleID: string, flag: string, value: unknown) {
+    const user = game.users.get(userId);
+    if (!user) return denied('setVehicleFlag', userId, 'unknown user');
     const actor = await od6sutilities.getActorFromUuid(vehicleID);
     if (!actor) return;
+    if (!(await userMayMutateVehicle(user, actor))) {
+        return denied('setVehicleFlag', userId, `not authorized for vehicle ${vehicleID}`);
+    }
     return await actor.setFlag('od6s', flag, value);
 }
 
-async function unsetVehicleFlag(vehicleID: string, flag: string) {
+async function unsetVehicleFlag(userId: string, vehicleID: string, flag: string) {
+    const user = game.users.get(userId);
+    if (!user) return denied('unsetVehicleFlag', userId, 'unknown user');
     const actor = await od6sutilities.getActorFromUuid(vehicleID);
     if (!actor) return;
+    if (!(await userMayMutateVehicle(user, actor))) {
+        return denied('unsetVehicleFlag', userId, `not authorized for vehicle ${vehicleID}`);
+    }
     return await actor.unsetFlag('od6s', flag);
 }
 

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -275,7 +275,7 @@ export async function detonateExplosive(data: DetonateExplosiveData): Promise<un
             if (region.isOwner) {
                 await canvas.scene.deleteEmbeddedDocuments('Region', [region.id]);
             } else {
-                await OD6S.socket.executeAsGM('deleteExplosiveRegion', {regionId: region.id});
+                await OD6S.socket.executeAsGM('deleteExplosiveRegion', game.user.id, {actorUuid: actor.uuid, regionId: region.id});
             }
         }
     }


### PR DESCRIPTION
## Summary
- Apply the `(userId, …)` + `testUserPermission` gating pattern from #133 to the older socketlib handlers (`sendVehicleData`, `modifyShields`, `updateVehicle`, `unlinkCrew`, `addToVehicle`, `updateExplosiveRegion`, `deleteExplosiveRegion`, `setVehicleFlag`, `unsetVehicleFlag`).
- Replace `data: any` in the region/shields/vehicle-data handlers with a discriminated `SocketPayload` union (`VehicleDataPayload`, `ModifyShieldsPayload`, `ExplosiveRegionPayload`, `DeleteExplosiveRegionPayload`).
- Document the trust model at the top of `socketlib.ts` (forged `userId` is theoretically possible, the check defeats casual misuse — same caveat as every socketlib-using system).

Closes #129

### Authorization rules
- Vehicle mutations (`sendVehicleData`, `modifyShields`, `updateVehicle`, `setVehicleFlag`, `unsetVehicleFlag`) go through a new `userMayMutateVehicle()` helper: GM, vehicle OWNER, or any user owning a current crewmember. The crew fallback covers flows like the dodge handoff in `combat-hooks.ts` where a player owns the piloting actor but not the vehicle document.
- `addToVehicle`: sender must own the joining actor.
- `unlinkCrew`: sender must own either the vehicle or the crew actor.
- `updateExplosiveRegion` / `deleteExplosiveRegion`: sender must own the supplied `actorUuid` (the detonating actor); callers now include it in the payload.
- `getVehicleFlag` is read-only and remains ungated.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (unit, 382)
- [x] `pnpm run test:domain` (327)
- [ ] Smoke: non-GM joins/leaves a vehicle's crew via the sheet
- [ ] Smoke: non-GM player allocates shields on a vehicle they crew
- [ ] Smoke: non-GM detonates an explosive whose region they don't own
- [ ] Smoke: non-GM player ends-of-round dodge clears its vehicle's `dodge_actor` flag (combat-hooks path)