### PR TITLE
refactor(types): tighten item-sheet, templates & character-creation (any-sweep r1+r2)

### DIFF
--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -12,12 +12,12 @@ import {
 
 export async function addEmbeddedPilot(actor: Actor, pilotActor: Actor): Promise<void> {
     /* Copy attributes and items to vehicle */
-    const update = {};
-
     await actor.createEmbeddedDocuments('Item',
-        pilotActor.items.filter((s: any) => s.type === 'skill' || s.type === "specialization"));
-    (update as any)[`system.attributes`] = pilotActor.system.attributes;
-    (update as any)[`system.embedded_pilot.actor`] = pilotActor;
+        pilotActor.items.filter((s: Item) => s.type === 'skill' || s.type === "specialization"));
+    const update: Record<string, unknown> = {
+        "system.attributes": (pilotActor.system as { attributes: unknown }).attributes,
+        "system.embedded_pilot.actor": pilotActor,
+    };
     await actor.update(update);
 }
 
@@ -84,10 +84,7 @@ export async function removeFromCrew(actor: Actor, vehicleID: string): Promise<v
 export async function forceRemoveCrewmember(actor: Actor, crewID: string): Promise<void> {
     if (!isVehicleActor(actor)) return;
     const crewMembers = removeCrewmember(actor.system.crewmembers, crewID);
-    const update: any = {};
-    update.system = {};
-    update.system.crewmembers = crewMembers;
-    await actor.update(update);
+    await actor.update({system: {crewmembers: crewMembers}});
 }
 
 export function isCrewMember(actor: Actor): boolean {
@@ -96,36 +93,38 @@ export function isCrewMember(actor: Actor): boolean {
 
 export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void> {
     if (!isVehicleActor(actor)) return;
-    const data: any = {};
     const sys = actor.system;
-    data.uuid = actor.uuid;
-    data.name = actor.name;
-    data.type = actor.type;
-    data.move = sys.move;
-    data.maneuverability = sys.maneuverability;
-    data.toughness = sys.toughness;
-    data.crewmembers = sys.crewmembers;
-    data.items = actor.items;
-    data.attribute = sys.attribute;
-    data.skill = sys.skill;
-    data.specialization = sys.specialization;
-    data.damage = sys.damage;
-    data.shields = sys.shields;
-    data.scale = sys.scale;
-    data.sensors = sys.sensors;
-    data.armor = sys.armor;
-    data.dodge = sys.dodge;
-    data.ranged = sys.ranged;
-    data.ranged_damage = sys.ranged_damage;
-    data.ram = sys.ram;
-    data.ram_damage = sys.ram_damage;
-    data.vehicle_weapons = buildVehicleWeaponSnapshots(actor.items.contents);
+    const data: Record<string, unknown> = {
+        uuid: actor.uuid,
+        name: actor.name,
+        type: actor.type,
+        move: sys.move,
+        maneuverability: sys.maneuverability,
+        toughness: sys.toughness,
+        crewmembers: sys.crewmembers,
+        items: actor.items,
+        attribute: sys.attribute,
+        skill: sys.skill,
+        specialization: sys.specialization,
+        damage: sys.damage,
+        shields: sys.shields,
+        scale: sys.scale,
+        sensors: (sys as unknown as { sensors: unknown }).sensors,
+        armor: sys.armor,
+        dodge: sys.dodge,
+        ranged: sys.ranged,
+        ranged_damage: sys.ranged_damage,
+        ram: sys.ram,
+        ram_damage: sys.ram_damage,
+        vehicle_weapons: buildVehicleWeaponSnapshots(actor.items.contents),
+    };
 
     if (shouldDispatchVehicleDataAsGM(game.user.isGM)) {
         await OD6S.socket.executeAsGM("sendVehicleData", game.user.id, data);
         return;
     }
-    const crew = selectCrewmembersForBroadcast(data.crewmembers, uuid);
+    const crew = selectCrewmembersForBroadcast(
+        data.crewmembers as Array<{ uuid: string }>, uuid);
     // Batch world-actor updates through Actor.updateDocuments to cut socket
     // chatter and avoid partial-failure half-states. Token-actor (synthetic)
     // updates fall back to the per-doc path because they live on a scene's
@@ -145,7 +144,7 @@ export async function sendVehicleData(actor: Actor, uuid?: string): Promise<void
     }
 }
 
-export async function modifyShields(actor: Actor, update: any): Promise<void> {
+export async function modifyShields(actor: Actor, update: Record<string, unknown>): Promise<void> {
     await OD6S.socket.executeAsGM("modifyShields", game.user.id, update);
 }
 
@@ -166,7 +165,10 @@ export async function vehicleCollision(actor: Actor): Promise<void> {
     await rollVehicleCollision(actor, result);
 }
 
-async function rollVehicleCollision(actor: any, result: any): Promise<void> {
+async function rollVehicleCollision(
+    actor: Actor,
+    result: { vehiclespeed: string; vehiclecollisiontype: string; vehiclecollisionmod?: string | number },
+): Promise<void> {
     const speed = result.vehiclespeed;
     const speedValue = OD6S.vehicle_speeds[speed].damage;
     const type = result.vehiclecollisiontype;
@@ -193,7 +195,12 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
         + game.i18n.localize(OD6S.damageTypes["p"]) + ") "
         + game.i18n.localize("OD6S.FROM") + " " + game.i18n.localize("OD6S.COLLISION");
 
-    const flags: any = {
+    const flags: {
+        type: string; source: string; damageType: string;
+        targetName: string | null; targetId: string | null;
+        isOpposable: boolean; wild: boolean; wildHandled: boolean;
+        wildResult: unknown; total: number; isVehicleCollision: boolean;
+    } = {
         type: "damage",
         source: game.i18n.localize("OD6S.COLLISION"),
         damageType: "p",
@@ -209,26 +216,32 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
 
     if (game.settings.get("od6s", "use_wild_die")) {
         const wildFlavor = game.i18n.localize("OD6S.WILD_DIE_FLAVOR").replace(/[[\]]/g, "");
-        const wildTerm = (roll.terms as any[]).find((d: any) => d.flavor === wildFlavor);
+        const wildTerm = (roll.terms as Array<{ flavor: string; total: number }>)
+            .find((d) => d.flavor === wildFlavor);
         if (wildTerm?.total === 1) {
             flags.wild = true;
             if (OD6S.wildDieOneDefault > 0 && OD6S.wildDieOneAuto === 0) flags.wildHandled = true;
         }
     }
 
-    let rollMode: any = CONST.DICE_ROLL_MODES.PUBLIC;
+    let rollMode: string = CONST.DICE_ROLL_MODES.PUBLIC;
     if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
         rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
     }
 
     const rollMessage = await roll.toMessage({
-        speaker: ChatMessage.getSpeaker({actor: game.actors.find((a: any) => a.id === actor.id)}),
+        speaker: ChatMessage.getSpeaker({actor: game.actors.find((a: Actor) => a.id === actor.id)}),
         flavor: label,
         flags: {od6s: flags},
     }, {rollMode, create: true});
 
     if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
-        const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));
+        type DieResult = { result: number; discarded?: boolean; active?: boolean };
+        type RollSnapshot = {
+            total: number;
+            terms: Array<{ results: DieResult[] }>;
+        };
+        const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON())) as RollSnapshot;
         let highest = 0;
         for (let i = 0; i < replacementRoll.terms[0].results.length; i++) {
             if (replacementRoll.terms[0].results[i].result > replacementRoll.terms[0].results[highest].result) {
@@ -238,11 +251,11 @@ async function rollVehicleCollision(actor: any, result: any): Promise<void> {
         replacementRoll.terms[0].results[highest].discarded = true;
         replacementRoll.terms[0].results[highest].active = false;
         replacementRoll.total -= (+replacementRoll.terms[0].results[highest].result) + 1;
-        flags.total = replacementRoll.total;
+        (flags as { total: number }).total = replacementRoll.total;
 
         if (rollMessage.getFlag("od6s", "difficulty") && rollMessage.getFlag("od6s", "success")) {
             await rollMessage.setFlag("od6s", "success",
-                replacementRoll.total >= rollMessage.getFlag("od6s", "difficulty"));
+                replacementRoll.total >= (rollMessage.getFlag("od6s", "difficulty") as number));
         }
 
         await rollMessage.setFlag("od6s", "originalroll", rollMessage.rolls?.[0]);
@@ -261,7 +274,7 @@ export async function onCargoHoldItemCreate(actor: Actor, event: Event): Promise
 
     const documentName = 'Item';
     let types = game.documentTypes[documentName].filter(t => t !== CONST.BASE_DOCUMENT_TYPE);
-    const data: any = {};
+    const data: Record<string, unknown> = {};
     const foldersCollection = game.folders.filter(f => (f.type === documentName) && f.displayed);
     const folders = foldersCollection.map(f => ({id: f.id, name: f.name}));
     const label = game.i18n.localize('OD6S.ITEM');
@@ -294,9 +307,9 @@ export async function onCargoHoldItemCreate(actor: Actor, event: Event): Promise
         folders: folders,
         hasFolders: folders.length > 0,
         type: data.type || types[0],
-        types: types.reduce((obj, t) => {
+        types: types.reduce<Record<string, string>>((obj, t) => {
             const label = CONFIG[documentName]?.typeLabels?.[t] ?? t;
-            (obj as any)[t] = game.i18n.has(label) ? game.i18n.localize(label) : t;
+            obj[t] = game.i18n.has(label) ? game.i18n.localize(label) : t;
             return obj;
         }, {}),
         hasTypes: types.length > 1
@@ -314,6 +327,7 @@ export async function onCargoHoldItemCreate(actor: Actor, event: Event): Promise
     foundry.utils.mergeObject(data, result);
     if (!data.folder) delete data["folder"];
     if (types.length === 1) data.type = types[0];
-    data.name = data.name || game.i18n.localize('OD6S.NEW') + " " + game.i18n.localize(OD6S.itemLabels[data.type]);
+    data.name = data.name
+        || game.i18n.localize('OD6S.NEW') + " " + game.i18n.localize(OD6S.itemLabels[data.type as string]);
     return actor.createEmbeddedDocuments('Item', [data]);
 }

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -258,35 +258,35 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     /*  Drop Handling (delegates)                    */
     /* -------------------------------------------- */
 
-    async _onDropItemGroup(event: any, item: any, data: any) {
+    async _onDropItemGroup(event: Event, item: OD6SItemGroupItem, data: Record<string, unknown>) {
         return onDropItemGroup(this, event, item, data);
     }
 
-    async _onDropSpeciesTemplate(event: any, item: any, data: any) {
+    async _onDropSpeciesTemplate(event: Event, item: OD6SSpeciesTemplateItem, data: Record<string, unknown>) {
         return onDropSpeciesTemplate(this, event, item, data);
     }
 
-    async _onDropCharacterTemplate(event: any, item: any, data: any) {
+    async _onDropCharacterTemplate(event: Event, item: OD6SCharacterTemplateItem, data: Record<string, unknown>) {
         return onDropCharacterTemplate(this, event, item, data);
     }
 
-    async _addCharacterTemplate(item: any) {
+    async _addCharacterTemplate(item: OD6SCharacterTemplateItem) {
         return addCharacterTemplate(this, item);
     }
 
-    async _templateItems(itemList: any) {
+    async _templateItems(itemList: OD6STemplateItemEntry[]) {
         return templateItems(this, itemList);
     }
 
-    async _onDrop(event: any) {
+    async _onDrop(event: DragEvent) {
         return onDrop(this, event);
     }
 
-    async _onDropItem(event: any, data: any) {
+    async _onDropItem(event: DragEvent, data: Record<string, unknown>) {
         return onDropItem(this, event, data);
     }
 
-    async _onDropActor(event: any, data: any) {
+    async _onDropActor(event: Event, data: Record<string, unknown>) {
         return onDropActor(this, event, data);
     }
 

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -136,7 +136,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         const root = this.element as HTMLElement;
 
-        bindPrimaryTabs(this as any, root);
+        bindPrimaryTabs(this, root);
 
         // Roll triggers must be bound for any owner regardless of edit mode —
         // V2 sheets render in PLAY mode by default (isEditable === false), but
@@ -241,13 +241,14 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         await this.render();
     }
 
-    async _onAvailableActionAdd(event: any) {
+    async _onAvailableActionAdd(event: Event) {
+        const target = event.currentTarget as HTMLElement;
         await this._createAction({
-            name: event.currentTarget.dataset.name,
+            name: target.dataset.name!,
             type: "availableaction",
-            subtype: event.currentTarget.dataset.type,
-            itemId: event.currentTarget.dataset.id,
-            rollable: event.currentTarget.dataset.rollable,
+            subtype: target.dataset.type!,
+            itemId: target.dataset.id,
+            rollable: target.dataset.rollable,
         });
     }
 
@@ -311,7 +312,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     /*  Utility Methods                              */
     /* -------------------------------------------- */
 
-    _isEquippable(itemType: any) {
+    _isEquippable(itemType: string) {
         return OD6S.equippable.includes(itemType);
     }
 
@@ -361,9 +362,10 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         return rollAvailableAction(this, ev);
     }
 
-    async _editEffect(ev: any) {
-        const effect = this.document.effects.find((e: any) => e.id === ev.currentTarget.dataset.effectId);
-        new (foundry.applications.sheets as any).ActiveEffectConfig({document: effect}).render({force: true});
+    async _editEffect(ev: Event) {
+        const target = ev.currentTarget as HTMLElement;
+        const effect = this.document.effects.find((e: ActiveEffect) => e.id === target.dataset.effectId);
+        new foundry.applications.sheets.ActiveEffectConfig({document: effect}).render({force: true});
     }
 
     /* -------------------------------------------- */

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -367,6 +367,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     async _editEffect(ev: Event) {
         const target = ev.currentTarget as HTMLElement;
         const effect = this.document.effects.find((e: ActiveEffect) => e.id === target.dataset.effectId);
+        if (!effect) return;
         new foundry.applications.sheets.ActiveEffectConfig({document: effect}).render({force: true});
     }
 

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -294,19 +294,19 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     /*  Sorting Methods (delegates)                  */
     /* -------------------------------------------- */
 
-    _onSortItem(event: any, itemData: any) {
+    _onSortItem(event: DragEvent, itemData: { _id: string; [key: string]: unknown }) {
         return onSortItem(this, event, itemData);
     }
 
-    async _onSortCrew(event: any, data: any) {
+    async _onSortCrew(event: DragEvent, data: { crewUuid: string }) {
         return onSortCrew(this, event, data);
     }
 
-    async _onSortContainerItem(event: any, itemData: any) {
+    async _onSortContainerItem(event: DragEvent, itemData: { _id: string; [key: string]: unknown }) {
         return onSortContainerItem(this, event, itemData);
     }
 
-    async _onSortCargoItem(event: any, itemData: any) {
+    async _onSortCargoItem(event: DragEvent, itemData: { _id: string; [key: string]: unknown }) {
         return onSortCargoItem(this, event, itemData);
     }
 

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -13,6 +13,7 @@ import {registerDragListeners} from "./sheet-listeners/drag";
 
 // Helper modules
 import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
+import {isCharacterActor} from "../system/type-guards";
 import {deleteItem, addItem, onItemCreate} from "./sheet-helpers/item-crud";
 import {
     onDropCharacterTemplate, onDropSpeciesTemplate, onDropItemGroup,
@@ -163,6 +164,7 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         root.querySelectorAll(".create-character").forEach((elem) =>
             elem.addEventListener("click", async () => {
+                if (!isCharacterActor(this.document)) return;
                 const newChar = new OD6SCreateCharacter(this.document,
                     od6sutilities.getAllItemsByType("character-template"));
                 newChar.render({force: true});

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -169,7 +169,7 @@ export async function onDropItem(sheet: DropSheetLike, event: DragEvent, data: D
 
     // Handle item sorting within the same Actor
     if (item.parent !== null && data.uuid!.startsWith(item.parent.uuid)) {
-        if (sheet.document.type === 'starship' || sheet.document.type === 'vehicle' &&
+        if ((sheet.document.type === 'starship' || sheet.document.type === 'vehicle') &&
             !OD6S.allowedItemTypes[sheet.document.type].includes(itemData.type)) {
             await sheet._onSortItem(event, itemData);
             await sheet._onSortCargoItem(event, itemData);

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -10,15 +10,45 @@ import {
 } from "../../system/type-guards";
 
 /**
+ * Minimal sheet shape consumed by the drop helpers. Avoiding `OD6SActorSheet`
+ * here breaks the actor-sheet ↔ helpers import cycle.
+ */
+interface DropSheetLike {
+    document: Actor;
+    render: () => unknown;
+    linkCrew: (uuid: string) => Promise<unknown>;
+    _isEquippable: (type: string) => boolean;
+    _createAction: (data: {
+        name: string; type?: string; subtype: string; rollable?: boolean | string; itemId?: string
+    }) => Promise<unknown>;
+    _onSortItem: (event: DragEvent, data: { _id: string; [key: string]: unknown }) => unknown;
+    _onSortCrew: (event: DragEvent, data: { crewUuid: string }) => unknown;
+    _onSortCargoItem: (event: DragEvent, data: { _id: string; [key: string]: unknown }) => unknown;
+    _onSortContainerItem: (event: DragEvent, data: { _id: string; [key: string]: unknown }) => unknown;
+}
+
+/** Drop payload returned by the drag-drop layer; type/uuid plus arbitrary extras. */
+type DropData = Record<string, unknown> & {
+    type?: string;
+    uuid?: string;
+    actorId?: string;
+    sceneId?: string;
+    tokenId?: string;
+    actor?: string;
+    itemId?: string;
+    _id?: string;
+};
+
+/**
  * Override for the _onDrop handler.
  */
-export async function onDrop(sheet: any, event: any) {
+export async function onDrop(sheet: DropSheetLike, event: DragEvent | { preventDefault: () => unknown; dataTransfer: { getData: (k: string) => string }; target?: unknown; currentTarget?: unknown }) {
     event.preventDefault();
     // Try to extract the data
 
-    let data;
+    let data: DropData;
     try {
-        data = JSON.parse(event.dataTransfer.getData('text/plain'));
+        data = JSON.parse(event.dataTransfer!.getData('text/plain')) as DropData;
     } catch {
         return false;
     }
@@ -31,20 +61,20 @@ export async function onDrop(sheet: any, event: any) {
     // Handle different data types
     switch (data.type) {
         case "ActiveEffect":
-            return onDropActiveEffect(sheet, event, data);
+            return onDropActiveEffect(sheet, event as Event, data);
         case "Actor":
-            return onDropActor(sheet, event, data);
+            return onDropActor(sheet, event as Event, data);
         case "Item": {
             const item = await Item.fromDropData(data);
             switch (item.type) {
                 case "character-template":
-                    if (isCharacterTemplateItem(item)) return onDropCharacterTemplate(sheet, event, item, data);
+                    if (isCharacterTemplateItem(item)) return onDropCharacterTemplate(sheet, event as Event, item, data);
                     return;
                 case "item-group":
-                    if (isItemGroupItem(item)) return onDropItemGroup(sheet, event, item, data);
+                    if (isItemGroupItem(item)) return onDropItemGroup(sheet, event as Event, item, data);
                     return;
                 case "species-template":
-                    if (isSpeciesTemplateItem(item)) return onDropSpeciesTemplate(sheet, event, item, data);
+                    if (isSpeciesTemplateItem(item)) return onDropSpeciesTemplate(sheet, event as Event, item, data);
                     return;
                 case "skill": {
                     if (!isSkillItem(item)) return;
@@ -53,7 +83,7 @@ export async function onDrop(sheet: any, event: any) {
                         ui.notifications.error(game.i18n.localize('OD6S.MISSING_ATTRIBUTE'))
                         return;
                     } else {
-                        return onDropItem(sheet, event, data);
+                        return onDropItem(sheet, event as DragEvent, data);
                     }
                 }
                 case "specialization": {
@@ -69,31 +99,32 @@ export async function onDrop(sheet: any, event: any) {
                         ui.notifications.warn(game.i18n.localize('OD6S.DOES_NOT_POSSESS_SKILL'));
                         return;
                     } else {
-                        return onDropItem(sheet, event, data);
+                        return onDropItem(sheet, event as DragEvent, data);
                     }
                 }
                 default:
-                    return onDropItem(sheet, event, data);
+                    return onDropItem(sheet, event as DragEvent, data);
             }
         }
         case "Folder":
-            return onDropFolder(sheet, event, data);
+            return onDropFolder(sheet, event as DragEvent, data);
         case "availableaction":
-            return await sheet._createAction(data);
+            return await sheet._createAction(data as unknown as Parameters<typeof sheet._createAction>[0]);
         case "assignedaction":
             data.type = "action";
             data._id = data.itemId;
-            return await sheet._onSortItem(event, data);
+            return await sheet._onSortItem(event as DragEvent, data as { _id: string; [k: string]: unknown });
         case "crewmember":
-            return await sheet._onSortCrew(event, data);
+            return await sheet._onSortCrew(event as DragEvent, data as { crewUuid: string });
     }
     sheet.render();
+    return undefined;
 }
 
 /**
  * Override for the _onDropItem handler.
  */
-export async function onDropItem(sheet: any, event: any, data: any) {
+export async function onDropItem(sheet: DropSheetLike, event: DragEvent, data: DropData) {
     if (!sheet.document.isOwner) return false;
     const item = await Item.implementation.fromDropData(data);
     const itemData = item.toObject();
@@ -111,7 +142,7 @@ export async function onDropItem(sheet: any, event: any, data: any) {
             itemData.type !== 'advantage' &&
             itemData.type !== 'disadvantage' &&
             itemData.type !== 'specialability') {
-            itemData.effects.forEach((i: any) => {
+            (itemData.effects as Array<{ disabled?: boolean; transfer?: boolean }>).forEach((i) => {
                 i.disabled = true;
             })
         }
@@ -129,7 +160,7 @@ export async function onDropItem(sheet: any, event: any, data: any) {
             if (sheet._isEquippable(itemData.type)) {
                 itemData.system.equipped.value = false;
             }
-            itemData.effects.forEach((i: any) => {
+            (itemData.effects as Array<{ disabled?: boolean; transfer?: boolean }>).forEach((i) => {
                 i.disabled = true;
                 i.transfer = false;
             })
@@ -137,7 +168,7 @@ export async function onDropItem(sheet: any, event: any, data: any) {
     }
 
     // Handle item sorting within the same Actor
-    if (item.parent !== null && data.uuid.startsWith(item.parent.uuid)) {
+    if (item.parent !== null && data.uuid!.startsWith(item.parent.uuid)) {
         if (sheet.document.type === 'starship' || sheet.document.type === 'vehicle' &&
             !OD6S.allowedItemTypes[sheet.document.type].includes(itemData.type)) {
             await sheet._onSortItem(event, itemData);
@@ -152,8 +183,8 @@ export async function onDropItem(sheet: any, event: any, data: any) {
         let sourceActor;
         if (typeof (data.actorId) !== 'undefined' && data.actorId !== null && data.actor !== '') {
             if (typeof (data.tokenId) !== 'undefined' && data.tokenId !== null && data.tokenId !== '') {
-                const scene = game.scenes.get(data.sceneId);
-                // @ts-expect-error
+                const scene = game.scenes.get(data.sceneId!);
+                // @ts-expect-error - synthetic .object on TokenDocument set by canvas
                 sourceActor = scene!.tokens.get(data.tokenId).object.actor;
             } else {
                 sourceActor = game.actors.get(data.actorId);
@@ -179,25 +210,26 @@ export async function onDropItem(sheet: any, event: any, data: any) {
 /**
  * Override for the _onDropActor handler.
  */
-export async function onDropActor(sheet: any, event: any, data: any) {
+export async function onDropActor(sheet: DropSheetLike, _event: Event, data: DropData) {
     if (!sheet.document.isOwner) return false;
 
     if (sheet.document.type === "vehicle" || sheet.document.type === "starship") {
-        if (sheet.document.system.embedded_pilot.value) {
+        if ((sheet.document.system as { embedded_pilot: { value: boolean } }).embedded_pilot.value) {
             let pilotActor: Actor | undefined;
-            if (data.uuid.startsWith('Compendium')) {
-                pilotActor = await fromUuid(data.uuid);
+            if (data.uuid!.startsWith('Compendium')) {
+                pilotActor = await fromUuid(data.uuid!);
             } else {
-                pilotActor = await od6sutilities.getActorFromUuid(data.uuid);
+                pilotActor = await od6sutilities.getActorFromUuid(data.uuid!);
             }
             if (typeof (pilotActor) === 'undefined') {
                 ui.notifications.warn(game.i18n.localize('OD6S.ACTOR_NOT_FOUND'));
                 return false;
             }
 
-            await sheet.document.addEmbeddedPilot(pilotActor);
+            await (sheet.document as Actor & { addEmbeddedPilot: (a: Actor) => Promise<unknown> })
+                .addEmbeddedPilot(pilotActor);
         } else {
-            await sheet.linkCrew(data.uuid);
+            await sheet.linkCrew(data.uuid!);
         }
     }
     return undefined;
@@ -208,11 +240,9 @@ export async function onDropActor(sheet: any, event: any, data: any) {
  * `_onDropActiveEffect`; ActorSheetV2 does not, so the prior call site
  * threw TypeError and the drop silently failed (#71).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function onDropActiveEffect(sheet: any, _event: any, data: any) {
+export async function onDropActiveEffect(sheet: DropSheetLike, _event: Event, data: DropData) {
     if (!sheet.document.isOwner) return false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const effect = await (ActiveEffect as any).implementation.fromDropData(data);
+    const effect = await ActiveEffect.implementation.fromDropData(data);
     if (!effect) return false;
     // Don't re-create an effect that's already on this actor.
     if (effect.target === sheet.document) return false;
@@ -229,21 +259,20 @@ export async function onDropActiveEffect(sheet: any, _event: any, data: any) {
  * flags, effect transfer disabling, container repacks) all apply
  * exactly as they would for an individual drop.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function onDropFolder(sheet: any, event: any, data: any) {
+export async function onDropFolder(sheet: DropSheetLike, event: DragEvent, data: DropData) {
     if (!sheet.document.isOwner) return false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const folder = await (Folder as any).implementation.fromDropData(data);
+    const folder = await Folder.implementation.fromDropData(data);
     if (!folder || folder.type !== "Item") return false;
 
     // Folder.children is an array of {folder, depth, root} wrappers in
     // v14 client side; .contents is the immediate documents.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const collected: any[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const walk = (f: any) => {
+    const collected: FoundryDocument[] = [];
+    const walk = (f: Folder) => {
         for (const doc of f.contents ?? []) collected.push(doc);
-        for (const child of f.children ?? []) walk(child.folder ?? child);
+        for (const child of f.children ?? []) {
+            const sub = (child as { folder?: Folder }).folder ?? (child as Folder);
+            walk(sub);
+        }
     };
     walk(folder);
 

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -34,7 +34,6 @@ type DropData = Record<string, unknown> & {
     actorId?: string;
     sceneId?: string;
     tokenId?: string;
-    actor?: string;
     itemId?: string;
     _id?: string;
 };
@@ -181,7 +180,7 @@ export async function onDropItem(sheet: DropSheetLike, event: DragEvent, data: D
     } else {
         // Could be dragging from sheet to sheet
         let sourceActor;
-        if (typeof (data.actorId) !== 'undefined' && data.actorId !== null && data.actor !== '') {
+        if (typeof (data.actorId) !== 'undefined' && data.actorId !== null && data.actorId !== '') {
             if (typeof (data.tokenId) !== 'undefined' && data.tokenId !== null && data.tokenId !== '') {
                 const scene = game.scenes.get(data.sceneId!);
                 // @ts-expect-error - synthetic .object on TokenDocument set by canvas
@@ -197,7 +196,7 @@ export async function onDropItem(sheet: DropSheetLike, event: DragEvent, data: D
                     await sourceActor!.deleteEmbeddedDocuments('Item', [item.id]);
                 }
             } else {
-                ui.notifications.warn('OD6S.WARN_NOT_DELETING_ITEM_OWNER');
+                ui.notifications.warn(game.i18n.localize('OD6S.WARN_NOT_DELETING_ITEM_OWNER'));
             }
         } else {
             await sheet.document.createEmbeddedDocuments("Item", [itemData]);

--- a/src/module/actor/sheet-helpers/drops.ts
+++ b/src/module/actor/sheet-helpers/drops.ts
@@ -1,7 +1,13 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {onDropCharacterTemplate, onDropItemGroup, onDropSpeciesTemplate} from "./templates";
-import {isSkillItem, isSpecializationItem} from "../../system/type-guards";
+import {
+    isCharacterTemplateItem,
+    isItemGroupItem,
+    isSkillItem,
+    isSpecializationItem,
+    isSpeciesTemplateItem,
+} from "../../system/type-guards";
 
 /**
  * Override for the _onDrop handler.
@@ -32,11 +38,14 @@ export async function onDrop(sheet: any, event: any) {
             const item = await Item.fromDropData(data);
             switch (item.type) {
                 case "character-template":
-                    return onDropCharacterTemplate(sheet, event, item, data);
+                    if (isCharacterTemplateItem(item)) return onDropCharacterTemplate(sheet, event, item, data);
+                    return;
                 case "item-group":
-                    return onDropItemGroup(sheet, event, item, data);
+                    if (isItemGroupItem(item)) return onDropItemGroup(sheet, event, item, data);
+                    return;
                 case "species-template":
-                    return onDropSpeciesTemplate(sheet, event, item, data);
+                    if (isSpeciesTemplateItem(item)) return onDropSpeciesTemplate(sheet, event, item, data);
+                    return;
                 case "skill": {
                     if (!isSkillItem(item)) return;
                     const sys = item.system;

--- a/src/module/actor/sheet-helpers/sorting.ts
+++ b/src/module/actor/sheet-helpers/sorting.ts
@@ -1,29 +1,46 @@
 /**
+ * Minimal sheet shape used by these sort helpers — keeps them decoupled
+ * from `OD6SActorSheet` to avoid circular imports.
+ */
+interface ActorSheetLike {
+    document: Actor;
+}
+
+/** Drop payload accumulated by Foundry's drag-drop pipeline. */
+type SortDropData = { _id: string; [key: string]: unknown };
+
+/** Subset of the crew-drop payload we actually read here. */
+interface CrewSortData { crewUuid: string }
+
+/**
  * Sort items within the actor sheet.
  */
-export function onSortItem(sheet: any, event: any, itemData: any) {
+export function onSortItem(sheet: ActorSheetLike, event: DragEvent, itemData: SortDropData) {
     // Get the drag source and drop target
     const items = sheet.document.items;
     const source = items.get(itemData._id);
-    const dropTarget = event.target.closest("li[data-item-id]");
+    const dropTarget = (event.target as HTMLElement | null)?.closest("li[data-item-id]") as
+        HTMLElement | null;
     if (!dropTarget) return;
-    const target = items.get(dropTarget.dataset.itemId);
+    const target = items.get(dropTarget.dataset.itemId!);
 
     // Don't sort on yourself
     if (source!.id === target!.id) return;
 
     // Identify sibling items based on adjacent HTML elements
-    const siblings = [];
-    for (const el of dropTarget.parentElement.children) {
+    const siblings: Item[] = [];
+    for (const el of dropTarget.parentElement!.children as HTMLCollectionOf<HTMLElement>) {
         const siblingId = el.dataset.itemId;
-        if (siblingId && (siblingId !== source!.id)) siblings.push(items.get(el.dataset.itemId));
+        if (!siblingId || siblingId === source!.id) continue;
+        const sib = items.get(siblingId);
+        if (sib) siblings.push(sib);
     }
 
     // Perform the sort
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target, siblings});
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
-        update._id = u.target._id;
+        update._id = u.target!._id;
         return update;
     });
 
@@ -34,18 +51,22 @@ export function onSortItem(sheet: any, event: any, itemData: any) {
 /**
  * Sort crew members within the vehicle sheet.
  */
-export async function onSortCrew(sheet: any, event: any, data: any) {
-    const crewMembers = [...sheet.document.system.crewmembers];
-    const source = crewMembers.filter((c: {uuid: string; sort?: number}) => c.uuid === data.crewUuid)[0];
-    const dropTarget = event.target.closest("li[data-crew-uuid]");
+export async function onSortCrew(sheet: ActorSheetLike, event: DragEvent, data: CrewSortData) {
+    type CrewMember = { uuid: string; sort?: number };
+    const crewMembers = [...(sheet.document.system as { crewmembers: CrewMember[] }).crewmembers];
+    const source = crewMembers.filter((c) => c.uuid === data.crewUuid)[0];
+    const dropTarget = (event.target as HTMLElement | null)?.closest("li[data-crew-uuid]") as
+        HTMLElement | null;
     if (!dropTarget) return;
-    const target = crewMembers.filter((c: {uuid: string; sort?: number}) => c.uuid === dropTarget.dataset.crewUuid)[0];
+    const target = crewMembers.filter((c) => c.uuid === dropTarget.dataset.crewUuid)[0];
 
     // Identify sibling items based on adjacent HTML elements
-    const siblings = [];
-    for (const el of dropTarget.parentElement.children) {
+    const siblings: CrewMember[] = [];
+    for (const el of dropTarget.parentElement!.children as HTMLCollectionOf<HTMLElement>) {
         const siblingId = el.dataset.crewUuid;
-        if (siblingId && (siblingId !== source.uuid)) siblings.push(crewMembers.filter((c: {uuid: string; sort?: number}) => c.uuid === el.dataset.crewUuid)[0]);
+        if (siblingId && (siblingId !== source.uuid)) {
+            siblings.push(crewMembers.filter((c) => c.uuid === siblingId)[0]);
+        }
     }
 
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target, siblings});
@@ -64,7 +85,7 @@ export async function onSortCrew(sheet: any, event: any, data: any) {
         }
     }
 
-    crewMembers.sort((a: {sort?: number}, b: {sort?: number}) => (a.sort ?? 0) - (b.sort ?? 0));
+    crewMembers.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
 
     const updateObject = {
         system: {
@@ -78,7 +99,7 @@ export async function onSortCrew(sheet: any, event: any, data: any) {
 /**
  * Sort cargo items within a vehicle/starship.
  */
-export async function onSortCargoItem(sheet: any, event: any, itemData: any) {
+export async function onSortCargoItem(sheet: ActorSheetLike, event: DragEvent, itemData: SortDropData) {
     // Get the drag source and its siblings
     const source = sheet.document.items.get(itemData._id);
     const siblings = sheet.document.items.filter((i: Item) => {
@@ -86,7 +107,8 @@ export async function onSortCargoItem(sheet: any, event: any, itemData: any) {
     });
 
     // Get the drop target
-    const dropTarget = event.target.closest("[data-item-id]");
+    const dropTarget = (event.target as HTMLElement | null)?.closest("[data-item-id]") as
+        HTMLElement | null;
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
     const target = siblings.find((s: Item) => s._id === targetId);
 
@@ -94,7 +116,7 @@ export async function onSortCargoItem(sheet: any, event: any, itemData: any) {
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target: target, siblings});
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
-        update._id = u.target._id;
+        update._id = u.target!._id;
         return update;
     });
 
@@ -105,7 +127,7 @@ export async function onSortCargoItem(sheet: any, event: any, itemData: any) {
 /**
  * Sort items within a container.
  */
-export async function onSortContainerItem(sheet: any, event: any, itemData: any) {
+export async function onSortContainerItem(sheet: ActorSheetLike, event: DragEvent, itemData: SortDropData) {
     // Get the drag source and its siblings
     const source = sheet.document.items.get(itemData._id);
     const siblings = sheet.document.items.filter((i: Item) => {
@@ -113,7 +135,8 @@ export async function onSortContainerItem(sheet: any, event: any, itemData: any)
     });
 
     // Get the drop target
-    const dropTarget = event.target.closest("[data-item-id]");
+    const dropTarget = (event.target as HTMLElement | null)?.closest("[data-item-id]") as
+        HTMLElement | null;
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
     const target = siblings.find((s: Item) => s._id === targetId);
 
@@ -124,7 +147,7 @@ export async function onSortContainerItem(sheet: any, event: any, itemData: any)
     const sortUpdates = SortingHelpers.performIntegerSort(source, {target: target, siblings});
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
-        update._id = u.target._id;
+        update._id = u.target!._id;
         return update;
     });
 

--- a/src/module/actor/sheet-helpers/templates.ts
+++ b/src/module/actor/sheet-helpers/templates.ts
@@ -3,9 +3,23 @@ import OD6S from "../../config/config-od6s";
 import {isSkillItem} from "../../system/type-guards";
 
 /**
+ * Minimal sheet shape used by the template helpers. Avoiding `OD6SActorSheet`
+ * here breaks the actor-sheet ↔ helpers import cycle.
+ */
+interface ActorSheetLike {
+    document: Actor;
+    render: () => unknown;
+}
+
+/**
  * Add a character template to an actor via drop.
  */
-export async function onDropCharacterTemplate(sheet: any, event: any, item: any, _data: any) {
+export async function onDropCharacterTemplate(
+    sheet: ActorSheetLike,
+    _event: Event,
+    item: OD6SCharacterTemplateItem,
+    _data: Record<string, unknown>,
+): Promise<false | undefined> {
     if (!sheet.document.isOwner) return false;
     if (sheet.document.type !== 'character') return false;
     // Check if a template has already been assigned to this actor
@@ -20,10 +34,12 @@ export async function onDropCharacterTemplate(sheet: any, event: any, item: any,
 /**
  * Add a species template to an actor via drop.
  */
-export async function onDropSpeciesTemplate(sheet: any, event: any, item: any, _data: any) {
-    const update: any = {};
-    update.system = {};
-
+export async function onDropSpeciesTemplate(
+    sheet: ActorSheetLike,
+    _event: Event,
+    item: OD6SSpeciesTemplateItem,
+    _data: Record<string, unknown>,
+): Promise<false | undefined> {
     if (!sheet.document.isOwner) return false;
     if (sheet.document.type !== 'character' && sheet.document.type !== 'npc') return false;
     if (sheet.document.items.find((E: Item) => E.type === 'species-template')) {
@@ -31,13 +47,15 @@ export async function onDropSpeciesTemplate(sheet: any, event: any, item: any, _
         return false;
     }
 
-    update.system.attributes = {};
+    const update: Record<string, unknown> = {};
+    const attributes: Record<string, { min: number; max: number }> = {};
     for (const attribute in item.system.attributes) {
-        update.system.attributes[attribute] = {};
-        update.system.attributes[attribute].min = item.system.attributes[attribute].min;
-        update.system.attributes[attribute].max = item.system.attributes[attribute].max;
+        attributes[attribute] = {
+            min: item.system.attributes[attribute as keyof typeof item.system.attributes].min,
+            max: item.system.attributes[attribute as keyof typeof item.system.attributes].max,
+        };
     }
-
+    update.system = {attributes};
     update['system.species.content'] = item.name;
     update.id = sheet.document.id;
     await sheet.document.update(update, {diff: true});
@@ -53,7 +71,12 @@ export async function onDropSpeciesTemplate(sheet: any, event: any, item: any, _
 /**
  * Add an item group to an actor via drop.
  */
-export async function onDropItemGroup(sheet: any, event: any, item: any, _data: any) {
+export async function onDropItemGroup(
+    sheet: ActorSheetLike,
+    _event: Event,
+    item: OD6SItemGroupItem,
+    _data: Record<string, unknown>,
+): Promise<false | undefined> {
     if (!sheet.document.isOwner) return false;
 
     // Compare group target type to actor type
@@ -69,27 +92,31 @@ export async function onDropItemGroup(sheet: any, event: any, item: any, _data: 
 /**
  * Apply a character template to an actor.
  */
-export async function addCharacterTemplate(sheet: any, item: any) {
+export async function addCharacterTemplate(
+    sheet: ActorSheetLike,
+    item: OD6SCharacterTemplateItem,
+): Promise<void> {
     const itemData = item.system;
-    const update: any = {};
-    update.system = {};
+    const update: Record<string, unknown> = {};
+    const system: Record<string, unknown> = {};
 
     // Set the actor's data to be equal to the data found in the template
-    update.system['chartype.content'] = item.name;
-    if (update.system['species.content'] === '') {
-        update.system['species.content'] = itemData.species;
+    system['chartype.content'] = item.name;
+    if (system['species.content'] === '') {
+        system['species.content'] = itemData.species;
     }
-    update.system['fatepoints.value'] = itemData.fp;
-    update.system['characterpoints.value'] = itemData.cp;
-    update.system['credits.value'] = itemData.credits;
-    update.system['funds.score'] = itemData.funds;
-    update.system['move.value'] = itemData.move;
-    update.system['background.content'] = itemData.description;
-    update.system['metaphysicsextranormal.value'] = itemData.me;
+    system['fatepoints.value'] = itemData.fp;
+    system['characterpoints.value'] = itemData.cp;
+    system['credits.value'] = itemData.credits;
+    system['funds.score'] = itemData.funds;
+    system['move.value'] = itemData.move;
+    system['background.content'] = itemData.description;
+    system['metaphysicsextranormal.value'] = itemData.me;
 
     for (const attribute in itemData.attributes) {
-        update.system[`attributes.${attribute}.base`] = itemData.attributes[attribute];
+        system[`attributes.${attribute}.base`] = itemData.attributes[attribute as keyof typeof itemData.attributes];
     }
+    update.system = system;
     update.id = sheet.document.id;
     await sheet.document.update(update, {diff: true});
 
@@ -103,10 +130,13 @@ export async function addCharacterTemplate(sheet: any, item: any) {
 /**
  * Takes an array of item names and returns an array of items.
  */
-export async function templateItems(sheet: any, itemList: any) {
+export async function templateItems(
+    sheet: ActorSheetLike,
+    itemList: OD6STemplateItemEntry[],
+): Promise<Item[]> {
     // Loop through template items and add to actor from world, then compendia.
     // Filter out items if config is set to do so.
-    const result = [];
+    const result: Item[] = [];
     for (const i of itemList) {
         let templateItem: Item | null | undefined = await od6sutilities._getItemFromWorld(i.name);
         if (typeof (templateItem) === 'undefined' || templateItem === null) {
@@ -119,7 +149,7 @@ export async function templateItems(sheet: any, itemList: any) {
         if ((i.type === 'advantage' || i.type === 'disadvantage') &&
             game.settings.get('od6s', 'hide_advantages_disadvantages')) continue;
         if (typeof i.description !== 'undefined' && i.description !== '' && i.description !== null) {
-            templateItem.description = i.description;
+            (templateItem as Item & { description?: string }).description = i.description;
         }
 
         // Filter out duplicate skills/specializations by name
@@ -143,33 +173,33 @@ export async function templateItems(sheet: any, itemList: any) {
 /**
  * Clear the character template from an actor.
  */
-export async function onClearCharacterTemplate(sheet: any) {
+export async function onClearCharacterTemplate(sheet: ActorSheetLike): Promise<boolean> {
     // Find the template
-    const item = sheet.document.items.find((E: Item) => E.type === 'character-template');
+    const item = sheet.document.items.find((E: Item) => E.type === 'character-template') as
+        OD6SCharacterTemplateItem | undefined;
     if (item) {
         const itemData = item.system;
-        const update: any = {};
-        update.system = {};
+        const system: Record<string, unknown> = {};
 
         // Clear template stuff from the actor
         for (const attribute in itemData.attributes) {
-            update.system[`attributes.${attribute}.base`] = 0;
+            system[`attributes.${attribute}.base`] = 0;
         }
 
-        update.system['chartype.content'] = "";
+        system['chartype.content'] = "";
         const speciesTemplate = sheet.document.items.find((E: Item) => E.type === 'species-template');
-        if (!speciesTemplate) update.system['species.content'] = "";
-        update.system['fatepoints.value'] = 0;
-        update.system['characterpoints.value'] = 0;
-        update.system['credits.value'] = 0;
-        update.system['funds.score'] = 0;
-        update.system['background.content'] = "";
-        update.system['metaphysicsextranormal.value'] = false;
-        update.system['move.value'] = 10;
-        update.id = sheet.document.id;
+        if (!speciesTemplate) system['species.content'] = "";
+        system['fatepoints.value'] = 0;
+        system['characterpoints.value'] = 0;
+        system['credits.value'] = 0;
+        system['funds.score'] = 0;
+        system['background.content'] = "";
+        system['metaphysicsextranormal.value'] = false;
+        system['move.value'] = 10;
+        const update: Record<string, unknown> = {system, id: sheet.document.id};
         await sheet.document.update(update, {diff: true});
 
-        if (itemData.items !== null && typeof(itemData.items !== 'undefined')) {
+        if (itemData.items != null) {
             for (const templateItem of itemData.items) {
                 const actorItem = sheet.document.items.find((I: Item) => I.name === templateItem.name);
                 if (typeof (actorItem) !== 'undefined') {
@@ -190,26 +220,27 @@ export async function onClearCharacterTemplate(sheet: any) {
 /**
  * Clear the species template from an actor.
  */
-export async function onClearSpeciesTemplate(sheet: any) {
-    // Find the template
-    const update: any = {};
-    update.system = {};
-
-    const item = sheet.document.items.find((E: Item) => E.type === 'species-template');
+export async function onClearSpeciesTemplate(sheet: ActorSheetLike): Promise<boolean> {
+    const item = sheet.document.items.find((E: Item) => E.type === 'species-template') as
+        OD6SSpeciesTemplateItem | undefined;
     if (item) {
         const itemData = item.system;
+        const update: Record<string, unknown> = {};
 
         // Set attribute min/max to default
-        for (const attribute in sheet.document.system.attributes) {
+        const docSystem = sheet.document.system as { attributes?: Record<string, unknown> };
+        for (const attribute in docSystem.attributes ?? {}) {
             if (attribute !== 'met') {
-                update[`system.attributes.${attribute}`] = {};
-                update[`system.attributes.${attribute}`].min = OD6S.pipsPerDice * OD6S.speciesMinDice;
-                update[`system.attributes.${attribute}`].max = OD6S.pipsPerDice * OD6S.speciesMaxDice;
+                update[`system.attributes.${attribute}`] = {
+                    min: OD6S.pipsPerDice * OD6S.speciesMinDice,
+                    max: OD6S.pipsPerDice * OD6S.speciesMaxDice,
+                };
             }
         }
 
         // Clear the species name from the template; check if a character template is applied and replace it from there
-        const characterTemplate = sheet.document.items.find((E: Item) => E.type === 'character-template');
+        const characterTemplate = sheet.document.items.find((E: Item) => E.type === 'character-template') as
+            OD6SCharacterTemplateItem | undefined;
         if (characterTemplate) {
             update[`system.species.content`] = characterTemplate.system.species;
         } else {
@@ -217,7 +248,7 @@ export async function onClearSpeciesTemplate(sheet: any) {
         }
 
         // Remove items
-        if (itemData.items !== null && typeof(itemData.items !== 'undefined')) {
+        if (itemData.items != null) {
             for (const templateItem of itemData.items) {
                 const actorItem = sheet.document.items.find((I: Item) => I.name === templateItem.name);
                 if (typeof (actorItem) !== 'undefined') {

--- a/src/module/actor/sheet-helpers/templates.ts
+++ b/src/module/actor/sheet-helpers/templates.ts
@@ -100,9 +100,13 @@ export async function addCharacterTemplate(
     const update: Record<string, unknown> = {};
     const system: Record<string, unknown> = {};
 
-    // Set the actor's data to be equal to the data found in the template
+    // Set the actor's data to be equal to the data found in the template.
+    // Only fill species from the template if the actor doesn't already have one
+    // (e.g. from a previously-applied species-template item).
     system['chartype.content'] = item.name;
-    if (system['species.content'] === '') {
+    const currentSpecies = (sheet.document.system as { species?: { content?: string } })
+        .species?.content ?? '';
+    if (currentSpecies === '') {
         system['species.content'] = itemData.species;
     }
     system['fatepoints.value'] = itemData.fp;
@@ -154,7 +158,7 @@ export async function templateItems(
 
         // Filter out duplicate skills/specializations by name
         if (i.type === 'skill' || i.type === 'specialization' || i.type === 'specialability' ||
-            i.type === 'disadvantage' || i.type === 'advanatage') {
+            i.type === 'disadvantage' || i.type === 'advantage') {
             if (sheet.document.items.filter((e: Item) => e.type === i.type && e.name === i.name).length) {
                 continue;
             }

--- a/src/module/apps/character-creation.ts
+++ b/src/module/apps/character-creation.ts
@@ -313,7 +313,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             elem.addEventListener("click", async (ev) => {
                 ev.preventDefault();
                 if (this.specScore === 0 && this.skillScore < OD6S.pipsPerDice) {
-                    (ui.notifications as any).warning("OD6S.NOT_ENOUGH_SKILL_DICE");
+                    ui.notifications.warn(game.i18n.localize("OD6S.NOT_ENOUGH_SKILL_DICE"));
                     return;
                 }
                 const specData = (ev.currentTarget as HTMLElement).dataset as DOMStringMap;
@@ -358,7 +358,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             const before = {skill: this.skillScore, spec: this.specScore};
             const result = addSpecDiceBudget(this.skillScore, this.specScore, getAllocationConfig());
             if (!result.ok) {
-                ui.notifications.warn("OD6S.NOT_ENOUGH_SKILL_DICE");
+                ui.notifications.warn(game.i18n.localize("OD6S.NOT_ENOUGH_SKILL_DICE"));
             } else {
                 this.skillScore = result.skillScore;
                 this.specScore = result.specScore;
@@ -372,7 +372,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             const before = {skill: this.skillScore, spec: this.specScore};
             const result = removeSpecDiceBudget(this.skillScore, this.specScore, getAllocationConfig());
             if (!result.ok) {
-                ui.notifications.warn("OD6S.NOT_ENOUGH_SPECIALIZATION_DICE");
+                ui.notifications.warn(game.i18n.localize("OD6S.NOT_ENOUGH_SPECIALIZATION_DICE"));
             } else {
                 this.skillScore = result.skillScore;
                 this.specScore = result.specScore;

--- a/src/module/apps/character-creation.ts
+++ b/src/module/apps/character-creation.ts
@@ -13,6 +13,21 @@ import {debug} from "../system/logger";
 
 const {ApplicationV2, HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
 
+/** Lightweight summary objects returned by `getAllItemsByType("character-template")`. */
+type CharacterTemplateSummary = {_id: string; name: string; type: string; description?: string};
+
+/** State of the in-progress custom-template form. */
+interface CustomTemplateState {
+    templateName: string;
+    attributeScore: number;
+    characterPoints: number;
+    fatePoints: number;
+    move: number;
+    attributeDice: number;
+    attributes: Record<string, number>;
+    me: boolean;
+}
+
 function getAllocationConfig(): AllocationConfig {
     return {
         pipsPerDice: OD6S.pipsPerDice,
@@ -24,33 +39,37 @@ function getAllocationConfig(): AllocationConfig {
 
 export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(ApplicationV2) {
 
-    actor: any;
-    characterTemplates: any;
-    selectedTemplate: any = "";
-    templateData: any = {};
+    actor: OD6SCharacterActor;
+    characterTemplates: CharacterTemplateSummary[];
+    selectedTemplate: string | null = "";
+    templateData: OD6SCharacterTemplateItem | Record<string, never>;
     skillScore: number;
     specScore = 0;
-    custom: any = {};
+    custom: CustomTemplateState;
     done = false;
     step = 1;
-    customTemplate: any = {};
+    customTemplate: { name?: string } = {};
 
-    constructor(actor: any, templates: any, options: any = {}) {
+    constructor(actor: OD6SCharacterActor, templates: CharacterTemplateSummary[], options: object = {}) {
         super(options);
         this.actor = actor;
         this.characterTemplates = templates;
         this.skillScore = OD6S.initialSkills;
-        this.custom.templateName = game.i18n.localize("OD6S.CREATE_CUSTOM_TEMPLATE");
-        this.custom.attributeScore = OD6S.initialAttributes;
-        this.custom.characterPoints = OD6S.initialCharacterPoints;
-        this.custom.fatePoints = OD6S.initialFatePoints;
-        this.custom.move = OD6S.initialMove;
-        this.custom.attributeDice = OD6S.initialAttributes;
-        this.custom.attributes = {};
+        this.templateData = {};
+        const attributes: Record<string, number> = {};
         for (const a in OD6S.attributes) {
-            this.custom.attributes[a] = 0;
+            attributes[a] = 0;
         }
-        this.custom.me = false;
+        this.custom = {
+            templateName: game.i18n.localize("OD6S.CREATE_CUSTOM_TEMPLATE"),
+            attributeScore: OD6S.initialAttributes,
+            characterPoints: OD6S.initialCharacterPoints,
+            fatePoints: OD6S.initialFatePoints,
+            move: OD6S.initialMove,
+            attributeDice: OD6S.initialAttributes,
+            attributes,
+            me: false,
+        };
     }
 
     static DEFAULT_OPTIONS = {
@@ -82,26 +101,32 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
 
     async _prepareContext(_options?: object): Promise<object> {
         if (this.actor.system.chartype.content !== "") {
-            const idx = this.characterTemplates.findIndex((t: any) => t.name === this.actor.system.chartype.content);
+            const idx = this.characterTemplates.findIndex((t) => t.name === this.actor.system.chartype.content);
             this.selectedTemplate = idx >= 0 ? this.characterTemplates[idx]._id : null;
             const matchedTemplate = this.selectedTemplate
-                ? this.characterTemplates.find((i: any) => i._id === this.selectedTemplate)
+                ? this.characterTemplates.find((i) => i._id === this.selectedTemplate)
                 : null;
-            this.templateData = matchedTemplate
+            const loaded = matchedTemplate
                 ? await od6sutilities.getItemByName(matchedTemplate.name)
                 : null;
-            if (!this.templateData) {
+            if (!loaded) {
                 ui.notifications.error(game.i18n.localize("OD6S.ERROR_TEMPLATE_NOT_FOUND"));
                 this.templateData = {};
+            } else {
+                this.templateData = loaded as OD6SCharacterTemplateItem;
             }
         }
 
-        const attrs: any[] = [];
-        if (Object.keys(this.templateData).length !== 0) {
-            for (const attribute in this.templateData.system.attributes) {
+        const attrs: Array<{id: string; score: number; sort: number; active: boolean}> = [];
+        const tpl = this.templateData;
+        const isLoaded = (t: typeof tpl): t is OD6SCharacterTemplateItem =>
+            Object.keys(t).length !== 0;
+        if (isLoaded(tpl)) {
+            for (const attribute in tpl.system.attributes) {
+                const key = attribute as keyof typeof tpl.system.attributes;
                 attrs.push({
                     id: attribute,
-                    score: this.templateData.system.attributes[attribute],
+                    score: tpl.system.attributes[key],
                     sort: OD6S.attributes[attribute].sort,
                     active: OD6S.attributes[attribute].active,
                 });
@@ -111,7 +136,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
 
         this.done = this.skillScore === 0 && this.specScore === 0;
 
-        const data: any = {
+        const data: Record<string, unknown> = {
             attrs,
             done: this.done,
             characterTemplates: this.characterTemplates,
@@ -124,10 +149,9 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             custom: this.custom,
         };
 
-        if (typeof this.templateData.system !== "undefined"
-            && typeof this.templateData.system.items !== "undefined") {
+        if (isLoaded(tpl) && typeof tpl.system.items !== "undefined") {
             data.skills = await od6sutilities.getSkillsFromTemplate(
-                this.templateData.system.items.filter((i: any) => i.type === "skill"),
+                tpl.system.items.filter((i) => i.type === "skill") as unknown as Item[],
             );
         }
         return data;
@@ -146,7 +170,8 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             } else {
                 this.selectedTemplate = value;
                 this.templateData = await od6sutilities.getItemByName(
-                    this.characterTemplates.find((i: any) => i._id === this.selectedTemplate).name);
+                    this.characterTemplates.find((i) => i._id === this.selectedTemplate)!.name) as
+                    OD6SCharacterTemplateItem;
             }
             await this.actor.sheet._onClearCharacterTemplate();
             await this.render();
@@ -163,7 +188,9 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             elem.addEventListener("click", async (ev) => {
                 ev.preventDefault();
                 const target = ev.currentTarget as HTMLElement;
-                const skill = this.actor.items.find((s: any) => s._id === target.dataset.itemId);
+                const skill = this.actor.items.find((s: Item) => s._id === target.dataset.itemId) as
+                    OD6SSkillItem | undefined;
+                if (!skill) return;
                 this.skillScore = applySkillDelete(skill.system.base, this.skillScore);
                 await this.actor.sheet.deleteItem(ev);
                 await this.actor.sheet.getData();
@@ -175,8 +202,12 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             elem.addEventListener("click", async (ev) => {
                 ev.preventDefault();
                 const target = ev.currentTarget as HTMLElement;
-                const spec = this.actor.items.find((s: any) => s._id === target.dataset.itemId);
-                const skill = this.actor.items.find((s: any) => s.name === spec.system.skill);
+                const spec = this.actor.items.find((s: Item) => s._id === target.dataset.itemId) as
+                    OD6SSpecializationItem | undefined;
+                if (!spec) return;
+                const skill = this.actor.items.find((s: Item) => s.name === spec.system.skill) as
+                    OD6SSkillItem | undefined;
+                if (!skill) return;
                 const updated = applySpecDelete(
                     spec.system.base,
                     skill.system.base,
@@ -200,15 +231,16 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                     return;
                 }
                 const target = ev.currentTarget as HTMLElement;
-                const skill = this.actor.items.find((i: any) => i._id === target.dataset.itemId);
-                if (typeof skill !== "undefined" && skill !== "") {
-                    const updates: any[] = [{
+                const skill = this.actor.items.find((i: Item) => i._id === target.dataset.itemId);
+                if (skill) {
+                    const updates: Array<Record<string, unknown>> = [{
                         _id: skill._id,
                         id: skill.id,
                         "system.base": (+target.dataset.base!) + 1,
                     }];
                     const specs = this.actor.items
-                        .filter((i: any) => i.type === "specialization" && i.system.skill === skill.name);
+                        .filter((i: Item) => i.type === "specialization"
+                            && (i as OD6SSpecializationItem).system.skill === skill.name) as OD6SSpecializationItem[];
                     for (const spec of specs) {
                         updates.push({_id: spec.id, "system.base": spec.system.base + 1});
                     }
@@ -225,8 +257,8 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 ev.preventDefault();
                 if (this.specScore < 1) return;
                 const target = ev.currentTarget as HTMLElement;
-                const spec = this.actor.items.find((i: any) => i._id === target.dataset.itemId);
-                if (typeof spec !== "undefined" && spec !== "") {
+                const spec = this.actor.items.find((i: Item) => i._id === target.dataset.itemId);
+                if (spec) {
                     await spec.update({"system.base": (+target.dataset.base!) + 1});
                     await this.actor.sheet.getData();
                     this.specScore = this.specScore - 1;
@@ -241,15 +273,16 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 if (this.skillScore >= OD6S.initialSkills) return;
                 const target = ev.currentTarget as HTMLElement;
                 if (+target.dataset.base! < 1) return;
-                const skill = this.actor.items.find((i: any) => i._id === target.dataset.itemId);
-                if (typeof skill !== "undefined" && skill !== "") {
-                    const updates: any[] = [{
+                const skill = this.actor.items.find((i: Item) => i._id === target.dataset.itemId);
+                if (skill) {
+                    const updates: Array<Record<string, unknown>> = [{
                         _id: skill._id,
                         id: skill.id,
                         "system.base": (+target.dataset.base!) - 1,
                     }];
                     const specs = this.actor.items
-                        .filter((i: any) => i.type === "specialization" && i.system.skill === skill.name);
+                        .filter((i: Item) => i.type === "specialization"
+                            && (i as OD6SSpecializationItem).system.skill === skill.name) as OD6SSpecializationItem[];
                     for (const spec of specs) {
                         updates.push({_id: spec.id, "system.base": spec.system.base - 1});
                     }
@@ -266,8 +299,8 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 ev.preventDefault();
                 const target = ev.currentTarget as HTMLElement;
                 if (+target.dataset.base! <= 1) return;
-                const spec = this.actor.items.find((i: any) => i._id === target.dataset.itemId);
-                if (typeof spec !== "undefined" && spec !== "") {
+                const spec = this.actor.items.find((i: Item) => i._id === target.dataset.itemId);
+                if (spec) {
                     await spec.update({"system.base": (+target.dataset.base!) - 1});
                     await this.actor.sheet.getData();
                     this.specScore = this.specScore + 1;
@@ -302,17 +335,17 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
         });
 
         find(".fate-points")?.addEventListener("change", async (ev) => {
-            this.custom.fatePoints = (ev.target as HTMLInputElement).value;
+            this.custom.fatePoints = Number((ev.target as HTMLInputElement).value);
             await this.render();
         });
 
         find(".character-points")?.addEventListener("change", async (ev) => {
-            this.custom.characterPoints = (ev.target as HTMLInputElement).value;
+            this.custom.characterPoints = Number((ev.target as HTMLInputElement).value);
             await this.render();
         });
 
         find(".move")?.addEventListener("change", async (ev) => {
-            this.custom.move = (ev.target as HTMLInputElement).value;
+            this.custom.move = Number((ev.target as HTMLInputElement).value);
             await this.render();
         });
 
@@ -353,9 +386,9 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
     static async #onNext(this: OD6SCreateCharacter): Promise<void> {
         if (this.step === 1) {
             await this.actor.sheet._onClearCharacterTemplate();
-            await this.actor.deleteEmbeddedDocuments("Item", this.actor.items.map((i: any) => i.id));
+            await this.actor.deleteEmbeddedDocuments("Item", this.actor.items.map((i: Item) => i.id));
             const template = await od6sutilities.getItemByName(
-                this.characterTemplates.find((i: any) => i._id === this.selectedTemplate).name);
+                this.characterTemplates.find((i) => i._id === this.selectedTemplate)!.name);
             await this.actor.sheet._addCharacterTemplate(template);
             await this.actor.sheet.getData();
         }
@@ -366,7 +399,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
     static async #onBack(this: OD6SCreateCharacter): Promise<void> {
         if (this.step === 2) {
             await this.actor.sheet._onClearCharacterTemplate();
-            await this.actor.deleteEmbeddedDocuments("Item", this.actor.items.map((i: any) => i.id));
+            await this.actor.deleteEmbeddedDocuments("Item", this.actor.items.map((i: Item) => i.id));
         }
         this.skillScore = OD6S.initialSkills;
         this.specScore = 0;
@@ -395,7 +428,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             ui.notifications.warn(game.i18n.localize("OD6S.ERR_SPECIALIZATION_NAME"));
             return;
         }
-        if (this.actor.specializations.find((s: any) => s.name === name)) {
+        if ((this.actor as unknown as { specializations: Item[] }).specializations.find((s) => s.name === name)) {
             ui.notifications.warn(game.i18n.localize("OD6S.ERR_SPECIALIZATION_EXISTS"));
             return;
         }
@@ -442,7 +475,7 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             this.actor.sheet.render(true);
         } else {
             await this.actor.sheet._onClearCharacterTemplate();
-            await this.actor.deleteEmbeddedDocuments("Item", this.actor.items.map((i: any) => i.id));
+            await this.actor.deleteEmbeddedDocuments("Item", this.actor.items.map((i: Item) => i.id));
         }
         return this;
     }

--- a/src/module/apps/explosives-template.ts
+++ b/src/module/apps/explosives-template.ts
@@ -1,59 +1,80 @@
+/** Minimal sheet handle the explosive preview minimises/restores. */
+interface MinimisableSheet {
+    minimize(): unknown;
+    maximize(): unknown;
+}
+
+/** Bound mouse handlers for the placement preview. */
+interface PreviewEventHandlers {
+    cancel: (event: MouseEvent) => unknown;
+    confirm: (event: PIXI.FederatedEvent) => unknown;
+    move: (event: PIXI.FederatedEvent) => unknown;
+    resolve: (regions: unknown[]) => void;
+    reject: () => void;
+}
+
+/** Payload passed to `setExplosiveData` — only the actor reference is read here. */
+interface ExplosiveData {
+    actor: { sheet?: MinimisableSheet | null };
+    [key: string]: unknown;
+}
+
 /**
  * Handles the preview and placement of explosive blast regions on the canvas.
  * Replaces the old MeasuredTemplate-based system with Scene Regions (Foundry v14).
  */
 export default class ExplosivesTemplate {
 
-    /** @type {number} Throttle timestamp for mouse movement */
+    /** Throttle timestamp for mouse movement */
     #moveTime = 0;
 
-    /** @type {CanvasLayer} The initially active layer to restore */
-    #initialLayer: any;
+    /** The initially active layer to restore */
+    #initialLayer: CanvasLayer | undefined;
 
-    /** @type {object} Bound event handlers */
-    #events: any;
+    /** Bound event handlers */
+    #events!: PreviewEventHandlers;
 
-    /** @type {PIXI.Graphics} Preview circle */
-    #circle: any;
+    /** Preview circle */
+    #circle!: PIXI.Graphics;
 
-    /** @type {PIXI.Graphics} Range line from origin to target */
-    #rangeLine: any;
+    /** Range line from origin to target */
+    #rangeLine!: PIXI.Graphics;
 
-    /** @type {PIXI.Text} Distance measurement display */
-    #rangeMeasure: any;
+    /** Distance measurement display */
+    #rangeMeasure!: PIXI.Text;
 
-    /** @type {PIXI.Container} Container for all preview graphics */
-    #container: any;
+    /** Container for all preview graphics */
+    #container!: PIXI.Container;
 
-    /** @type {object} Explosive data from the dialog */
-    exData: any;
+    /** Explosive data from the dialog */
+    exData!: ExplosiveData;
 
-    /** @type {object} Actor sheet reference */
-    actorSheet: any;
+    /** Actor sheet reference */
+    actorSheet: MinimisableSheet | null | undefined;
 
-    /** @type {number} Origin X position */
-    originX: any;
+    /** Origin X position */
+    originX = 0;
 
-    /** @type {number} Origin Y position */
-    originY: any;
+    /** Origin Y position */
+    originY = 0;
 
-    /** @type {number} Blast radius in grid units */
-    radius;
+    /** Blast radius in grid units */
+    radius: number;
 
-    /** @type {number} Current preview X position */
-    previewX: any;
+    /** Current preview X position */
+    previewX = 0;
 
-    /** @type {number} Current preview Y position */
-    previewY: any;
+    /** Current preview Y position */
+    previewY = 0;
 
-    /** @type {boolean} Whether the preview position has a wall collision */
+    /** Whether the preview position has a wall collision */
     _preview = false;
 
-    constructor(radius: any) {
+    constructor(radius: number) {
         this.radius = radius;
     }
 
-    async setExplosiveData(data: any, x: any, y: any) {
+    async setExplosiveData(data: ExplosiveData, x: number, y: number) {
         this.exData = data;
         this.actorSheet = this.exData.actor.sheet;
         this.originX = x;
@@ -93,7 +114,7 @@ export default class ExplosivesTemplate {
     /**
      * Draw the blast radius circle at the given position.
      */
-    #drawCircle(x: any, y: any) {
+    #drawCircle(x: number, y: number) {
         const radiusPixels = this.radius * canvas.dimensions.distancePixels;
         this.#circle.clear();
         this.#circle.lineStyle(2, 0xFFFF00, 0.8);
@@ -107,7 +128,7 @@ export default class ExplosivesTemplate {
      * @returns {Promise<RegionDocument[]>}
      */
     #activatePreviewListeners() {
-        return new Promise((resolve, reject) => {
+        return new Promise<unknown[]>((resolve, reject) => {
             this.#events = {
                 cancel: this.#onCancelPlacement.bind(this),
                 confirm: this.#onConfirmPlacement.bind(this),
@@ -116,9 +137,9 @@ export default class ExplosivesTemplate {
                 reject,
             };
 
-            (canvas.stage as any).on("mousemove", this.#events.move);
-            (canvas.stage as any).on("mousedown", this.#events.confirm);
-            canvas.app.view.oncontextmenu = this.#events.cancel;
+            canvas.stage.on("mousemove", this.#events.move);
+            canvas.stage.on("mousedown", this.#events.confirm);
+            canvas.app.view.oncontextmenu = this.#events.cancel as (e: MouseEvent) => unknown;
         });
     }
 
@@ -128,8 +149,8 @@ export default class ExplosivesTemplate {
     async #finishPlacement() {
         canvas.stage.removeChild(this.#container);
         this.#container.destroy({ children: true });
-        (canvas.stage as any).off("mousemove", this.#events.move);
-        (canvas.stage as any).off("mousedown", this.#events.confirm);
+        canvas.stage.off("mousemove", this.#events.move);
+        canvas.stage.off("mousedown", this.#events.confirm);
         canvas.app.view.oncontextmenu = null;
         this.#initialLayer?.activate();
         await this.actorSheet?.maximize();
@@ -138,7 +159,7 @@ export default class ExplosivesTemplate {
     /**
      * Handle mouse movement during placement.
      */
-    #onMovePlacement(event: any) {
+    #onMovePlacement(event: PIXI.FederatedEvent) {
         event.stopPropagation();
         const now = Date.now();
         if (now - this.#moveTime <= 20) return;
@@ -183,7 +204,7 @@ export default class ExplosivesTemplate {
     /**
      * Confirm placement and create a Region document.
      */
-    async #onConfirmPlacement(_event: any) {
+    async #onConfirmPlacement(_event: PIXI.FederatedEvent) {
         // Block placement through walls
         const origin = { x: this.originX, y: this.originY };
         const target = { x: this.previewX, y: this.previewY };
@@ -225,7 +246,7 @@ export default class ExplosivesTemplate {
     /**
      * Cancel placement on right-click.
      */
-    async #onCancelPlacement(_event: any) {
+    async #onCancelPlacement(_event: MouseEvent) {
         await this.#finishPlacement();
         this.#events.reject();
     }

--- a/src/module/apps/roll-dialog.ts
+++ b/src/module/apps/roll-dialog.ts
@@ -1,19 +1,30 @@
  
 import {od6sutilities} from "../system/utilities";
-import OD6S from "../config/config-od6s";
+import OD6S, {type CharacterPointLimits} from "../config/config-od6s";
 import {od6sroll} from "./roll";
 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
+/** Minimal sheet handle the dialog reads `rollData` from. */
+interface RollDialogActorSheet {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rollData: any;
+}
+
 export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
 
-    actorSheet: any;
+    actorSheet: RollDialogActorSheet;
+    // The roll dialog's runtime rollData is a wider blob than the typed
+    // `RollData` interface (it carries metaphysics `skills`, mutated
+    // `target = string`, etc); narrowing here would cascade through
+    // ~30 access chains. Keep `any` until rollData is unified.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rollData: any;
-    cpLimit: any;
+    cpLimit: CharacterPointLimits;
     onSubmit: () => void | Promise<void>;
 
-    constructor(actorSheet: any, onSubmit: () => void | Promise<void>, options: any = {}) {
+    constructor(actorSheet: RollDialogActorSheet, onSubmit: () => void | Promise<void>, options: object = {}) {
         super(options);
         this.actorSheet = actorSheet;
         this.rollData = this.actorSheet.rollData;
@@ -50,7 +61,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         },
     };
 
-    _configureRenderOptions(options: any): void {
+    _configureRenderOptions(options: { parts?: string[] } & Record<string, unknown>): void {
         super._configureRenderOptions(options);
         const isMetaphysics = this.rollData?.template?.includes("metaphysics");
         options.parts = [isMetaphysics ? "metaphysics" : "standard"];
@@ -71,7 +82,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
 
     async _onClose(_options: object): Promise<void> {
         if (!this.#submitted) {
-            await od6sroll.cancelAction(null as any);
+            await od6sroll.cancelAction();
         }
     }
 
@@ -105,7 +116,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             if (this.rollData.subtype === "vehicledodge") rollType = "dodge";
             if (this.rollData.subtype === "parry") rollType = "parry";
 
-            if ((+this.rollData.characterpoints) >= this.cpLimit[rollType]) {
+            if ((+this.rollData.characterpoints) >= this.cpLimit[rollType as keyof CharacterPointLimits]) {
                 ui.notifications.warn(game.i18n.localize("OD6S.MAX_CP"));
             } else if ((+this.rollData.characterpoints) >= actor.system.characterpoints.value) {
                 ui.notifications.warn(game.i18n.localize("OD6S.NOT_ENOUGH_CP_ROLL"));

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -14,8 +14,7 @@ function delegateEvent(
     parent: HTMLElement,
     eventType: string,
     selector: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handler: (ev: any) => void | Promise<void>,
+    handler: (ev: Event) => void | Promise<void>,
 ) {
     parent.addEventListener(eventType, (ev: Event) => {
         const target = (ev.target as Element | null)?.closest(selector);
@@ -40,11 +39,13 @@ export function registerChatLogListeners() {
     Hooks.on('renderChatLog', (log, html, data) => {
         // In v14, html is an HTMLElement, not jQuery
 
-        delegateEvent(html, 'input', ".explosive-damage", async (ev: any) => {
-            const message =  await game.messages.get(ev.currentTarget.dataset.messageId);
-            const targets = message!.getFlag('od6s','targets');
-            targets[ev.currentTarget.dataset.target].damage = ev.target.value;
-            await message!.setFlag('od6s','targets',targets);
+        delegateEvent(html, 'input', ".explosive-damage", async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const input = ev.target as HTMLInputElement;
+            const message = await game.messages.get(target.dataset.messageId!);
+            const targets = message!.getFlag('od6s', 'targets') as Record<string, { damage: string }>;
+            targets[target.dataset.target!].damage = input.value;
+            await message!.setFlag('od6s', 'targets', targets);
         })
 
         // Keyboard activation for chat-card controls that aren't native <button>s
@@ -57,43 +58,47 @@ export function registerChatLogListeners() {
             ".message-delete, .message-reveal, .message-oppose-button, " +
                 ".modifiers-button, .damage-modifiers-button, " +
                 ".edit-difficulty, .edit-damage, .choose-target",
-            (ev: any) => {
-                if (ev.key === 'Enter' || ev.key === ' ') {
+            (ev: Event) => {
+                const ke = ev as KeyboardEvent;
+                if (ke.key === 'Enter' || ke.key === ' ') {
                     ev.preventDefault();
                     (ev.currentTarget as HTMLElement).click();
                 }
             },
         )
 
-        delegateEvent(html, "click", ".modifiers-button", async (ev: any) => {
-            const content = document.getElementById("modifiers-display-" + ev.currentTarget.dataset.messageId);
+        delegateEvent(html, "click", ".modifiers-button", async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const content = document.getElementById("modifiers-display-" + target.dataset.messageId);
             if (content!.style.display === "block") {
                 content!.style.display = "none";
             } else {
                 content!.style.display = "block";
             }
-            game!.messages.get(ev.currentTarget.dataset.messageId)?.render();
+            game!.messages.get(target.dataset.messageId!)?.render();
         })
 
-        delegateEvent(html, "click", ".damage-modifiers-button", async (ev: any) => {
-            const content = document.getElementById("damage-modifiers-display-" + ev.currentTarget.dataset.messageId);
+        delegateEvent(html, "click", ".damage-modifiers-button", async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const content = document.getElementById("damage-modifiers-display-" + target.dataset.messageId);
             if (content!.style.display === "block") {
                 content!.style.display = "none";
             } else {
                 content!.style.display = "block";
             }
-            game!.messages.get(ev.currentTarget.dataset.messageId)?.render();
+            game!.messages.get(target.dataset.messageId!)?.render();
         })
 
-        delegateEvent(html, "click", ".apply-damage-button", async (ev: any) => {
+        delegateEvent(html, "click", ".apply-damage-button", async (ev: Event) => {
             ev.preventDefault();
-            const token = game.scenes.active.tokens.get(ev.currentTarget.dataset.tokenId);
+            const target = ev.currentTarget as HTMLElement;
+            const token = game.scenes.active.tokens.get(target.dataset.tokenId!);
             let actor = token?.actor;
             if (!actor) return;
-            const result = ev.currentTarget.dataset.result;
-            const isVehicleData = ev.currentTarget.dataset.isVehicle === true || ev.currentTarget.dataset.isVehicle === 'true';
-            const messageId = ev.currentTarget.dataset.messageId;
-            const stun = ev.currentTarget.dataset.stun;
+            const result = target.dataset.result!;
+            const isVehicleData = target.dataset.isVehicle === 'true';
+            const messageId = target.dataset.messageId!;
+            const stun = target.dataset.stun;
             const msg = game.messages.get(messageId);
             const stunEffect = msg!.getFlag('od6s', 'stunEffect');
 
@@ -117,7 +122,7 @@ export function registerChatLogListeners() {
                         });
                     }
                     const stunnedName = game.i18n.localize(CONFIG!.statusEffects.find(e => e.id === 'stunned')!.name);
-                    if (!actor.effects.contents.find((i: any) => i.name === stunnedName)) {
+                    if (!actor.effects.contents.find((i: ActiveEffect) => i.name === stunnedName)) {
                         await actor.toggleStatusEffect('stunned', {overlay: false, active: true});
                     }
                 }
@@ -132,7 +137,7 @@ export function registerChatLogListeners() {
                         await actor.applyWounds(result);
                     }
                 } else if (isCharacterActor(actor)) {
-                    let bp = actor.system.wounds.body_points.current - result;
+                    let bp = actor.system.wounds.body_points.current - Number(result);
                     if (bp < 0) bp = 0;
                     await actor.update({ 'system.wounds.body_points.current': bp });
                     if (game.settings.get('od6s', 'bodypoints') === 1) await actor.setWoundLevelFromBodyPoints(bp);
@@ -141,37 +146,40 @@ export function registerChatLogListeners() {
             await msg!.setFlag('od6s', 'applied', true);
         })
 
-        delegateEvent(html, "click", ".explosive-damage-button", async (ev: any) => {
+        delegateEvent(html, "click", ".explosive-damage-button", async (ev: Event) => {
             ev.preventDefault();
-            await od6sutilities.detonateExplosive(ev.currentTarget.dataset);
+            const target = ev.currentTarget as HTMLElement;
+            await od6sutilities.detonateExplosive(target.dataset);
         })
 
-        delegateEvent(html, 'click', '.remove-template-button', async (ev: any) => {
-            const message =  await game.messages.get(ev.currentTarget.dataset.messageId);
+        delegateEvent(html, 'click', '.remove-template-button', async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const message = await game.messages.get(target.dataset.messageId!);
             const actor = message!.speaker.token === null
                 ? game.actors.get(message!.speaker.actor)
                 : game!.scenes.active.tokens.get(message!.speaker.token)?.actor;
-            const item = actor!.items.get(message!.getFlag('od6s','itemId'));
-            const regionId = message!.getFlag('od6s','template') as string | undefined;
+            const item = actor!.items.get(message!.getFlag('od6s', 'itemId') as string);
+            const regionId = message!.getFlag('od6s', 'template') as string | undefined;
             const region = regionId ? canvas.scene.getEmbeddedDocument('Region', regionId) : null;
             if (item && regionId) {
                 await item.update({
                     [`flags.od6s.explosivePending.-=${regionId}`]: null,
                 });
             }
-            if (region) await region.setFlag('od6s','handled', true);
-            await message!.setFlag('od6s','handled', true);
+            if (region) await region.setFlag('od6s', 'handled', true);
+            await message!.setFlag('od6s', 'handled', true);
             if (region) await canvas.scene.deleteEmbeddedDocuments('Region', [region.id]);
-            // @ts-expect-error
-            msg.setFlag('od6s', 'applied', true);
+            await message!.setFlag('od6s', 'applied', true);
         })
 
-        delegateEvent(html, "click", ".damage-button", async (ev: any) => {
+        delegateEvent(html, "click", ".damage-button", async (ev: Event) => {
             ev.preventDefault();
-            const data = ev.currentTarget.dataset;
-            const dice: any = {};
-            dice.dice = data.damageDice;
-            dice.pips = data.damagePips;
+            const target = ev.currentTarget as HTMLElement;
+            const data = target.dataset;
+            const dice: { dice: number; pips: number } = {
+                dice: Number(data.damageDice),
+                pips: Number(data.damagePips),
+            };
             let rollString;
             let itemId = '';
 
@@ -192,14 +200,15 @@ export function registerChatLogListeners() {
             }
             dice.pips ? rollString += "+" + dice.pips : null;
             if (!game.settings.get('od6s', 'dice_for_scale')) {
-                if (data.damagescalebonus > 0) rollString += "+" + Math.abs(data.damagescalebonus);
-                if (data.damagescalebonus < 0) rollString += "-" + Math.abs(data.damagescalebonus);
+                const scaleBonus = Number(data.damagescalebonus ?? 0);
+                if (scaleBonus > 0) rollString += "+" + Math.abs(scaleBonus);
+                if (scaleBonus < 0) rollString += "-" + Math.abs(scaleBonus);
             }
 
             const roll = await new Roll(rollString).evaluate();
 
             let label = game.i18n.localize('OD6S.DAMAGE') + " (" +
-                game.i18n.localize(OD6S.damageTypes[data.damagetype]) + ")";
+                game.i18n.localize(OD6S.damageTypes[data.damagetype ?? ""]) + ")";
 
             if (typeof (data.source) !== 'undefined' && data.source !== '') {
                 label = label + " " + game.i18n.localize('OD6S.FROM') + " " +
@@ -215,7 +224,7 @@ export function registerChatLogListeners() {
                 label = label + " " + game.i18n.localize('OD6S.TO') + " " + data.targetname;
             }
 
-            data.collision = (data.collision === 'true');
+            const collisionFlag = data.collision === 'true';
 
             const flags = {
                 "type": "damage",
@@ -229,7 +238,7 @@ export function registerChatLogListeners() {
                 "wildHandled": false,
                 "wildResult": OD6S.wildDieResult[OD6S.wildDieOneDefault],
                 "total": roll.total,
-                "isVehicleCollision": data.collision,
+                "isVehicleCollision": collisionFlag,
                 "stun": data.stun,
                 "itemId": itemId
             }
@@ -268,12 +277,12 @@ export function registerChatLogListeners() {
                 replacementRoll.terms[0].results[highest].discarded = true;
                 replacementRoll.terms[0].results[highest].active = false;
                 replacementRoll.total -= (+replacementRoll.terms[0].results[highest].result);
-                const rollMessageUpdate: any = {};
-                rollMessageUpdate.system = {};
-                rollMessageUpdate.content = replacementRoll.total;
-                rollMessageUpdate.id = rollMessage.id;
-                rollMessageUpdate.rolls = [];
-                rollMessageUpdate.rolls[0] = replacementRoll;
+                const rollMessageUpdate: Record<string, unknown> = {
+                    system: {},
+                    content: replacementRoll.total,
+                    id: rollMessage.id,
+                    rolls: [replacementRoll],
+                };
 
                 if (game.user.isGM) {
                     if (rollMessage.getFlag('od6s', 'difficulty') && rollMessage.getFlag('od6s', 'success')) {
@@ -288,35 +297,38 @@ export function registerChatLogListeners() {
             }
         })
 
-        delegateEvent(html, "click", ".flavor-text", async (ev: any) => {
+        delegateEvent(html, "click", ".flavor-text", async (ev: Event) => {
             if (!game.user.isGM) return;
-            const message = game.messages.get(ev.currentTarget.dataset.messageId);
+            const target = ev.currentTarget as HTMLElement;
+            const message = game.messages.get(target.dataset.messageId!);
             let actor;
             if (message!.speaker.actor && message?.speaker.token) {
                 actor = game.actors.tokens[message.speaker.token];
-                if (typeof actor === "undefined" || actor === '') {
+                if (typeof actor === "undefined") {
                     actor = game.actors.get(message.speaker.actor);
                 }
             } else {
                 actor = game.actors.get(message!.speaker.actor)
             }
             // Find the item
-            let item = actor?.items.find((i: any) => i.id === message!.getFlag('od6s', 'itemId'));
-            if (typeof (item) === "undefined" || item === "") {
+            const itemId = message!.getFlag('od6s', 'itemId') as string;
+            let item = actor?.items.find((i: Item) => i.id === itemId);
+            if (typeof (item) === "undefined") {
                 // See if the actor is a crewmember
-                if (typeof (actor?.system.vehicle.name) !== 'undefined') {
+                if (isCharacterActor(actor!) && typeof actor.system.vehicle.name !== 'undefined') {
                     const vehicleActor = await od6sutilities.getActorFromUuid(actor.system.vehicle.uuid);
-                    item = vehicleActor!.items.find((i: any) => i.id === message!.getFlag('od6s', 'itemId'));
+                    item = vehicleActor!.items.find((i: Item) => i.id === itemId);
                 }
             }
             if (typeof (item) === "undefined") return;
             item.sheet.render(true);
         })
 
-        delegateEvent(html, "click", ".select-actor", async (ev: any) => {
+        delegateEvent(html, "click", ".select-actor", async (ev: Event) => {
             if (!game.user.isGM) return;
             ev.preventDefault();
-            const message = game.messages.get(ev.currentTarget.dataset.messageId);
+            const target = ev.currentTarget as HTMLElement;
+            const message = game.messages.get(target.dataset.messageId!);
             let actor;
             if (message!.speaker.actor && message!.speaker.token) {
                 actor = game.actors.tokens[message!.speaker.token];
@@ -326,49 +338,56 @@ export function registerChatLogListeners() {
             actor.sheet.render(true);
         })
 
-        delegateEvent(html, "click", ".edit-difficulty", async (ev: any) => {
-            const data: any = {};
-            const dataSet = ev.currentTarget.dataset;
-            data.messageId = dataSet.messageId;
-            const message = game.messages.get(dataSet.messageId);
-            data.baseDifficulty = message!.getFlag('od6s', 'baseDifficulty');
-            data.modifiers = message!.getFlag('od6s', 'modifiers');
+        delegateEvent(html, "click", ".edit-difficulty", async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const dataSet = target.dataset;
+            const message = game.messages.get(dataSet.messageId!);
+            const data = {
+                messageId: dataSet.messageId,
+                baseDifficulty: message!.getFlag('od6s', 'baseDifficulty'),
+                modifiers: message!.getFlag('od6s', 'modifiers'),
+            };
             new OD6SEditDifficulty(data).render(true);
         })
 
-        delegateEvent(html, "click", ".edit-difficulty-submit", async (_ev: any) => {
+        delegateEvent(html, "click", ".edit-difficulty-submit", async (_ev: Event) => {
         })
 
-        delegateEvent(html, "click", ".edit-damage", async (ev: any) => {
+        delegateEvent(html, "click", ".edit-damage", async (ev: Event) => {
             ev.preventDefault();
-            const data: any = {};
-            const dataSet = ev.currentTarget.dataset;
-            data.messageId = dataSet.messageId;
-            const message = game.messages.get(dataSet.messageId);
-            data.damage = message!.getFlag('od6s', 'damageScore');
-            data.damageDice = message!.getFlag('od6s', 'damageDice');
+            const target = ev.currentTarget as HTMLElement;
+            const dataSet = target.dataset;
+            const message = game.messages.get(dataSet.messageId!);
+            const data = {
+                messageId: dataSet.messageId,
+                damage: message!.getFlag('od6s', 'damageScore'),
+                damageDice: message!.getFlag('od6s', 'damageDice'),
+            };
             new OD6SEditDamage(data).render(true);
         })
 
-        delegateEvent(html, "click", ".choose-target", async (ev: any) => {
+        delegateEvent(html, "click", ".choose-target", async (ev: Event) => {
             ev.preventDefault();
-            data = {};
-            data.targets = [];
-            data.messageId = ev.currentTarget.dataset.messageId;
+            const target = ev.currentTarget as HTMLElement;
+            const data: {
+                targets: Array<{ id: string; name: string }> | unknown;
+                messageId: string;
+                isExplosive?: unknown;
+            } = {
+                targets: [],
+                messageId: target.dataset.messageId!,
+            };
             const message = game.messages.get(data.messageId);
 
             if (game.user.isGM) {
-                data.isExplosive = message!.getFlag('od6s','isExplosive');
+                data.isExplosive = message!.getFlag('od6s', 'isExplosive');
                 // If in combat, only load tokens in combat.  Otherwise, load all tokens in scene
                 if (game.combat) {
+                    const targets: Array<{ id: string; name: string }> = [];
                     for (const t of game.combat.combatants) {
-                        const target = {
-                            "id": t.token.id,
-                            "name": t.token.name
-                        }
-                        data.targets.push(target);
-
+                        targets.push({id: t.token.id, name: t.token.name});
                     }
+                    data.targets = targets;
                 } else {
                     data.targets = game.scenes.active.tokens;
                 }
@@ -378,20 +397,23 @@ export function registerChatLogListeners() {
             new OD6SChooseTarget(data).render({force: true});
         })
 
-        delegateEvent(html, "change", ".explosive-target-zone", async (ev: any) => {
-            const message = game.messages.get(ev.currentTarget.dataset.messageId);
-            const targets = Array.from(message!.getFlag('od6s','targets')) as Array<{ id: string; zone?: number }>;
+        delegateEvent(html, "change", ".explosive-target-zone", async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const input = ev.target as HTMLInputElement;
+            const message = game.messages.get(target.dataset.messageId!);
+            const targets = Array.from(message!.getFlag('od6s', 'targets') as ArrayLike<{ id: string; zone?: number }>);
             for (const t in targets) {
-                if(ev.currentTarget.dataset.targetId === targets[t].id) {
-                    targets[t].zone = parseInt(ev.target.value);
+                if (target.dataset.targetId === targets[t].id) {
+                    targets[t].zone = parseInt(input.value);
                 }
             }
-            await message!.setFlag('od6s','targets', targets);
+            await message!.setFlag('od6s', 'targets', targets);
         })
 
-        delegateEvent(html, "click", ".message-sender", async (ev: any) => {
+        delegateEvent(html, "click", ".message-sender", async (ev: Event) => {
             ev.preventDefault();
-            const message = await game.messages.get(ev.currentTarget.dataset.messageId);
+            const target = ev.currentTarget as HTMLElement;
+            const message = await game.messages.get(target.dataset.messageId!);
             if (message!.speaker?.token !== null && message!.speaker?.token !== "") {
                 const scene = game.scenes.get(message!.speaker.scene);
                 const token = scene!.tokens.get(message!.speaker.token);
@@ -403,64 +425,71 @@ export function registerChatLogListeners() {
             }
         })
 
-        delegateEvent(html, "click", ".wilddiegm", async (ev: any) => {
+        delegateEvent(html, "click", ".wilddiegm", async (ev: Event) => {
             ev.preventDefault();
             // three choices: leave it as-is, remove the highest die from the roll, or cause a complication
             new OD6SHandleWildDieForm(ev).render({force: true});
         })
 
-        delegateEvent(html, "click", ".message-reveal", async (ev: any) => {
-            const message = game.messages.get(ev.currentTarget.dataset.messageId);
+        delegateEvent(html, "click", ".message-reveal", async (ev: Event) => {
+            const target = ev.currentTarget as HTMLElement;
+            const message = game.messages.get(target.dataset.messageId!);
             await message!.setFlag('od6s', 'isVisible', true);
             await message!.setFlag('od6s', 'isKnown', true);
-            if(message!.getFlag('od6s','isExplosive') && game.settings.get('od6s','auto_explosive')) {
+            if (message!.getFlag('od6s', 'isExplosive') && game.settings.get('od6s', 'auto_explosive')) {
                 // Reveal the explosive region
                 const region = od6sutilities.getTemplateFromMessage(message!).template;
-                if(region) {
+                if (region) {
                     await region.update({ visibility: 2 }); // Make visible to all
                 }
             }
         })
 
-        delegateEvent(html, "click", ".message-oppose", async (ev: any) => {
+        delegateEvent(html, "click", ".message-oppose", async (ev: Event) => {
             ev.preventDefault();
             // Check if there are any opposed cards already in the pipe
-            const data: any = {};
-            data.messageId = ev.currentTarget.dataset.messageId;
-            data.target = ev.currentTarget.dataset?.target;
+            const target = ev.currentTarget as HTMLElement;
+            const data = {
+                messageId: target.dataset.messageId!,
+                target: target.dataset.target,
+            };
 
             if (!isOpposedQueueEmpty()) {
                 pushOpposedQueue(data);
-                // @ts-expect-error
+                // @ts-expect-error - od6sutilities.handleOpposedRoll is added at runtime in od6s.ts
                 return od6sutilities.handleOpposedRoll(data);
             } else {
                 pushOpposedQueue(data);
             }
         })
 
-        delegateEvent(html, "change", ".choose-difficulty", async (ev: any) => {
+        delegateEvent(html, "change", ".choose-difficulty", async (ev: Event) => {
             ev.preventDefault();
-            const message = game.messages.get(ev.currentTarget.dataset.messageId);
-            const flags = {
-                difficultyLevel: ev.currentTarget.value,
-                difficulty: await od6sutilities.getDifficultyFromLevel(ev.currentTarget.value)
-            }
+            const target = ev.currentTarget as HTMLSelectElement;
+            const message = game.messages.get(target.dataset.messageId!);
+            const flags: {
+                difficultyLevel: string;
+                difficulty: number;
+                success?: boolean;
+            } = {
+                difficultyLevel: target.value,
+                difficulty: await od6sutilities.getDifficultyFromLevel(target.value),
+            };
 
-            const update: any = {};
-            update.flags = {};
-            update.flags.od6s = flags;
-            update.id = message!.id;
-            update._id = message!.id;
+            const update = {
+                flags: { od6s: flags },
+                id: message!.id,
+                _id: message!.id,
+            };
 
-            if (message!.getFlag('od6s', 'total') < flags.difficulty) {
-                (flags as any).success = false;
-            } else {
-                (flags as any).success = true;
-            }
+            const total = message!.getFlag('od6s', 'total') as number | undefined;
+            flags.success = !(typeof total === 'number' && total < flags.difficulty);
 
             if (message!.getFlag('od6s', 'subtype') === 'purchase' && message!.getFlag('od6s', 'success')) {
-                const seller = game.actors.get(message!.getFlag('od6s', 'seller'));
-                await seller!.sheet._onPurchase(message!.getFlag('od6s', 'purchasedItem'), message!.speaker.actor);
+                const seller = game.actors.get(message!.getFlag('od6s', 'seller') as string);
+                await (seller!.sheet as unknown as {
+                    _onPurchase: (item: unknown, actor: unknown) => Promise<void>
+                })._onPurchase(message!.getFlag('od6s', 'purchasedItem'), message!.speaker.actor);
             }
 
             await message!.update(update, {"diff": true});

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -315,7 +315,7 @@ export function registerChatLogListeners() {
             let item = actor?.items.find((i: Item) => i.id === itemId);
             if (typeof (item) === "undefined") {
                 // See if the actor is a crewmember
-                if (isCharacterActor(actor!) && typeof actor.system.vehicle.name !== 'undefined') {
+                if (actor && isCharacterActor(actor) && typeof actor.system.vehicle.name !== 'undefined') {
                     const vehicleActor = await od6sutilities.getActorFromUuid(actor.system.vehicle.uuid);
                     item = vehicleActor!.items.find((i: Item) => i.id === itemId);
                 }
@@ -335,6 +335,7 @@ export function registerChatLogListeners() {
             } else {
                 actor = game.actors.get(message!.speaker.actor)
             }
+            if (!actor) return;
             actor.sheet.render(true);
         })
 

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -222,7 +222,10 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
     async _editEffect(ev: Event): Promise<void> {
         const target = ev.currentTarget as HTMLElement;
-        const effect = this.document.getEmbeddedDocument("ActiveEffect", target.dataset.effectId!);
+        const effectId = target.dataset.effectId;
+        if (!effectId) return;
+        const effect = this.document.getEmbeddedDocument("ActiveEffect", effectId);
+        if (!effect) return;
         new foundry.applications.sheets.ActiveEffectConfig({document: effect}).render({force: true});
     }
 

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -8,6 +8,9 @@ import {isItemGroupItem, isTemplateLikeItem, isWeaponItem} from "../system/type-
 const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
 const ItemSheetV2 = foundry.applications.sheets.ItemSheetV2;
 
+/** Drop payload returned by TextEditor.getDragEventData — type/uuid plus arbitrary extras. */
+type DropData = Record<string, unknown> & { type?: string; uuid?: string };
+
 /**
  * OD6S item sheet — ApplicationV2 with HandlebarsApplicationMixin.
  *
@@ -43,7 +46,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         };
     }
 
-    async _renderHTML(_context: any, options: any): Promise<Record<string, HTMLElement>> {
+    async _renderHTML(_context: object, options: object): Promise<Record<string, HTMLElement>> {
         const context = await this._prepareContext(options);
         const html = await foundry.applications.handlebars.renderTemplate(this.template, context);
         const tempEl = document.createElement("div");
@@ -54,7 +57,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         return {body: element};
     }
 
-    _replaceHTML(result: Record<string, HTMLElement>, content: HTMLElement, _options: any): void {
+    _replaceHTML(result: Record<string, HTMLElement>, content: HTMLElement, _options: object): void {
         content.replaceChildren(result.body);
     }
 
@@ -63,7 +66,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
         const root = this.element as HTMLElement;
 
-        bindPrimaryTabs(this as any, root);
+        bindPrimaryTabs(this, root);
 
         if (!this.isEditable) return;
         const $ = (sel: string): NodeListOf<HTMLElement> => root.querySelectorAll(sel);
@@ -94,23 +97,23 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
     async _onDrop(event: DragEvent): Promise<void> {
         event.preventDefault();
-        let data: any;
+        let data: DropData;
         try {
-            data = (foundry.applications.ux.TextEditor as any).implementation.getDragEventData(event);
+            data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event) as DropData;
         } catch {
             return;
         }
 
-        let item: any = "";
+        let item: Item | undefined;
         if (data.type === "Item") {
             item = await this._onDropItem(event, data);
         }
-        if (typeof item === "undefined") return;
+        if (!item) return;
 
         await this._addTemplateItemAction(item.name, item.type, this);
     }
 
-    async _onDropItem(_event: DragEvent, data: any): Promise<any> {
+    async _onDropItem(_event: DragEvent, data: DropData): Promise<Item | undefined> {
         const item = await Item.implementation.fromDropData(data);
 
         switch (this.item.type) {
@@ -121,7 +124,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
             case "weapon":
                 if (item.type === "specialization" && isWeaponItem(this.item)) {
-                    this.item.system.stats.specialization = (item as Item).name;
+                    this.item.system.stats.specialization = item.name;
                     await this.item.update(this.item.system, {diff: true});
                 }
         }
@@ -136,7 +139,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (!isItemGroupItem(this.item)) return;
         const item = this.item;
         const data = {
-            actorTypes: game.od6s.OD6SActor.TYPES.filter((i: any) => !item.system.actor_types.includes(i)),
+            actorTypes: game.od6s.OD6SActor.TYPES.filter((i: string) => !item.system.actor_types.includes(i)),
         };
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-add-actor-type.html", data);
@@ -148,37 +151,32 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (result?.["actor-type"]) await this._addActorTypeAction(result["actor-type"]);
     }
 
-    async _addActorTypeAction(type: any): Promise<void> {
+    async _addActorTypeAction(type: string): Promise<void> {
         if (!isItemGroupItem(this.item)) return;
         const item = this.item;
-        const update: any = {id: item.id, system: {actor_types: item.system.actor_types}};
-        update.system.actor_types.push(type);
-        await item.update(update);
+        const actorTypes = [...item.system.actor_types, type];
+        await item.update({id: item.id, system: {actor_types: actorTypes}});
     }
 
-    async _deleteActorType(ev: any): Promise<void> {
+    async _deleteActorType(ev: Event): Promise<void> {
         if (!isItemGroupItem(this.item)) return;
         const item = this.item;
-        const type = ev.currentTarget.dataset.type;
-        const update: any = {
-            id: item.id,
-            system: {
-                actor_types: item.system.actor_types.filter((i: any) => i !== type),
-                items: [],
-            },
-        };
-        for (const i of item.system.items) {
-            for (const t of update.system.actor_types) {
-                if (OD6S.allowedItemTypes[t].includes(i.type as string)) {
-                    update.system.items.push(i);
+        const target = ev.currentTarget as HTMLElement;
+        const type = target.dataset.type;
+        const actorTypes = item.system.actor_types.filter((i: string) => i !== type);
+        const items: OD6STemplateItemEntry[] = [];
+        for (const i of item.system.items as OD6STemplateItemEntry[]) {
+            for (const t of actorTypes) {
+                if (OD6S.allowedItemTypes[t].includes(i.type)) {
+                    items.push(i);
                     break;
                 }
             }
         }
-        await this.item.update(update);
+        await this.item.update({id: item.id, system: {actor_types: actorTypes, items}});
     }
 
-    async _addLabel(_ev: any): Promise<void> {
+    async _addLabel(): Promise<void> {
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-add-label.html",
             {id: this.item.id});
@@ -190,7 +188,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (result?.key) await this._addLabelAction(result.key, result.value);
     }
 
-    async _addLabelAction(key: any, value: any): Promise<void> {
+    async _addLabelAction(key: string, value: string): Promise<void> {
         if (this.item.system.labels[key]) {
             ui.notifications.warn(game.i18n.localize("OD6S.LABEL_ALREADY_EXISTS"));
             return;
@@ -198,48 +196,55 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         await this.item.update({id: this.item.id, [`system.labels.${key}`]: value});
     }
 
-    async _editLabel(ev: any): Promise<void> {
+    async _editLabel(ev: Event): Promise<void> {
+        const target = ev.currentTarget as HTMLElement;
+        const input = ev.target as HTMLInputElement;
         await this.item.update({
             id: this.item.id,
-            [`system.labels.${ev.currentTarget.dataset.key}`]: ev.target.value,
+            [`system.labels.${target.dataset.key}`]: input.value,
         });
     }
 
-    async _deleteLabel(ev: any): Promise<void> {
+    async _deleteLabel(ev: Event): Promise<void> {
+        const target = ev.currentTarget as HTMLElement;
         await this.item.update({
             id: this.item.id,
             system: this.item.system,
-            [`system.labels.-=${ev.currentTarget.dataset.key}`]: null,
+            [`system.labels.-=${target.dataset.key}`]: null,
         });
     }
 
     async _addEffect(): Promise<void> {
         const name = game.i18n.localize("OD6S.NEW_ACTIVE_EFFECT");
         const effect = await this.document.createEmbeddedDocuments("ActiveEffect", [{label: name}]);
-        new (foundry.applications.sheets as any).ActiveEffectConfig({document: effect[0]}).render({force: true});
+        new foundry.applications.sheets.ActiveEffectConfig({document: effect[0]}).render({force: true});
     }
 
-    async _editEffect(ev: any): Promise<void> {
-        const effect = this.document.getEmbeddedDocument("ActiveEffect", ev.currentTarget.dataset.effectId);
-        new (foundry.applications.sheets as any).ActiveEffectConfig({document: effect}).render({force: true});
+    async _editEffect(ev: Event): Promise<void> {
+        const target = ev.currentTarget as HTMLElement;
+        const effect = this.document.getEmbeddedDocument("ActiveEffect", target.dataset.effectId!);
+        new foundry.applications.sheets.ActiveEffectConfig({document: effect}).render({force: true});
     }
 
-    async _deleteEffect(ev: any): Promise<void> {
-        await this.document.deleteEmbeddedDocuments("ActiveEffect", [ev.currentTarget.dataset.effectId]);
+    async _deleteEffect(ev: Event): Promise<void> {
+        const target = ev.currentTarget as HTMLElement;
+        await this.document.deleteEmbeddedDocuments("ActiveEffect", [target.dataset.effectId!]);
     }
 
     /* -------------------------------------------- */
     /*  Numeric edit handlers (skill/spec/damage…)   */
     /* -------------------------------------------- */
 
-    async _editSkill(event: any): Promise<void> {
-        const itemId = event.currentTarget.dataset.itemId;
-        const oldDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.base);
-        let newScore: any;
-        if (event.target.id === "dice") {
-            newScore = od6sutilities.getScoreFromDice(event.target.value, oldDice.pips);
-        } else if (event.target.id === "pips") {
-            newScore = od6sutilities.getScoreFromDice(oldDice.dice, event.target.value);
+    async _editSkill(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const input = event.target as HTMLInputElement;
+        const itemId = target.dataset.itemId;
+        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.base ?? 0));
+        let newScore: number | undefined;
+        if (input.id === "dice") {
+            newScore = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
+        } else if (input.id === "pips") {
+            newScore = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
         }
         if (this.actor != null) {
             await this.actor.updateEmbeddedDocuments("Item", [{id: itemId, _id: itemId, "system.base": newScore}]);
@@ -249,14 +254,16 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         }
     }
 
-    async _editSpecialization(event: any): Promise<void> {
-        const itemId = event.currentTarget.dataset.itemId;
-        const oldDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.score);
-        let newScore: any;
-        if (event.target.id === "system.die.dice") {
-            newScore = od6sutilities.getScoreFromDice(event.target.value, oldDice.pips);
-        } else if (event.target.id === "system.die.pips") {
-            newScore = od6sutilities.getScoreFromDice(oldDice.dice, event.target.value);
+    async _editSpecialization(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const input = event.target as HTMLInputElement;
+        const itemId = target.dataset.itemId;
+        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+        let newScore: number | undefined;
+        if (input.id === "system.die.dice") {
+            newScore = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
+        } else if (input.id === "system.die.pips") {
+            newScore = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
         }
         if (this.actor != null) {
             await this.actor.updateEmbeddedDocuments("Item", [{id: itemId, _id: itemId, "system.base": newScore}]);
@@ -266,45 +273,49 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         }
     }
 
-    async _editWeaponDamage(event: any): Promise<void> {
-        const itemId = event.currentTarget.dataset.itemId;
-        if (event.currentTarget.dataset.score === "") event.currentTarget.dataset.score = 0;
-        const oldDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.score);
-        let newDamage: any;
-        if (event.target.id === "dice") newDamage = od6sutilities.getScoreFromDice(event.target.value, oldDice.pips);
-        else if (event.target.id === "pips") newDamage = od6sutilities.getScoreFromDice(oldDice.dice, event.target.value);
+    async _editWeaponDamage(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const input = event.target as HTMLInputElement;
+        const itemId = target.dataset.itemId;
+        if (target.dataset.score === "") target.dataset.score = "0";
+        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+        let newDamage: number | undefined;
+        if (input.id === "dice") newDamage = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
+        else if (input.id === "pips") newDamage = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
 
-        const update: any = {_id: itemId, system: {damage: {score: newDamage}}};
         if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [update]);
+            await this.actor.updateEmbeddedDocuments("Item", [{_id: itemId, system: {damage: {score: newDamage}}}]);
         } else {
             await this.item.update({"system.damage.score": newDamage}, {diff: true});
         }
     }
 
-    async _editWeaponStunDamage(event: any): Promise<void> {
-        const itemId = event.currentTarget.dataset.itemId;
-        if (event.currentTarget.dataset.score === "") event.currentTarget.dataset.score = 0;
-        const oldDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.score);
-        let newDamage: any;
-        if (event.target.id === "dice") newDamage = od6sutilities.getScoreFromDice(event.target.value, oldDice.pips);
-        else if (event.target.id === "pips") newDamage = od6sutilities.getScoreFromDice(oldDice.dice, event.target.value);
+    async _editWeaponStunDamage(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const input = event.target as HTMLInputElement;
+        const itemId = target.dataset.itemId;
+        if (target.dataset.score === "") target.dataset.score = "0";
+        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+        let newDamage: number | undefined;
+        if (input.id === "dice") newDamage = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
+        else if (input.id === "pips") newDamage = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
 
-        const update: any = {_id: itemId, system: {stun: {score: newDamage}}};
         if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [update]);
+            await this.actor.updateEmbeddedDocuments("Item", [{_id: itemId, system: {stun: {score: newDamage}}}]);
         } else {
             await this.item.update({"system.stun.score": newDamage}, {diff: true});
         }
     }
 
-    async _editWeaponFireControl(event: any): Promise<void> {
-        const itemId = event.currentTarget.dataset.itemId;
-        if (event.currentTarget.dataset.score === "") event.currentTarget.dataset.score = 0;
-        const oldDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.score);
-        let newScore: any;
-        if (event.target.id === "dice") newScore = od6sutilities.getScoreFromDice(event.target.value, oldDice.pips);
-        else if (event.target.id === "pips") newScore = od6sutilities.getScoreFromDice(oldDice.dice, event.target.value);
+    async _editWeaponFireControl(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const input = event.target as HTMLInputElement;
+        const itemId = target.dataset.itemId;
+        if (target.dataset.score === "") target.dataset.score = "0";
+        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+        let newScore: number | undefined;
+        if (input.id === "dice") newScore = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
+        else if (input.id === "pips") newScore = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
 
         if (this.actor != null) {
             await this.actor.updateEmbeddedDocuments("Item",
@@ -314,25 +325,23 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         }
     }
 
-    async _editArmor(event: any): Promise<void> {
-        const itemId = event.currentTarget.dataset.itemId;
-        const update: any = {id: itemId, _id: itemId, system: {}};
-        const oldPrDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.pr);
-        const oldErDice = od6sutilities.getDiceFromScore(event.currentTarget.dataset.er);
-        let newScore: any;
-        if (event.target.id === "prDice") {
-            newScore = od6sutilities.getScoreFromDice(event.target.value, oldPrDice.pips);
-            update.system.pr = newScore;
-        } else if (event.target.id === "prPips") {
-            newScore = od6sutilities.getScoreFromDice(oldPrDice.dice, event.target.value);
-            update.system.pr = newScore;
-        } else if (event.target.id === "erDice") {
-            newScore = od6sutilities.getScoreFromDice(event.target.value, oldErDice.pips);
-            update.system.er = newScore;
-        } else if (event.target.id === "erPips") {
-            newScore = od6sutilities.getScoreFromDice(oldErDice.dice, event.target.value);
-            update.system.er = newScore;
+    async _editArmor(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const input = event.target as HTMLInputElement;
+        const itemId = target.dataset.itemId;
+        const system: { pr?: number; er?: number } = {};
+        const oldPrDice = od6sutilities.getDiceFromScore(Number(target.dataset.pr ?? 0));
+        const oldErDice = od6sutilities.getDiceFromScore(Number(target.dataset.er ?? 0));
+        if (input.id === "prDice") {
+            system.pr = od6sutilities.getScoreFromDice(Number(input.value), oldPrDice.pips);
+        } else if (input.id === "prPips") {
+            system.pr = od6sutilities.getScoreFromDice(oldPrDice.dice, Number(input.value));
+        } else if (input.id === "erDice") {
+            system.er = od6sutilities.getScoreFromDice(Number(input.value), oldErDice.pips);
+        } else if (input.id === "erPips") {
+            system.er = od6sutilities.getScoreFromDice(oldErDice.dice, Number(input.value));
         }
+        const update = {id: itemId, _id: itemId, system};
         if (this.actor != null) {
             await this.actor.updateEmbeddedDocuments("Item", [update]);
         } else {
@@ -344,21 +353,24 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
     /*  Template item handlers                       */
     /* -------------------------------------------- */
 
-    async _getGameItemsByType(type: any): Promise<any[]> {
-        const compendia = await od6sutilities.getItemsFromCompendiumByType(type);
-        const world = await od6sutilities.getItemsFromWorldByType(type);
-        const data = compendia.concat(world);
-        return data.sort((a: any, b: any) => a.name.localeCompare(b.name));
+    async _getGameItemsByType(
+        type: string,
+    ): Promise<Array<{_id: string; name: string; type: string; description?: string}>> {
+        const compendia = await od6sutilities.getItemsFromCompendiumByType(type as OD6SItemType);
+        const world = await od6sutilities.getItemsFromWorldByType(type as OD6SItemType);
+        const data = [...compendia, ...world];
+        return data.sort((a, b) => a.name.localeCompare(b.name));
     }
 
-    async _addTemplateItem(event: any): Promise<void> {
-        const type = event.currentTarget.dataset.type;
+    async _addTemplateItem(event: Event): Promise<void> {
+        const target = event.currentTarget as HTMLElement;
+        const type = target.dataset.type!;
         const templateItems = await Promise.all(await this._getGameItemsByType(type));
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-template-add.html",
             {templateItems});
         const label = game.i18n.localize(
-            game.system.template.Item[event.currentTarget.dataset.type].label);
+            game.system.template.Item[type].label);
         const result = await DialogV2.input({
             window: {title: game.i18n.localize("OD6S.ADD") + " " + label + "!"},
             content,
@@ -367,7 +379,7 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (result?.itemname) await this._addTemplateItemAction(result.itemname, type, this);
     }
 
-    async _addTemplateItemAction(name: any, type: any, itemSheet: any): Promise<void> {
+    async _addTemplateItemAction(name: string, type: string, itemSheet: OD6SItemSheet): Promise<void> {
         if (isItemGroupItem(this.item)) {
             const item = this.item;
             let allowed = false;
@@ -386,20 +398,23 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
             return;
         }
 
+        if (!isTemplateLikeItem(itemSheet.item)) return;
+        const sheetItem = itemSheet.item;
         const item = await od6sutilities.getItemByName(name);
-        const description = item ? (item.system as { description?: string }).description ?? "" : "";
-        const newItem = {name, type, description};
-        (itemSheet.item.system as { items: unknown[] }).items.push(newItem);
-        await itemSheet.item.update(
-            {id: itemSheet.id, system: itemSheet.item.system},
+        const description = item?.system.description ?? "";
+        const newItem: OD6STemplateItemEntry = {name, type, description};
+        (sheetItem.system.items as OD6STemplateItemEntry[]).push(newItem);
+        await sheetItem.update(
+            {id: sheetItem.id, system: sheetItem.system},
             {diff: true});
         await this.render();
     }
 
-    async _editTemplateItem(event: any): Promise<void> {
+    async _editTemplateItem(event: Event): Promise<void> {
         if (!isTemplateLikeItem(this.item)) return;
         const target = event.currentTarget as HTMLElement;
-        const item = this.item.system.items.find((i: any) => i.name === target.dataset.name);
+        const items = this.item.system.items as OD6STemplateItemEntry[];
+        const item = items.find((i) => i.name === target.dataset.name);
         const itemData = {name: target.dataset.name, type: target.dataset.type, description: item?.description};
         const content = await foundry.applications.handlebars.renderTemplate(
             "systems/od6s/templates/item/item-template-item-edit.html",
@@ -416,20 +431,22 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         }
     }
 
-    async _editTemplateItemAction(desc: any, event: any, itemSheet: any): Promise<void> {
-        const data = event.currentTarget.dataset;
-        const newItem = {name: data.name, type: data.type, description: desc};
-        const itemIndex = itemSheet.item.system.items.findIndex(
-            (i: any) => i.name === data.name && i.type === data.type);
+    async _editTemplateItemAction(desc: string, event: Event, itemSheet: OD6SItemSheet): Promise<void> {
+        if (!isTemplateLikeItem(itemSheet.item)) return;
+        const target = event.currentTarget as HTMLElement;
+        const data = target.dataset;
+        const newItem: OD6STemplateItemEntry = {name: data.name!, type: data.type!, description: desc};
+        const items = itemSheet.item.system.items as OD6STemplateItemEntry[];
+        const itemIndex = items.findIndex((i) => i.name === data.name && i.type === data.type);
         if (itemIndex < 0) return;
-        itemSheet.item.system.items[itemIndex] = newItem;
+        items[itemIndex] = newItem;
         await itemSheet.item.update(
             {id: itemSheet.item.id, system: itemSheet.item.system},
             {diff: false});
         await this.render();
     }
 
-    async _deleteTemplateItem(event: any): Promise<void> {
+    async _deleteTemplateItem(event: Event): Promise<void> {
         if (!isTemplateLikeItem(this.item)) return;
         const item = this.item;
         const result = await DialogV2.confirm({
@@ -439,17 +456,18 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (!result) return;
 
         const target = event.currentTarget as HTMLElement;
-        const itemIndex = item.system.items.findIndex(
-            (i: any) => i.name === target.dataset.name && i.type === target.dataset.type);
+        const items = item.system.items as OD6STemplateItemEntry[];
+        const itemIndex = items.findIndex(
+            (i) => i.name === target.dataset.name && i.type === target.dataset.type);
         if (itemIndex < 0) return;
-        item.system.items.splice(itemIndex, 1);
+        items.splice(itemIndex, 1);
         await item.update(
             {id: item.id, system: item.system},
             {diff: true});
         await this.render();
     }
 
-    async _editTemplateAttribute(event: any): Promise<void> {
+    async _editTemplateAttribute(event: Event): Promise<void> {
         const target = event.currentTarget as HTMLElement;
         const score = target.dataset.score;
         const content = await foundry.applications.handlebars.renderTemplate(
@@ -463,14 +481,20 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         if (result) await this._editAttributeAction(result.dice, result.pips, event, this);
     }
 
-    async _editAttributeAction(dice: any, pips: any, event: any, itemSheet: any): Promise<void> {
-        const newScore = od6sutilities.getScoreFromDice(dice, pips);
+    async _editAttributeAction(
+        dice: string,
+        pips: string,
+        event: Event,
+        itemSheet: OD6SItemSheet,
+    ): Promise<void> {
+        const newScore = od6sutilities.getScoreFromDice(Number(dice), Number(pips));
         const target = event.currentTarget as HTMLElement;
         const attrname = target.dataset.attrname!;
+        const attributes = (itemSheet.item.system as { attributes: Record<string, unknown> }).attributes;
         switch (target.dataset.sub) {
-            case "base": itemSheet.item.system.attributes[attrname] = newScore; break;
-            case "min": itemSheet.item.system.attributes[attrname].min = newScore; break;
-            case "max": itemSheet.item.system.attributes[attrname].max = newScore; break;
+            case "base": attributes[attrname] = newScore; break;
+            case "min": (attributes[attrname] as { min: number }).min = newScore; break;
+            case "max": (attributes[attrname] as { max: number }).max = newScore; break;
         }
         await itemSheet.item.update(
             {id: itemSheet.item.id, system: itemSheet.item.system},

--- a/src/module/system/type-guards.ts
+++ b/src/module/system/type-guards.ts
@@ -57,6 +57,10 @@ export function isCharacterTemplateItem(item: Item): item is OD6SCharacterTempla
     return item.type === "character-template";
 }
 
+export function isSpeciesTemplateItem(item: Item): item is OD6SSpeciesTemplateItem {
+    return item.type === "species-template";
+}
+
 /**
  * Combined guard for the three template-shaped item types whose system data
  * carries a `system.items` array (item-group, character-template, species-template).

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -1299,10 +1299,10 @@ declare var FormDataExtended: {
 // ---- SortingHelpers ----
 
 declare class SortingHelpers {
-    static performIntegerSort(
-        event: Event,
-        options: { target: any; siblings: any[]; sortKey?: string; sortBefore?: boolean }
-    ): { target: any; update: Record<string, any> }[];
+    static performIntegerSort<T>(
+        source: T,
+        options: { target: T | undefined | null; siblings: T[]; sortKey?: string; sortBefore?: boolean }
+    ): { target: T; update: Record<string, any> }[];
 }
 
 // ---- jQuery (for v1 Application migration period) ----

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -107,6 +107,7 @@ declare namespace foundry {
                 _onRender(context: object, options: object): void;
                 _prepareContext(options?: object): Promise<object>;
                 _configureRenderOptions(options: object): void;
+                tabGroups?: Record<string, string>;
             }
 
             function HandlebarsApplicationMixin<T extends new (...args: any[]) => any>(
@@ -138,6 +139,9 @@ declare namespace foundry {
                 get document(): Item;
                 get actor(): Actor | null;
                 get isEditable(): boolean;
+            }
+            class ActiveEffectConfig extends applications.api.ApplicationV2 {
+                constructor(options?: { document?: ActiveEffect } & Record<string, unknown>);
             }
         }
 
@@ -200,7 +204,8 @@ declare namespace foundry {
             }
             /** v14-namespaced TextEditor utility (replaces the global `TextEditor`) */
             class TextEditor {
-                static getDragEventData(event: DragEvent): any;
+                static implementation: typeof TextEditor;
+                static getDragEventData(event: DragEvent): Record<string, unknown>;
                 static enrichHTML(content: string, options?: any): Promise<string>;
                 static create(options?: any): Promise<any>;
                 [key: string]: any;

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -532,6 +532,9 @@ declare class ActiveEffect extends FoundryDocument {
     icon: string;
     duration: any;
     toDragData(): any;
+    toObject(): Record<string, unknown>;
+    static implementation: typeof ActiveEffect;
+    static fromDropData(data: unknown): Promise<ActiveEffect | undefined>;
 }
 
 interface ActiveEffectChange {
@@ -643,7 +646,10 @@ interface CompendiumPack {
 declare class Folder extends FoundryDocument {
     type: string;
     displayed: boolean;
-    children: Folder[];
+    children: Array<Folder | { folder: Folder; depth?: number; root?: boolean }>;
+    contents?: FoundryDocument[];
+    static implementation: typeof Folder;
+    static fromDropData(data: unknown): Promise<Folder | undefined>;
 }
 
 // ---- Region (v14 - replaces MeasuredTemplate) ----

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -1232,6 +1232,16 @@ declare namespace PIXI {
         removeChild(child: any): void;
         children: any[];
         destroy(options?: any): void;
+        on(event: string, handler: (...args: any[]) => void): this;
+        off(event: string, handler: (...args: any[]) => void): this;
+    }
+    /** Federated pointer/wheel/etc event delivered by the PIXI display tree. */
+    interface FederatedEvent {
+        data: { getLocalPosition(parent: Container): { x: number; y: number } };
+        stopPropagation(): void;
+        preventDefault(): void;
+        currentTarget: unknown;
+        target: unknown;
     }
     class Application {
         view: HTMLCanvasElement;

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -392,6 +392,17 @@ interface OD6SManifestationItemSystem extends OD6SItemBase {
     >;
 }
 
+/**
+ * Entry shape for `system.items` arrays carried by item-group / template items.
+ * The runtime objects also accumulate ad-hoc keys, so an index signature is included.
+ */
+interface OD6STemplateItemEntry {
+    name: string;
+    type: string;
+    description?: string;
+    [key: string]: unknown;
+}
+
 interface OD6SCharacterTemplateItemSystem extends OD6SItemBase {
     species: string;
     attributes: Record<"agi" | "str" | "kno" | "mec" | "per" | "tec" | "met", number>;
@@ -401,7 +412,7 @@ interface OD6SCharacterTemplateItemSystem extends OD6SItemBase {
     credits: number;
     move: number;
     me: boolean;
-    items: Array<Record<string, unknown>>;
+    items: OD6STemplateItemEntry[];
 }
 
 interface OD6SActionItemSystem extends OD6SItemBase {
@@ -457,12 +468,12 @@ interface OD6SStarshipGearItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEq
 
 interface OD6SSpeciesTemplateItemSystem extends OD6SItemBase {
     attributes: Record<"agi" | "str" | "kno" | "mec" | "per" | "tec" | "met", { min: number; max: number }>;
-    items: Array<Record<string, unknown>>;
+    items: OD6STemplateItemEntry[];
 }
 
 interface OD6SItemGroupSystem extends OD6SItemBase {
     actor_types: string[];
-    items: Array<Record<string, unknown>>;
+    items: OD6STemplateItemEntry[];
 }
 
 /** Discriminated union of all 18 OD6S item subtype system shapes. */

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -137,6 +137,12 @@ interface OD6SCharacterSystem {
     visible?: boolean;
     /** Created marker on character actors. */
     created?: { value: boolean };
+    /** Character profile fields (some shared with vehicles via the common schema). */
+    chartype: { type: string; label: string; content: string };
+    species: { type: string; label: string; content: string };
+    move: { type: string; label: string; mod: number; value: number };
+    background: { type: string; label: string; content: string };
+    metaphysicsextranormal: { type: string; label: string; value: boolean };
 }
 
 /** System data for the container actor type. */


### PR DESCRIPTION
## Summary
Multi-round `any`-cast reduction sweep across `apps/`, `actor/`, `item/`, `hooks/`. **Lint warnings: 557 → 315 (−242, −43%)**, full `pnpm run check` (lint + typecheck + unit + domain) green on every commit.

### Per-round results
| Round | Files | Δ |
|---|---|---|
| 1 (`bb3609e`) | `item/item-sheet.ts` 60→0; `actor/sheet-helpers/templates.ts` 22→0; 4 quick wins on `actor-sheet.ts` | −88 |
| 2 (`13b4112`) | `apps/character-creation.ts` 36→0 | −31 |
| 3 (`54882fe`) | `hooks/chat-log-listeners.ts` 31→0 | −30 |
| 4 (`de3cda6`) | `apps/explosives-template.ts` 25→0 | −25 |
| 5 (`5cebea4`) | `actor/actor-helpers/crew-vehicle.ts` 15→0 | −15 |
| 6 (`60089d3`) | `actor/sheet-helpers/sorting.ts` 12→0 + 4 actor-sheet sort delegates | −12 |
| 7 (`66ca434`) | `actor/sheet-helpers/drops.ts` 10→0 + 7 actor-sheet drop delegates | −26 |
| 8 (`67ae724`) | `apps/roll-dialog.ts` 14→0 (with 2 documented eslint-disable comments on rollData) | −7 |

### Type-surface additions (`types/foundry.d.ts`, `types/od6s.d.ts`)
- `ApplicationV2.tabGroups`, `TextEditor.implementation` (+ tighter `getDragEventData` return), `foundry.applications.sheets.ActiveEffectConfig`.
- `ActiveEffect.implementation` + `static fromDropData` + `toObject()`; `Folder.implementation` + `static fromDropData` + the `children` wrapper shape that `onDropFolder` walks.
- `PIXI.Container.on/off` event-emitter surface; `PIXI.FederatedEvent` minimal interface.
- `SortingHelpers.performIntegerSort<T>` is generic — was incorrectly typed `(event: Event, …) => …`, now `<T>(source: T, { target: T | undefined | null; siblings: T[] })`.
- `OD6STemplateItemEntry` for `system.items` arrays on item-group / character-template / species-template.
- `OD6SCharacterSystem` gains `chartype` / `species` / `move` / `background` / `metaphysicsextranormal` (real schema fields previously missing from the typed shape).
- New `isSpeciesTemplateItem` guard.

### Recurring patterns
- Helper signatures take a structural sheet handle (`ActorSheetLike` / `DropSheetLike` / `RollDialogActorSheet`) instead of `sheet: any`, which avoids reintroducing the helpers ↔ actor-sheet import cycle.
- Drop helpers (`drops.ts` switch on `data.type`) gate by the matching `is*Item` guard before forwarding to typed downstream helpers — TS won't narrow the base `Item` type on a string switch.
- Dataset/input string values are coerced to `Number(...)` at the dice-math boundary (`item-sheet.ts`, `chat-log-listeners.ts`, `character-creation.ts`).

### Drive-bys (real bugs surfaced once `any` was lifted)
- `actor/sheet-helpers/templates.ts`: a no-op `typeof(x !== 'undefined')` paren bug (always-truthy boolean check) replaced with `x != null`.
- `hooks/chat-log-listeners.ts:remove-template-button`: called `msg.setFlag(...)` with `msg` undefined behind a `// @ts-expect-error`; replaced with `message!.setFlag('od6s', 'applied', true)` (the obvious intended target).
- `apps/character-creation.ts`: bogus `&& spec !== ""` checks after `items.find` — Item objects can't equal `""`, so the `if (spec)` undefined-guard is the real check.
- `apps/character-creation.ts`: custom-template number inputs (`fatePoints` / `characterPoints` / `move`) were assigning `HTMLInputElement.value` (string) into number-typed fields; now `Number(…)`-coerced.

### Follow-up issues (315 → ~250 of remaining warnings, deferred from this sweep)
- #147 — prepare-actor.ts (Actor.system union narrowing, ~15 anys)
- #148 — unify rollData runtime shape with the typed `RollData` interface (~14 anys; the two eslint-disable comments added in this PR call out the divergence)
- #149 — remaining sheet-helpers (rolls / inventory-transfer / item-crud / advance-dialog) + actor-sheet residual delegate stubs
- #150 — mechanical: `system/utilities.ts` wrapper signature passthroughs (~12 anys)

## Test plan
- [x] `pnpm run check` (lint + typecheck + unit + domain) green on every commit
- [ ] Smoke: drag character-template / species-template / item-group / Folder onto an actor; clear template
- [ ] Smoke: weapon item sheet — edit damage / stun / fire-control / armor; add and edit an active effect
- [ ] Smoke: create-character dialog — pick template, allocate skill/spec dice, add specialization, finish
- [ ] Smoke: roll dialog — CP up/down, fate point, full-defense, vehicle dodge, metaphysics roll
- [ ] Smoke: chat-card buttons — apply damage, explosive damage, edit difficulty, edit damage, choose target, message reveal/oppose
- [ ] Smoke: vehicle collision dialog → roll → chat card
- [ ] Smoke: explosives blast preview placement (mousemove cursor, click confirm, right-click cancel)