### PR TITLE
refactor(types): mirror impl signatures in od6sutilities wrappers

### DIFF
--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -453,7 +453,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
             await region.setFlag('od6s', 'originalOwner', game.user.id);
             await region.setFlag('od6s', 'templateId', rollMessage._id);
 
-            if (!flags.success) {
+            if (!flags.success && origin && regionId) {
                 await od6sutilities.scatterExplosive(rollData.range, origin, regionId);
                 await od6sutilities.wait(100);
                 const newTargets = await od6sutilities.getExplosiveTargets(rollData.actor, rollData.itemid, regionId);

--- a/src/module/hooks/chat-hooks.ts
+++ b/src/module/hooks/chat-hooks.ts
@@ -123,7 +123,7 @@ export function registerChatHooks() {
                         updateTargets = true;
                     }
 
-                    if (updateTargets) {
+                    if (updateTargets && actor) {
                         newTargets = await od6sutilities.getExplosiveTargets(actor, item!.id, template?.id);
                         if (Object.keys(newTargets).length === 0) {
                             await message.setFlag('od6s','showButton', false);

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -1,5 +1,4 @@
 import {od6sutilities} from "../system/utilities";
-import type { DetonateExplosiveData } from "../system/utilities/explosives";
 import OD6S from "../config/config-od6s";
 import {isCharacterActor} from "../system/type-guards";
 import { isOpposedQueueEmpty, pushOpposedQueue } from "../system/utilities/opposed";
@@ -150,7 +149,9 @@ export function registerChatLogListeners() {
         delegateEvent(html, "click", ".explosive-damage-button", async (ev: Event) => {
             ev.preventDefault();
             const target = ev.currentTarget as HTMLElement;
-            await od6sutilities.detonateExplosive(target.dataset as unknown as DetonateExplosiveData);
+            const { itemId, messageId, actorId, tokenId, templateId, stun } = target.dataset;
+            if (!itemId) return;
+            await od6sutilities.detonateExplosive({ itemId, messageId, actorId, tokenId, templateId, stun });
         })
 
         delegateEvent(html, 'click', '.remove-template-button', async (ev: Event) => {

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -1,4 +1,5 @@
 import {od6sutilities} from "../system/utilities";
+import type { DetonateExplosiveData } from "../system/utilities/explosives";
 import OD6S from "../config/config-od6s";
 import {isCharacterActor} from "../system/type-guards";
 import { isOpposedQueueEmpty, pushOpposedQueue } from "../system/utilities/opposed";
@@ -149,7 +150,7 @@ export function registerChatLogListeners() {
         delegateEvent(html, "click", ".explosive-damage-button", async (ev: Event) => {
             ev.preventDefault();
             const target = ev.currentTarget as HTMLElement;
-            await od6sutilities.detonateExplosive(target.dataset);
+            await od6sutilities.detonateExplosive(target.dataset as unknown as DetonateExplosiveData);
         })
 
         delegateEvent(html, 'click', '.remove-template-button', async (ev: Event) => {

--- a/src/module/hooks/region-hooks.ts
+++ b/src/module/hooks/region-hooks.ts
@@ -19,6 +19,7 @@ export function registerRegionHooks() {
                     } else {
                         actor = game.actors.get(message.speaker.actor);
                     }
+                    if (!actor) return;
                     const targets = await od6sutilities.getExplosiveTargets(
                         actor,
                         region.getFlag('od6s', 'item'),

--- a/src/module/system/handlebars/explosives.ts
+++ b/src/module/system/handlebars/explosives.ts
@@ -25,10 +25,6 @@ export function registerExplosiveHelpers() {
         return zones;
     });
 
-    Handlebars.registerHelper('getExplosiveTargets', async (actorId, itemId, regionId) => {
-        return await od6sutilities.getExplosiveTargets(actorId, itemId, regionId);
-    })
-
     Handlebars.registerHelper('checkExplosiveTargets', (targets) => {
 
         if (typeof (targets) === 'undefined' || targets === '') {

--- a/src/module/system/utilities.ts
+++ b/src/module/system/utilities.ts
@@ -7,6 +7,7 @@ import * as itemUtils from "./utilities/items";
 import * as actorUtils from "./utilities/actors";
 import * as skillUtils from "./utilities/skills";
 import * as explosiveUtils from "./utilities/explosives";
+import type { DetonateExplosiveData } from "./utilities/explosives";
 import * as effectUtils from "./utilities/effects";
 import * as weaponUtils from "./utilities/weapons";
 import * as opposedUtils from "./utilities/opposed";
@@ -22,19 +23,19 @@ export const od6sutilities = {
     lookupAttributeKey(id: string) {
         return miscUtils.lookupAttributeKey(id);
     },
-    async scatterExplosive(range: any, origin: any, regionId: any) {
+    async scatterExplosive(range: string, origin: { x: number; y: number }, regionId: string) {
         return explosiveUtils.scatterExplosive(range, origin, regionId);
     },
-    async getExplosiveTargets(actor: any, itemId: any, regionId: string | undefined) {
+    async getExplosiveTargets(actor: Actor, itemId: string, regionId: string | undefined) {
         return explosiveUtils.getExplosiveTargets(actor, itemId, regionId);
     },
-    async detonateExplosives(combat: any) {
+    async detonateExplosives(combat: Combat) {
         return explosiveUtils.detonateExplosives(combat);
     },
-    async detonateExplosive(data: any) {
+    async detonateExplosive(data: DetonateExplosiveData) {
         return explosiveUtils.detonateExplosive(data);
     },
-    getBlastRadius(item: any, range: any) {
+    getBlastRadius(item: Item, range: number) {
         return explosiveUtils.getBlastRadius(item, range);
     },
     getDiceFromScore(score: number) {
@@ -88,7 +89,7 @@ export const od6sutilities = {
     getAllItemsByType(itemType: OD6SItemType) {
         return itemUtils.getAllItemsByType(itemType);
     },
-    mergeByProperty(target: any, source: any, prop: any) {
+    mergeByProperty<T extends Record<string, unknown>>(target: T[], source: T[], prop: keyof T) {
         return itemUtils.mergeByProperty(target, source, prop);
     },
     async getActorFromUuid(uuid: string) {


### PR DESCRIPTION
## Summary

Closes #150.

- Mirror typed implementation signatures on the six explosive/item wrappers in `system/utilities.ts` that were still declaring `any` parameters: `scatterExplosive`, `getExplosiveTargets`, `detonateExplosives`, `detonateExplosive`, `getBlastRadius`, `mergeByProperty` (now generic).
- Surfaced four pre-existing latent bugs the `any` casts were masking; fixed inline:
  - `roll-execute.ts` could call `scatterExplosive` with `undefined` `origin`/`regionId` (would crash in `Ray(undefined, …)`); guard the branch like `chat-hooks` already does.
  - `chat-hooks.ts` `updateTargets` branch could call `getExplosiveTargets` with an undefined actor when the speaker doesn't resolve.
  - `region-hooks.ts` `updateRegion` branch had the same actor-missing hole; bail early.
  - `system/handlebars/explosives.ts` registered a `getExplosiveTargets` helper passing an `actorId` string where the implementation expects an `Actor`. Helper has no template callers — removed rather than threading a uuid resolution into dead code.

`no-explicit-any` warnings: 314 → 298 (−16). `system/utilities.ts` at zero warnings (DoD).

## Test plan

- [x] `pnpm run check` green (lint + typecheck + unit + domain)
- [ ] Smoke: throw an explosive that misses (verify scatter still works); throw one that hits (verify un-scatter); detonate via the chat-card button (verify dataset round-trip).