### PR TITLE
refactor(types): #137 retire per-file foundry shadows + narrow item-system

### DIFF
--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import OD6SCreateCharacter from "../apps/character-creation";

--- a/src/module/actor/add-crew.ts
+++ b/src/module/actor/add-crew.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 
 

--- a/src/module/actor/add-embedded-crew.ts
+++ b/src/module/actor/add-embedded-crew.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/actor/add-item.ts
+++ b/src/module/actor/add-item.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import {OD6SItem} from "../item/item";
 

--- a/src/module/actor/advance-dialog.ts
+++ b/src/module/actor/advance-dialog.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 

--- a/src/module/actor/attribute-edit.ts
+++ b/src/module/actor/attribute-edit.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 
 

--- a/src/module/actor/sheet-helpers/item-crud.ts
+++ b/src/module/actor/sheet-helpers/item-crud.ts
@@ -1,8 +1,7 @@
 import OD6S from "../../config/config-od6s";
 import {isSkillItem} from "../../system/type-guards";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 /**
  * Delete an item from the actor, with confirmation dialog.

--- a/src/module/actor/sheet-listeners/scores.ts
+++ b/src/module/actor/sheet-listeners/scores.ts
@@ -6,8 +6,7 @@ import {od6sattributeedit} from "../attribute-edit";
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 interface DiceScore { dice: number; pips: number }
 

--- a/src/module/actor/specialize-dialog.ts
+++ b/src/module/actor/specialize-dialog.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/character-creation.ts
+++ b/src/module/apps/character-creation.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import {

--- a/src/module/apps/choose-target.ts
+++ b/src/module/apps/choose-target.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-active-attributes.ts
+++ b/src/module/apps/config-active-attributes.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import OD6S from "../config/config-od6s";
 
 

--- a/src/module/apps/config-attributes-sorting.ts
+++ b/src/module/apps/config-attributes-sorting.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import OD6S from "../config/config-od6s";
 
 

--- a/src/module/apps/config-automation.ts
+++ b/src/module/apps/config-automation.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-characterpoints.ts
+++ b/src/module/apps/config-characterpoints.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-custom-fields.ts
+++ b/src/module/apps/config-custom-fields.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import OD6S from "../config/config-od6s";
 
 

--- a/src/module/apps/config-deadliness.ts
+++ b/src/module/apps/config-deadliness.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-difficulty.ts
+++ b/src/module/apps/config-difficulty.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-initiative.ts
+++ b/src/module/apps/config-initiative.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-labels.ts
+++ b/src/module/apps/config-labels.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-miscrules.ts
+++ b/src/module/apps/config-miscrules.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-reveal.ts
+++ b/src/module/apps/config-reveal.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/config-wild-die.ts
+++ b/src/module/apps/config-wild-die.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/edit-damage.ts
+++ b/src/module/apps/edit-damage.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 
 

--- a/src/module/apps/edit-difficulty.ts
+++ b/src/module/apps/edit-difficulty.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/explosive-dialog.ts
+++ b/src/module/apps/explosive-dialog.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import ExplosivesTemplate from "./explosives-template";
 
 

--- a/src/module/apps/handle-wild-die.ts
+++ b/src/module/apps/handle-wild-die.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 

--- a/src/module/apps/init-roll-dialog.ts
+++ b/src/module/apps/init-roll-dialog.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import OD6S from "../config/config-od6s";
 
 

--- a/src/module/apps/item-info.ts
+++ b/src/module/apps/item-info.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 

--- a/src/module/apps/roll-dialog.ts
+++ b/src/module/apps/roll-dialog.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 import {od6sroll} from "./roll";

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -1,9 +1,8 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const foundry: any;
+ 
 import {od6sutilities} from "../system/utilities";
 import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
 import OD6S from "../config/config-od6s";
-import {isWeaponItem} from "../system/type-guards";
+import {isItemGroupItem, isTemplateLikeItem, isWeaponItem} from "../system/type-guards";
 
 
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
@@ -134,8 +133,10 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     /* -------------------------------------------- */
 
     async _addActorType(): Promise<void> {
+        if (!isItemGroupItem(this.item)) return;
+        const item = this.item;
         const data = {
-            actorTypes: game.od6s.OD6SActor.TYPES.filter((i: any) => !this.item.system.actor_types.includes(i)),
+            actorTypes: game.od6s.OD6SActor.TYPES.filter((i: any) => !item.system.actor_types.includes(i)),
         };
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-add-actor-type.html", data);
@@ -148,23 +149,27 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     }
 
     async _addActorTypeAction(type: any): Promise<void> {
-        const update: any = {id: this.item.id, system: {actor_types: this.item.system.actor_types}};
+        if (!isItemGroupItem(this.item)) return;
+        const item = this.item;
+        const update: any = {id: item.id, system: {actor_types: item.system.actor_types}};
         update.system.actor_types.push(type);
-        await this.item.update(update);
+        await item.update(update);
     }
 
     async _deleteActorType(ev: any): Promise<void> {
+        if (!isItemGroupItem(this.item)) return;
+        const item = this.item;
         const type = ev.currentTarget.dataset.type;
         const update: any = {
-            id: this.item.id,
+            id: item.id,
             system: {
-                actor_types: this.item.system.actor_types.filter((i: any) => i !== type),
+                actor_types: item.system.actor_types.filter((i: any) => i !== type),
                 items: [],
             },
         };
-        for (const i of this.item.system.items) {
+        for (const i of item.system.items) {
             for (const t of update.system.actor_types) {
-                if (OD6S.allowedItemTypes[t].includes(i.type)) {
+                if (OD6S.allowedItemTypes[t].includes(i.type as string)) {
                     update.system.items.push(i);
                     break;
                 }
@@ -363,10 +368,11 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     }
 
     async _addTemplateItemAction(name: any, type: any, itemSheet: any): Promise<void> {
-        if (this.item.type === "item-group") {
+        if (isItemGroupItem(this.item)) {
+            const item = this.item;
             let allowed = false;
             for (const [key, items] of Object.entries(OD6S.allowedItemTypes)) {
-                if (this.item.system.actor_types.includes(key)) {
+                if (item.system.actor_types.includes(key)) {
                     for (const i of (items as string[])) {
                         if (OD6S.templateItemTypes["item-group"].includes(i)) {
                             allowed = true;
@@ -391,9 +397,10 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     }
 
     async _editTemplateItem(event: any): Promise<void> {
+        if (!isTemplateLikeItem(this.item)) return;
         const target = event.currentTarget as HTMLElement;
         const item = this.item.system.items.find((i: any) => i.name === target.dataset.name);
-        const itemData = {name: target.dataset.name, type: target.dataset.type, description: item.description};
+        const itemData = {name: target.dataset.name, type: target.dataset.type, description: item?.description};
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-template-item-edit.html",
             itemData);
@@ -422,6 +429,8 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     }
 
     async _deleteTemplateItem(event: any): Promise<void> {
+        if (!isTemplateLikeItem(this.item)) return;
+        const item = this.item;
         const result = await DialogV2.confirm({
             window: {title: game.i18n.localize("OD6S.DELETE")},
             content: `<p>${game.i18n.localize("OD6S.DELETE_CONFIRM")}</p>`,
@@ -429,11 +438,11 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (!result) return;
 
         const target = event.currentTarget as HTMLElement;
-        const itemIndex = this.item.system.items.findIndex(
+        const itemIndex = item.system.items.findIndex(
             (i: any) => i.name === target.dataset.name && i.type === target.dataset.type);
-        this.item.system.items.splice(itemIndex, 1);
-        await this.item.update(
-            {id: this.item.id, system: this.item.system},
+        item.system.items.splice(itemIndex, 1);
+        await item.update(
+            {id: item.id, system: item.system},
             {diff: true});
         await this.render();
     }

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -421,6 +421,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         const newItem = {name: data.name, type: data.type, description: desc};
         const itemIndex = itemSheet.item.system.items.findIndex(
             (i: any) => i.name === data.name && i.type === data.type);
+        if (itemIndex < 0) return;
         itemSheet.item.system.items[itemIndex] = newItem;
         await itemSheet.item.update(
             {id: itemSheet.item.id, system: itemSheet.item.system},
@@ -440,6 +441,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         const target = event.currentTarget as HTMLElement;
         const itemIndex = item.system.items.findIndex(
             (i: any) => i.name === target.dataset.name && i.type === target.dataset.type);
+        if (itemIndex < 0) return;
         item.system.items.splice(itemIndex, 1);
         await item.update(
             {id: item.id, system: item.system},

--- a/src/module/system/type-guards.ts
+++ b/src/module/system/type-guards.ts
@@ -49,6 +49,32 @@ export function isActionItem(item: Item): item is OD6SActionItem {
     return item.type === "action";
 }
 
+export function isItemGroupItem(item: Item): item is OD6SItemGroupItem {
+    return item.type === "item-group";
+}
+
+export function isCharacterTemplateItem(item: Item): item is OD6SCharacterTemplateItem {
+    return item.type === "character-template";
+}
+
+/**
+ * Combined guard for the three template-shaped item types whose system data
+ * carries a `system.items` array (item-group, character-template, species-template).
+ * Use when the surrounding code reads/writes that nested item list.
+ */
+export function isTemplateLikeItem(
+    item: Item,
+): item is OD6SItemGroupItem | OD6SCharacterTemplateItem | (Item & {
+    type: "species-template";
+    system: OD6SSpeciesTemplateItemSystem;
+}) {
+    return (
+        item.type === "item-group" ||
+        item.type === "character-template" ||
+        item.type === "species-template"
+    );
+}
+
 /**
  * Combined guard for any weapon-family item. Use when the surrounding code
  * accesses fields shared across the three weapon types (e.g. `mods`,

--- a/src/module/system/type-guards.ts
+++ b/src/module/system/type-guards.ts
@@ -64,10 +64,7 @@ export function isCharacterTemplateItem(item: Item): item is OD6SCharacterTempla
  */
 export function isTemplateLikeItem(
     item: Item,
-): item is OD6SItemGroupItem | OD6SCharacterTemplateItem | (Item & {
-    type: "species-template";
-    system: OD6SSpeciesTemplateItemSystem;
-}) {
+): item is OD6SItemGroupItem | OD6SCharacterTemplateItem | OD6SSpeciesTemplateItem {
     return (
         item.type === "item-group" ||
         item.type === "character-template" ||

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -411,7 +411,7 @@ interface OD6SActionItemSystem extends OD6SItemBase {
     itemId: string;
 }
 
-interface OD6SVehicleItemSystem extends OD6SVehicleCommon {
+interface OD6SVehicleItemSystem extends OD6SVehicleCommon, OD6SItemBase {
     cover: { value: string; type: string; label: string };
     altitude: { value: number; type: string; label: string };
 }


### PR DESCRIPTION
Follow-up to #138, the second PR for #137. Removes the 31 `declare const foundry: any;` shadows under `src/module/` and fixes the bucket-3 item-system narrowing gaps that surfaced once the shadows were gone.

Replaces #139 (auto-closed when its stacked base branch was deleted on merge of #138).

## Changes
- Drop every per-file `declare const foundry: any;` (and the now-redundant `eslint-disable-next-line` directives above them).
- `OD6SVehicleItemSystem` now extends `OD6SItemBase` — vehicle items always carry the `labels` / `tags` / `description` fields from `baseSchema`; the omission was a typing oversight.
- New item-side guards in `system/type-guards.ts` (`isItemGroupItem`, `isCharacterTemplateItem`, `isTemplateLikeItem`), mirroring the actor-side discriminated-unions work from #57.
- `OD6SItemSheet` template-action handlers (`_addActorType`, `_deleteActorType`, `_addTemplateItemAction`, `_editTemplateItem`, `_deleteTemplateItem`) gate on the new guards instead of reaching into the union directly. The DOM wiring already binds these to template-shaped items only, so the early-return is defensive.

## Validation
- `pnpm run typecheck` — clean
- `pnpm run lint` — baseline unchanged at 562 warnings. The per-file shadows themselves carried `eslint-disable-next-line` directives, so removing them was net-zero on the warning count rather than the "~chunk of 626" the issue speculated. The structural win is that shadows no longer hide regressions in the typed surface.
- `pnpm run test` / `pnpm run test:domain` — all green
- `pnpm run build` — succeeds

Closes #137.