### PR TITLE
refactor(socket): tighten socketlib handler typing

### DIFF
--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -370,12 +370,12 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     /*  Crew Management (delegates)                  */
     /* -------------------------------------------- */
 
-    async linkCrew(uuid: any) {
-        return linkCrew(this, uuid);
+    async linkCrew(uuid: string) {
+        return linkCrew(this.document, uuid);
     }
 
-    async unlinkCrew(crewID: any) {
-        return unlinkCrew(this, crewID);
+    async unlinkCrew(crewID: string) {
+        return unlinkCrew(this.document, crewID);
     }
 
     /* -------------------------------------------- */

--- a/src/module/actor/sheet-helpers/crew.ts
+++ b/src/module/actor/sheet-helpers/crew.ts
@@ -14,50 +14,47 @@
 import OD6S from "../../config/config-od6s";
 import {od6sutilities} from "../../system/utilities";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Sheet = any;
+type CrewmemberRef = {uuid: string; name?: string; sort?: number};
 
-export async function linkCrew(sheet: Sheet, uuid: string): Promise<void> {
+export async function linkCrew(vehicle: Actor, uuid: string): Promise<void> {
     // crewmembers is an array of {uuid, name, sort} objects, so .includes(uuid)
     // would always be false — match by .uuid to actually deduplicate.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const existing: any[] = sheet.document.system.crewmembers;
+    const existing: CrewmemberRef[] = (vehicle.system as {crewmembers: CrewmemberRef[]}).crewmembers;
     if (existing.some((c) => c.uuid === uuid)) return;
 
     const actor = await od6sutilities.getActorFromUuid(uuid);
     let result;
     if (game.user.isGM) {
-        result = await actor!.addToCrew(sheet.document.uuid);
+        result = await actor!.addToCrew(vehicle.uuid);
     } else {
-        result = await OD6S.socket.executeAsGM("addToVehicle", game.user.id, sheet.document.uuid, uuid);
+        result = await OD6S.socket.executeAsGM("addToVehicle", game.user.id, vehicle.uuid, uuid);
     }
 
     if (result) {
-        const crew = {uuid: actor!.uuid, name: actor!.name, sort: 0};
-        await sheet.document.update({
-            id: sheet.document.id,
+        const crew: CrewmemberRef = {uuid: actor!.uuid, name: actor!.name, sort: 0};
+        await vehicle.update({
+            id: vehicle.id,
             system: {crewmembers: [...existing, crew]},
         });
     }
 }
 
-export async function unlinkCrew(sheet: Sheet, crewID: string): Promise<void> {
-    const crewMembers = sheet.document.system.crewmembers.filter(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (e: any) => e.uuid !== crewID,
+export async function unlinkCrew(vehicle: Actor, crewID: string): Promise<void> {
+    const crewMembers = (vehicle.system as {crewmembers: CrewmemberRef[]}).crewmembers.filter(
+        (e) => e.uuid !== crewID,
     );
 
     if (await fromUuid(crewID)) {
         if (game.user.isGM) {
             const actor = await od6sutilities.getActorFromUuid(crewID);
-            await actor!.removeFromCrew(sheet.document.uuid);
+            await actor!.removeFromCrew(vehicle.uuid);
         } else {
-            await OD6S.socket.executeAsGM("removeFromVehicle", game.user.id, crewID, sheet.document.uuid);
+            await OD6S.socket.executeAsGM("removeFromVehicle", game.user.id, crewID, vehicle.uuid);
         }
     }
 
-    await sheet.document.update({
-        id: sheet.document.id,
+    await vehicle.update({
+        id: vehicle.id,
         system: {crewmembers: crewMembers},
     });
 }

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -2,6 +2,7 @@ import {od6sutilities} from "./system/utilities";
 import OD6S from "./config/config-od6s";
 import {isVehicleActor} from "./system/type-guards";
 import {error as logError} from "./system/logger";
+import type {OD6SActorSheet} from "./actor/actor-sheet";
 
 // Trust model for socketlib handlers
 // ----------------------------------
@@ -58,11 +59,13 @@ export interface DeleteExplosiveRegionPayload {
 }
 
 // Wrap each handler so failures leave an `[od6s:socket]` breadcrumb instead of
-// surfacing as bare "Uncaught (in promise)" rejections through socketlib.
-function register(name: string, handler: (...args: any[]) => unknown): void {
+// surfacing as bare "Uncaught (in promise)" rejections through socketlib. The
+// generic preserves the handler's own parameter types at call sites — only
+// the dispatch boundary into socketlib's untyped `register` remains `any`.
+function register<H extends (...args: never[]) => unknown>(name: string, handler: H): void {
     OD6S.socket.register(name, async (...args: unknown[]) => {
         try {
-            return await handler(...args);
+            return await (handler as unknown as (...args: unknown[]) => unknown)(...args);
         } catch (err) {
             logError('socket', `${name} handler failed`, err);
             throw err;
@@ -111,7 +114,12 @@ async function userMayMutateVehicle(user: User, vehicle: Actor): Promise<boolean
     return false;
 }
 
-async function updateRollMessage(userId: string, messageId: string, update: any) {
+interface RollMessageUpdate {
+    content: string | number;
+    [key: string]: unknown;
+}
+
+async function updateRollMessage(userId: string, messageId: string, update: RollMessageUpdate) {
     const user = game.users.get(userId);
     if (!user) return denied('updateRollMessage', userId, 'unknown user');
     const message = game.messages.get(messageId);
@@ -286,7 +294,7 @@ async function unlinkCrew(userId: string, crewId: string, vehicleId: string) {
     if (!user.isGM && !vehicle.testUserPermission(user, 'OWNER') && !ownsCrew) {
         return denied('unlinkCrew', userId, `not authorized for crew=${crewId} on vehicle=${vehicleId}`);
     }
-    await (vehicle as any).sheet.unlinkCrew(crewId);
+    await (vehicle.sheet as unknown as OD6SActorSheet).unlinkCrew(crewId);
 }
 
 async function addToVehicle(userId: string, vehicleId: string, crewId: string) {

--- a/src/module/socketlib.ts
+++ b/src/module/socketlib.ts
@@ -2,7 +2,7 @@ import {od6sutilities} from "./system/utilities";
 import OD6S from "./config/config-od6s";
 import {isVehicleActor} from "./system/type-guards";
 import {error as logError} from "./system/logger";
-import type {OD6SActorSheet} from "./actor/actor-sheet";
+import {unlinkCrew as unlinkCrewFromVehicle} from "./actor/sheet-helpers/crew";
 
 // Trust model for socketlib handlers
 // ----------------------------------
@@ -60,12 +60,13 @@ export interface DeleteExplosiveRegionPayload {
 
 // Wrap each handler so failures leave an `[od6s:socket]` breadcrumb instead of
 // surfacing as bare "Uncaught (in promise)" rejections through socketlib. The
-// generic preserves the handler's own parameter types at call sites — only
-// the dispatch boundary into socketlib's untyped `register` remains `any`.
-function register<H extends (...args: never[]) => unknown>(name: string, handler: H): void {
+// `Args` tuple generic preserves the handler's own parameter types at call
+// sites; only the dispatch boundary into socketlib's untyped `register`
+// remains `unknown[]`.
+function register<Args extends unknown[]>(name: string, handler: (...args: Args) => unknown): void {
     OD6S.socket.register(name, async (...args: unknown[]) => {
         try {
-            return await (handler as unknown as (...args: unknown[]) => unknown)(...args);
+            return await handler(...(args as Args));
         } catch (err) {
             logError('socket', `${name} handler failed`, err);
             throw err;
@@ -294,7 +295,10 @@ async function unlinkCrew(userId: string, crewId: string, vehicleId: string) {
     if (!user.isGM && !vehicle.testUserPermission(user, 'OWNER') && !ownsCrew) {
         return denied('unlinkCrew', userId, `not authorized for crew=${crewId} on vehicle=${vehicleId}`);
     }
-    await (vehicle.sheet as unknown as OD6SActorSheet).unlinkCrew(crewId);
+    // Run the unlink directly on the document instead of going through the
+    // vehicle's sheet — the helper only ever needed the document, and the
+    // socket handler shouldn't depend on whatever sheet class is registered.
+    await unlinkCrewFromVehicle(vehicle, crewId);
 }
 
 async function addToVehicle(userId: string, vehicleId: string, crewId: string) {


### PR DESCRIPTION
## Summary

- Make the `register()` wrapper generic so handler param types are preserved at call sites; only the dispatch boundary into socketlib's untyped `register` remains `unknown[]`.
- Replace `updateRollMessage`'s `update: any` with a typed `RollMessageUpdate` (function only reads `update.content`).
- Narrow `(vehicle as any).sheet.unlinkCrew(crewId)` to `OD6SActorSheet` (via `unknown`, since Foundry's typed `Actor.sheet` is the base class).

Surfaced during pre-2.6.0 review of the #129/#130 socket consolidation work — typed payload interfaces had landed but the wrapper and a couple of adjacent sites still leaked `any`. Net 3 fewer `no-explicit-any` warnings (562 → 559). No behavioural change.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean (559 warnings, under 720 CI threshold)
- [x] `pnpm run test` — 382 unit tests pass