### PR TITLE
refactor: #132 v14 polish batch (items 2, 3, 5, 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ### Changed
 
+- v14 polish batch (#132): dropped the dead V1
+  `foundry.appv1.sheets.ActorSheet` / `ItemSheet` `unregisterSheet`
+  calls in `od6s.ts`; routed `system/migration.ts` and
+  `system/schema-version.ts` console output through `logger.ts` so
+  output is debug-flag-gated (`localStorage.od6sDebug`) and tagged
+  consistently; wrapped the async `chat-hooks` (`preDeleteChatMessage`,
+  `updateChatMessage`, `createChatMessage`), `region-hooks`
+  (`updateRegion`, `deleteRegion`), and the `chat-log-listeners`
+  `delegateEvent` shared helper in error boundaries that emit an
+  `[od6s:…]` breadcrumb instead of surfacing as bare unhandled
+  rejections; and replaced the per-actor crew-broadcast `actor.update()`
+  loops in `crew-vehicle.ts` and `socketlib.ts:sendVehicleData` with a
+  single `Actor.updateDocuments` batch (token-actor sync stays
+  per-doc since synthetic actors don't live in `game.actors`).
+
 - Replaced the `Record<string, any>` typing on the central `OD6S`
   config object with a typed `Od6sConfig` interface, and split the
   remaining inline tables out of `config-od6s.ts` into typed

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -126,16 +126,22 @@ export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void
         return;
     }
     const crew = selectCrewmembersForBroadcast(data.crewmembers, uuid);
+    // Batch world-actor updates through Actor.updateDocuments to cut socket
+    // chatter and avoid partial-failure half-states. Token-actor (synthetic)
+    // updates fall back to the per-doc path because they live on a scene's
+    // token collection, not in `game.actors`.
+    const worldUpdates: Array<Record<string, unknown>> = [];
     for (const e of crew) {
         const crewActor = await od6sutilities.getActorFromUuid(e.uuid);
-        if (crewActor) {
-            const update: any = {};
-            update.id = crewActor.id;
-            update._id = crewActor.id;
-            update.system = {}
-            update.system.vehicle = data;
-            await crewActor.update(update);
+        if (!crewActor) continue;
+        if (crewActor.isToken) {
+            await crewActor.update({_id: crewActor.id, system: {vehicle: data}});
+        } else {
+            worldUpdates.push({_id: crewActor.id, system: {vehicle: data}});
         }
+    }
+    if (worldUpdates.length > 0) {
+        await Actor.updateDocuments(worldUpdates);
     }
 }
 

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -46,7 +46,7 @@ export function registerChatHooks() {
         if(message.getFlag('od6s','isExplosive') && game.user.isGM) {
             // Delete the template and clear the flag from the item
             let actor;
-            if (message.speaker.token !== '') {
+            if (message.speaker.token !== null && message.speaker.token !== '') {
                 // @ts-expect-error
                 actor = game!.scenes.get(message.speaker.scene).tokens.get(message.speaker.token).object.actor;
             } else {

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -3,6 +3,7 @@ import OD6S from "../config/config-od6s";
 import { isOpposedQueueEmpty, setOpposedQueueEntry } from "../system/utilities/opposed";
 import {promptResistanceRolls} from "../socketlib";
 import {deriveRollMode} from "./chat-mode";
+import {error as logError} from "../system/logger";
 
 function tagRollMode(msg: any, html: HTMLElement) {
     const mode = deriveRollMode(msg);
@@ -41,6 +42,7 @@ export function registerChatHooks() {
     })
 
     Hooks.on("preDeleteChatMessage", async (message, _data, _diff, _id) => {
+        try {
         if(message.getFlag('od6s','isExplosive') && game.user.isGM) {
             // Delete the template and clear the flag from the item
             let actor;
@@ -70,9 +72,13 @@ export function registerChatHooks() {
             }
             await od6sutilities.wait(100);
         }
+        } catch (err) {
+            logError('chat-hooks', 'preDeleteChatMessage failed', err);
+        }
     })
 
     Hooks.on("updateChatMessage", async (message, data, _diff, _id) => {
+        try {
         if (data.blind === false) {
             const messageLi = document.querySelector(`.message[data-message-id="${data._id}"]`);
             if (messageLi) (messageLi as any).style.display = '';
@@ -132,6 +138,9 @@ export function registerChatHooks() {
         }
 
         await promptResistanceRolls(message);
+        } catch (err) {
+            logError('chat-hooks', 'updateChatMessage failed', err);
+        }
     });
 
     Hooks.on('renderChatMessageHTML', (_message, _html, _data) => {
@@ -139,7 +148,7 @@ export function registerChatHooks() {
     })
 
     Hooks.on('createChatMessage', async function (msg) {
-
+        try {
         if (game.user.isGM) {
             if (msg.getFlag('od6s', 'isOpposable') && OD6S.autoOpposed) {
                 if ((msg.getFlag('od6s', 'type') === 'damage') ||
@@ -198,5 +207,8 @@ export function registerChatHooks() {
         }
 
         await promptResistanceRolls(msg);
+        } catch (err) {
+            logError('chat-hooks', 'createChatMessage failed', err);
+        }
     })
 }

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -6,21 +6,32 @@ import OD6SEditDifficulty from "../apps/edit-difficulty";
 import {OD6SEditDamage} from "../apps/edit-damage";
 import {OD6SChooseTarget} from "../apps/choose-target";
 import {OD6SHandleWildDieForm} from "../apps/handle-wild-die";
+import {error as logError} from "../system/logger";
 
-// Delegated event helper: attaches a listener on a parent that fires when a child matching selector is the target
+// Delegated event helper: attaches a listener on a parent that fires when a child matching selector is the target.
+// Wraps the handler so async failures leave a `[od6s:chat-log]` breadcrumb instead of unhandled rejections.
 function delegateEvent(
     parent: HTMLElement,
     eventType: string,
     selector: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handler: (ev: any) => void,
+    handler: (ev: any) => void | Promise<void>,
 ) {
     parent.addEventListener(eventType, (ev: Event) => {
         const target = (ev.target as Element | null)?.closest(selector);
         if (target && parent.contains(target)) {
             // Make ev.currentTarget behave like jQuery delegation
             Object.defineProperty(ev, 'currentTarget', { value: target, configurable: true });
-            handler(ev);
+            try {
+                const result = handler(ev);
+                if (result && typeof (result as Promise<void>).catch === 'function') {
+                    (result as Promise<void>).catch(err =>
+                        logError('chat-log', `${eventType} ${selector} handler failed`, err),
+                    );
+                }
+            } catch (err) {
+                logError('chat-log', `${eventType} ${selector} handler failed`, err);
+            }
         }
     });
 }

--- a/src/module/hooks/region-hooks.ts
+++ b/src/module/hooks/region-hooks.ts
@@ -1,59 +1,68 @@
 import {od6sutilities} from "../system/utilities";
+import {error as logError} from "../system/logger";
 
 export function registerRegionHooks() {
     // Scene Region hooks for explosive system
     Hooks.on('updateRegion', async (region, change) => {
-        if (!game.user.isGM) return;
-        if (!region.getFlag('od6s', 'explosive')) return;
-        if (change.flags?.od6s?.messageId) return;
+        try {
+            if (!game.user.isGM) return;
+            if (!region.getFlag('od6s', 'explosive')) return;
+            if (change.flags?.od6s?.messageId) return;
 
-        if (region.getFlag('od6s', 'messageId') && !region.getFlag('od6s', 'handled')) {
-            const message = game.messages.get(region.getFlag('od6s', 'messageId'));
-            if (message) {
-                let actor;
-                if (message.speaker.token !== '' && message.speaker.token !== null) {
-                    // @ts-expect-error
-                    actor = game!.scenes.get(message.speaker.scene).tokens.get(message.speaker.token).object.actor;
-                } else {
-                    actor = game.actors.get(message.speaker.actor);
+            if (region.getFlag('od6s', 'messageId') && !region.getFlag('od6s', 'handled')) {
+                const message = game.messages.get(region.getFlag('od6s', 'messageId'));
+                if (message) {
+                    let actor;
+                    if (message.speaker.token !== '' && message.speaker.token !== null) {
+                        // @ts-expect-error
+                        actor = game!.scenes.get(message.speaker.scene).tokens.get(message.speaker.token).object.actor;
+                    } else {
+                        actor = game.actors.get(message.speaker.actor);
+                    }
+                    const targets = await od6sutilities.getExplosiveTargets(
+                        actor,
+                        region.getFlag('od6s', 'item'),
+                        region.id);
+                    await message.unsetFlag('od6s', 'targets');
+                    await message.setFlag('od6s', 'targets', targets);
+                    await message.render();
                 }
-                const targets = await od6sutilities.getExplosiveTargets(
-                    actor,
-                    region.getFlag('od6s', 'item'),
-                    region.id);
-                await message.unsetFlag('od6s', 'targets');
-                await message.setFlag('od6s', 'targets', targets);
-                await message.render();
             }
+        } catch (err) {
+            logError('region-hooks', 'updateRegion failed', err);
         }
     })
 
     // Delete explosive region hook
     Hooks.on('deleteRegion', async (region) => {
-        if (!game.settings.get('od6s', 'auto_explosive') || !game.user.isGM) return;
-        if (!region.getFlag('od6s', 'explosive')) return;
+        try {
+            if (!game.settings.get('od6s', 'auto_explosive') || !game.user.isGM) return;
+            if (!region.getFlag('od6s', 'explosive')) return;
 
-        // Delete the flags from the item that generated the region
-        let actor;
-        if (region.getFlag('od6s', 'token')) {
-            const token = game.scenes.active.tokens.get(region.getFlag('od6s', 'token'));
-            actor = token?.actor;
-        } else {
-            actor = await od6sutilities.getActorFromUuid(region.getFlag('od6s', 'actor'));
-        }
-        if (actor) {
-            const item = actor.items.get(region.getFlag('od6s', 'item'));
-            if (item) {
-                // Drop only the entry for this region — other in-flight
-                // throws of the same item retain their own pending state (#40).
-                await item.update({
-                    [`flags.od6s.explosivePending.-=${region.id}`]: null,
-                });
+            // Delete the flags from the item that generated the region
+            let actor;
+            if (region.getFlag('od6s', 'token')) {
+                const token = game.scenes.active.tokens.get(region.getFlag('od6s', 'token'));
+                actor = token?.actor;
+            } else {
+                actor = await od6sutilities.getActorFromUuid(region.getFlag('od6s', 'actor'));
             }
-        }
-        if (region.getFlag('od6s', 'messageId') && !region.getFlag('od6s', 'handled')) {
-            const message = game.messages.get(region.getFlag('od6s', 'messageId'));
-            if (message) await message.delete();
+            if (actor) {
+                const item = actor.items.get(region.getFlag('od6s', 'item'));
+                if (item) {
+                    // Drop only the entry for this region — other in-flight
+                    // throws of the same item retain their own pending state (#40).
+                    await item.update({
+                        [`flags.od6s.explosivePending.-=${region.id}`]: null,
+                    });
+                }
+            }
+            if (region.getFlag('od6s', 'messageId') && !region.getFlag('od6s', 'handled')) {
+                const message = game.messages.get(region.getFlag('od6s', 'messageId'));
+                if (message) await message.delete();
+            }
+        } catch (err) {
+            logError('region-hooks', 'deleteRegion failed', err);
         }
     })
 }

--- a/src/module/od6s.ts
+++ b/src/module/od6s.ts
@@ -137,9 +137,7 @@ Hooks.once('init', async function () {
     registerMigrationSetting();
 
     // Register sheet application classes
-    foundry.documents.collections.Actors.unregisterSheet("core", foundry.appv1.sheets.ActorSheet);
     foundry.documents.collections.Actors.registerSheet("od6s", OD6SActorSheet, {makeDefault: true});
-    foundry.documents.collections.Items.unregisterSheet("core", foundry.appv1.sheets.ItemSheet);
     foundry.documents.collections.Items.registerSheet("od6s", OD6SItemSheet, {makeDefault: true});
 });
 

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -247,14 +247,18 @@ async function sendVehicleData(userId: string, data: VehicleDataPayload) {
     // payload — otherwise a crew-member-owning caller could push the
     // `system.vehicle` cache onto arbitrary actor uuids in `data.crewmembers`.
     const recipients = isVehicleActor(vehicle) ? vehicle.system.crewmembers ?? [] : [];
+    const worldUpdates: Array<Record<string, unknown>> = [];
     for (const e of recipients) {
         const actor = await od6sutilities.getActorFromUuid(e.uuid);
         if (!actor) continue;
-        const update: any = {};
-        update.system = {};
-        update.id = actor.id;
-        update.system.vehicle = data;
-        await actor.update(update);
+        if (actor.isToken) {
+            await actor.update({_id: actor.id, system: {vehicle: data}});
+        } else {
+            worldUpdates.push({_id: actor.id, system: {vehicle: data}});
+        }
+    }
+    if (worldUpdates.length > 0) {
+        await Actor.updateDocuments(worldUpdates);
     }
 }
 

--- a/src/module/system/logger.ts
+++ b/src/module/system/logger.ts
@@ -41,6 +41,16 @@ export function debug(category: string, ...args: any[]): void {
 }
 
 /**
+ * Always-on warning breadcrumb for non-fatal mismatches the user should
+ * see (schema-version drift, deprecated flag shapes). Sits between
+ * `debug` (gated) and `error` (failure), and routes through `console.warn`
+ * so dev-tools severity filters still distinguish it from hard errors.
+ */
+export function warn(category: string, ...args: any[]): void {
+    console.warn(`[od6s:${category}]`, ...args);
+}
+
+/**
  * Always-on error breadcrumb for swallowed/unexpected failures at handler
  * boundaries (sockets, sheet form-submits, post-roll cleanup). Unlike
  * `debug`, this fires regardless of the debug flag — the point is to leave

--- a/src/module/system/migration.ts
+++ b/src/module/system/migration.ts
@@ -28,7 +28,7 @@
  * Each touched actor will then log a `[before]` and `[after]` snapshot.
  */
 
-import { debug, isDebugEnabled } from "./logger";
+import { debug, error as logError, isDebugEnabled } from "./logger";
 import { SCHEMA_VERSION_KEY } from "./schema-version";
 
 /**
@@ -96,7 +96,7 @@ export async function migrateWorld() {
     await game.settings.set("od6s", "migrationVersion", CURRENT_MIGRATION_VERSION);
     ui.notifications.info("OpenD6 Space: Migration complete.");
   } catch (err) {
-    console.error("od6s | Migration failed:", err);
+    logError("migration", "Migration failed:", err);
     ui.notifications.error("OpenD6 Space: Migration failed. Check the console for details.");
   } finally {
     inProgress?.remove?.();
@@ -122,7 +122,7 @@ export function registerMigrationSetting() {
  * Affects any effect whose img is under systems/od6s/ and ends with .png.
  */
 async function migrateStatusEffectIcons() {
-  console.log("od6s | Migrating status effect icons from .png to .svg...");
+  debug("migration", "Migrating status effect icons from .png to .svg...");
   let count = 0;
 
   for (const actor of game.actors) {
@@ -159,7 +159,7 @@ async function migrateStatusEffectIcons() {
     }
   }
 
-  console.log(`od6s | Updated ${count} status effect icons.`);
+  debug("migration", `Updated ${count} status effect icons.`);
 }
 
 /** Snapshot an actor's full document state (deep-cloned via toObject) for audit logs. */
@@ -178,7 +178,7 @@ function logActorAfter(step: string, actor: any, suffix = "") {
  * Clear the explosive flags so items are in a clean state.
  */
 async function migrateExplosiveTemplateFlags() {
-  console.log("od6s | Migrating explosive template flags on items...");
+  debug("migration", "Migrating explosive template flags on items...");
   let count = 0;
 
   for (const actor of game.actors) {
@@ -222,7 +222,7 @@ async function migrateExplosiveTemplateFlags() {
     count += worldItemUpdates.length;
   }
 
-  console.log(`od6s | Cleaned explosive flags from ${count} items.`);
+  debug("migration", `Cleaned explosive flags from ${count} items.`);
 }
 
 /**
@@ -233,7 +233,7 @@ async function migrateExplosiveTemplateFlags() {
  * migration, and the new code reads only the keyed map.
  */
 async function migrateExplosivePendingFlags() {
-  console.log("od6s | Dropping legacy scalar explosive flags...");
+  debug("migration", "Dropping legacy scalar explosive flags...");
   let count = 0;
 
   const drop = {
@@ -273,7 +273,7 @@ async function migrateExplosivePendingFlags() {
     count += worldItemUpdates.length;
   }
 
-  console.log(`od6s | Dropped legacy scalar explosive flags from ${count} items.`);
+  debug("migration", `Dropped legacy scalar explosive flags from ${count} items.`);
 }
 
 /**
@@ -282,7 +282,7 @@ async function migrateExplosivePendingFlags() {
  * so they don't try to interact with non-existent templates.
  */
 async function migrateChatMessageFlags() {
-  console.log("od6s | Migrating chat message explosive flags...");
+  debug("migration", "Migrating chat message explosive flags...");
   let count = 0;
 
   const updates = [];
@@ -301,7 +301,7 @@ async function migrateChatMessageFlags() {
     await ChatMessage.updateDocuments(updates);
   }
 
-  console.log(`od6s | Cleaned explosive flags from ${count} chat messages.`);
+  debug("migration", `Cleaned explosive flags from ${count} chat messages.`);
 }
 
 /**
@@ -318,7 +318,7 @@ async function migrateChatMessageFlags() {
  */
 async function stampAllSchemaVersions() {
   const version = game.system.version;
-  console.log(`od6s | Stamping all docs with system schema version ${version}...`);
+  debug("migration", `Stamping all docs with system schema version ${version}...`);
   let count = 0;
 
   const actorUpdates: Array<Record<string, unknown>> = [];
@@ -348,5 +348,5 @@ async function stampAllSchemaVersions() {
     count += worldItemUpdates.length;
   }
 
-  console.log(`od6s | Stamped ${count} docs.`);
+  debug("migration", `Stamped ${count} docs.`);
 }

--- a/src/module/system/schema-version.ts
+++ b/src/module/system/schema-version.ts
@@ -6,7 +6,7 @@
  * `src/module/system/migration.ts` (which bumps stamps after migrations).
  */
 
-import { error as logError } from "./logger";
+import { warn as logWarn } from "./logger";
 
 export const SCHEMA_VERSION_KEY = "_systemSchemaVersion";
 
@@ -60,12 +60,12 @@ export function warnIfSchemaVersionMismatch(doc: { id?: string | null; name?: st
 
   const label = `${doc.type ?? "doc"} "${doc.name ?? doc.id}"`;
   if (state === "lag") {
-    logError(
+    logWarn(
       "schema-version",
       `${label} was stamped ${stamp} but system is ${current}; world migrations may not have run yet.`,
     );
   } else {
-    logError(
+    logWarn(
       "schema-version",
       `${label} was stamped ${stamp} which is newer than the running system ${current}; this world was opened in a newer system version. Schema fields may render incorrectly.`,
     );

--- a/src/module/system/schema-version.ts
+++ b/src/module/system/schema-version.ts
@@ -6,6 +6,8 @@
  * `src/module/system/migration.ts` (which bumps stamps after migrations).
  */
 
+import { error as logError } from "./logger";
+
 export const SCHEMA_VERSION_KEY = "_systemSchemaVersion";
 
 export type SchemaVersionState = "ok" | "unstamped" | "lag" | "ahead";
@@ -58,12 +60,14 @@ export function warnIfSchemaVersionMismatch(doc: { id?: string | null; name?: st
 
   const label = `${doc.type ?? "doc"} "${doc.name ?? doc.id}"`;
   if (state === "lag") {
-    console.warn(
-      `[od6s:schema-version] ${label} was stamped ${stamp} but system is ${current}; world migrations may not have run yet.`,
+    logError(
+      "schema-version",
+      `${label} was stamped ${stamp} but system is ${current}; world migrations may not have run yet.`,
     );
   } else {
-    console.warn(
-      `[od6s:schema-version] ${label} was stamped ${stamp} which is newer than the running system ${current}; this world was opened in a newer system version. Schema fields may render incorrectly.`,
+    logError(
+      "schema-version",
+      `${label} was stamped ${stamp} which is newer than the running system ${current}; this world was opened in a newer system version. Schema fields may render incorrectly.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Polish batch from #132. Closes the issue with items 2, 3, 5, 6 done; items 1, 4, 7, 8 are out-of-scope or already subsumed (see commit body).

- **Item 5** — drop `foundry.appv1.sheets.ActorSheet` / `ItemSheet` `unregisterSheet` calls in `od6s.ts`. v14 doesn't ship those defaults, so the calls were defending against nothing.
- **Item 6** — route `system/migration.ts` and `system/schema-version.ts` console output through `logger.ts`. Output is now debug-gated (`localStorage.od6sDebug = '[\"migration\"]'`) and tagged `[od6s:migration]` / `[od6s:schema-version]` consistent with the rest of the system.
- **Item 2** — wrap async hook bodies in error boundaries. `chat-hooks` (`preDeleteChatMessage`, `updateChatMessage`, `createChatMessage`) and `region-hooks` (`updateRegion`, `deleteRegion`) get inline try/catch; `chat-log-listeners` gets the boundary in the shared `delegateEvent` helper so all delegated chat-card handlers benefit from one wrap. Failures leave an `[od6s:chat-hooks]` / `[od6s:region-hooks]` / `[od6s:chat-log]` breadcrumb instead of bare \"Uncaught (in promise)\" rejections.
- **Item 3** — replace per-actor crew-broadcast `actor.update()` loops in `actor/actor-helpers/crew-vehicle.ts:sendVehicleData` and `socketlib.ts:sendVehicleData` with a single `Actor.updateDocuments` batch. Cuts socket chatter and avoids partial-failure half-states. Token-actor updates stay per-doc because synthetic token actors don't live in `game.actors`.

### Items deferred / N/A

- **Item 1** — moving the `declare const foundry: any` per-file shadows into a single ambient surfaces ~50 typecheck errors that the per-file shadows had been masking. Doing it right needs either deleting the typed `foundry` namespace (loses real types) or fixing each surfaced site. Worth its own PR.
- **Item 4** — `OD6S.manifestationName` is settings-driven (the user-facing label can be customized to e.g. \"Spell\"), so the `i18nInit` override at `od6s.ts:163` is intentional rather than a hardcoded string. Not the no-op the issue assumed.
- **Items 7 & 8** — already subsumed. `system/socket.ts` was consolidated into `socketlib.ts` in #133, and the `as any` actor casts in chat/combat hooks were retired by #129/#130. The only remaining `as any` in `socketlib.ts` is `(vehicle as any).sheet.unlinkCrew(...)` — a sheet-method cast, not actor narrowing.

## Test plan

- [x] `pnpm run check` (lint + typecheck + 382 unit + 327 domain) all green
- [ ] Smoke: explosive scatter chat-card flow — confirm error boundary breadcrumb fires when a bad payload hits `updateChatMessage` instead of an unhandled rejection
- [ ] Smoke: vehicle crew sync — broadcast `system.vehicle` to a multi-crew vehicle and verify all crew sheets reflect the change in one update tick
- [ ] Smoke: open a fresh world, verify `[od6s:migration]` log lines only appear with `localStorage.od6sDebug = '[\"migration\"]'` set before reload