### PR TITLE
ci(release): prepend changelog section to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,12 @@ jobs:
           #     joined with a single space (leading indent stripped)
           # If the version isn't found (e.g. someone tagged without
           # updating CHANGELOG), fall back to a bare link.
-          SECTION=$(awk -v v="$VERSION" '
+          # `index($0, header) == 1` is a literal-substring check — avoids
+          # treating the dots in `VERSION` as regex metacharacters.
+          SECTION=$(awk -v header="## [$VERSION]" '
             BEGIN              { capture=0; buf="" }
             function flush()   { if (buf != "") { print buf; buf="" } }
-            $0 ~ "^## \\[" v "\\]" { capture=1; next }
+            index($0, header) == 1 { capture=1; next }
             capture && /^## \[/    { flush(); exit }
             !capture           { next }
             /^$/               { flush(); print ""; next }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,13 +82,29 @@ jobs:
           set -eu
           VERSION="${{ steps.meta.outputs.version }}"
           TAG="${{ steps.meta.outputs.tag }}"
-          # Pull the section bounded by `## [VERSION]` and the next `## [`.
+          # Pull the section bounded by `## [VERSION]` and the next `## [`,
+          # then reflow paragraphs and list items so hard wraps in the
+          # source CHANGELOG don't render as visible <br>s in release
+          # notes (GitHub Releases honor GFM `breaks: true`).
+          # Reflow rules:
+          #   - blank lines and headers (`#`) flush + pass through
+          #   - lines starting `- ` / `* ` start a new buffered list item
+          #   - any other non-empty line appends to the current buffer,
+          #     joined with a single space (leading indent stripped)
           # If the version isn't found (e.g. someone tagged without
           # updating CHANGELOG), fall back to a bare link.
           SECTION=$(awk -v v="$VERSION" '
-            $0 ~ "^## \\[" v "\\]" {capture=1; next}
-            capture && /^## \[/      {exit}
-            capture                  {print}
+            BEGIN              { capture=0; buf="" }
+            function flush()   { if (buf != "") { print buf; buf="" } }
+            $0 ~ "^## \\[" v "\\]" { capture=1; next }
+            capture && /^## \[/    { flush(); exit }
+            !capture           { next }
+            /^$/               { flush(); print ""; next }
+            /^#+ /             { flush(); print; next }
+            /^[-*] /           { flush(); buf=$0; next }
+                               { line=$0; sub(/^[ \t]+/, "", line);
+                                 buf = (buf == "" ? line : buf " " line) }
+            END                { flush() }
           ' CHANGELOG.md)
           CHANGELOG_URL="https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md"
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,32 @@ jobs:
           --output build/artifacts/sbom.cdx.json
           .
 
+      - name: Extract CHANGELOG section
+        id: changelog
+        run: |
+          set -eu
+          VERSION="${{ steps.meta.outputs.version }}"
+          TAG="${{ steps.meta.outputs.tag }}"
+          # Pull the section bounded by `## [VERSION]` and the next `## [`.
+          # If the version isn't found (e.g. someone tagged without
+          # updating CHANGELOG), fall back to a bare link.
+          SECTION=$(awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" {capture=1; next}
+            capture && /^## \[/      {exit}
+            capture                  {print}
+          ' CHANGELOG.md)
+          CHANGELOG_URL="https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md"
+          {
+            if [ -n "$SECTION" ]; then
+              printf '%s\n' "$SECTION"
+              echo
+              echo "[Full changelog →](${CHANGELOG_URL})"
+            else
+              echo "[Release notes in CHANGELOG.md →](${CHANGELOG_URL})"
+            fi
+          } > release-body.md
+          echo "body_path=release-body.md" >> "$GITHUB_OUTPUT"
+
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Sign artifacts (cosign keyless)
@@ -94,6 +120,9 @@ jobs:
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
+          # `body_path` is prepended; `generate_release_notes: true`
+          # then appends GitHub's auto-generated "What's Changed" PR list.
+          body_path: ${{ steps.changelog.outputs.body_path }}
           generate_release_notes: true
           files: |
             build/artifacts/od6s.zip


### PR DESCRIPTION
## Summary

Currently GitHub release notes are just the auto-generated \"What's Changed\" PR list — useful, but the curated narrative in CHANGELOG.md isn't surfaced.

This change extracts the version's section from CHANGELOG.md (between \`## [VERSION]\` and the next \`## [\`) and passes it via \`body_path\` to the existing \`softprops/action-gh-release\` step. The auto-generated PR list still appears after — \`generate_release_notes: true\` is preserved — so readers get the curated narrative on top and the raw PR list below.

Falls back to a bare link to CHANGELOG.md@TAG if the section can't be found (e.g. tagged without updating the changelog), so the release still publishes.

## Follow-up

Will retroactively patch v2.6.0's release notes via \`gh release edit\` once this lands.

## Test plan

- [x] Awk extraction tested locally against the current CHANGELOG.md for the v2.6.0 section — output matches the rendered section.
- [ ] Next release tag exercises the full path; if it breaks, the section still publishes (just with auto-generated PR list only).