### PR TITLE
refactor(types): narrow prepare-actor.ts via OD6SAnyActor + type guards

### DIFF
--- a/src/module/actor/actor-helpers/prepare-actor.ts
+++ b/src/module/actor/actor-helpers/prepare-actor.ts
@@ -1,22 +1,23 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {computeSkillDisplayScore} from "./skill-score";
+import {isCharacterActor, isVehicleActor, isContainerActor} from "../../system/type-guards";
 
-export function prepareBaseActorData(actor: any): void {
+export function prepareBaseActorData(actor: Actor): void {
     // Set all mod values to zero
-    if(actor.type.match(/^(character|npc|creature)/)) {
+    if (isCharacterActor(actor)) {
         for (const a in actor.system.attributes) {
             actor.system.attributes[a].mod = 0;
             actor.system.attributes[a].label = OD6S.attributes[a].name;
         }
 
-        const mList = {...OD6S.data_tab.offense, ...OD6S.data_tab.defense}
+        const mList = {...OD6S.data_tab.offense, ...OD6S.data_tab.defense};
         for (const m in mList) {
-            actor.system[m].mod = 0;
+            (actor.system as unknown as Record<string, OD6SModScoreField>)[m].mod = 0;
         }
     }
 
-    if (['starship', 'vehicle'].includes(actor.type)) {
+    if (isVehicleActor(actor)) {
         actor.system.sensors.mod = 0;
         for (const a in actor.system.attributes) {
             actor.system.attributes[a].mod = 0;
@@ -24,20 +25,27 @@ export function prepareBaseActorData(actor: any): void {
         }
     }
 
-    if (typeof(actor.system.use_wild_die) === 'undefined') {
-        if (actor.type !== 'vehicle' && actor.type !== 'starship' && actor.type !== 'container' && actor.type !== 'base') {
+    if (!isVehicleActor(actor) && !isContainerActor(actor) && isCharacterActor(actor)) {
+        if (typeof actor.system.use_wild_die === 'undefined') {
             actor.system.use_wild_die = true;
         }
     }
 }
 
-export async function prepareDerivedActorData(actor: any): Promise<void> {
-    const actorData = actor.system;
-
-    if(actor.type.match(/^(character|npc|creature)/)) {
+export async function prepareDerivedActorData(actor: Actor): Promise<void> {
+    if (isCharacterActor(actor)) {
+        const actorData = actor.system;
         if (OD6S.woundConfig === 1) {
-            actorData.wounds.value =
-                Object.keys(Object.fromEntries(Object.entries(OD6S.deadliness[3]).filter(([_k, v]: any) => v!.description === actor.getWoundLevelFromBodyPoints())))[0];
+            actorData.wounds.value = Number(
+                Object.keys(
+                    Object.fromEntries(
+                        Object.entries(OD6S.deadliness[3]).filter(
+                            ([_k, v]: [string, { description: string }]) =>
+                                v.description === actor.getWoundLevelFromBodyPoints(),
+                        ),
+                    ),
+                )[0],
+            );
         } else if (OD6S.woundConfig === 2) {
             actorData.wounds.value = 0;
         }
@@ -45,116 +53,122 @@ export async function prepareDerivedActorData(actor: any): Promise<void> {
         // Remove mortally wounded flag if actor is not mortally wounded
         if (actor.getFlag('od6s', 'mortally_wounded')) {
             if (OD6S.woundsId[od6sutilities.getWoundLevel(actor.system.wounds.value, actor)] !== 'mortally_wounded') {
-                await actor.unsetFlag('od6s','mortally_wounded');
+                await actor.unsetFlag('od6s', 'mortally_wounded');
             }
         }
-    }
 
-    if (['character','npc'].includes(actor.type)) {
-        actor.system.species.label = OD6S.speciesLabelName;
-    }
+        if (actor.type === 'character' || actor.type === 'npc') {
+            actor.system.species.label = OD6S.speciesLabelName;
+        }
 
-    if (actor.type === 'character') {
-        actor.system.chartype.label = OD6S.typeLabel;
+        if (actor.type === 'character') {
+            actor.system.chartype.label = OD6S.typeLabel;
+        }
     }
 
     actor.applyMods();
 
-    if (actor.type !== 'container') actor.setInitiative(actorData);
+    if (!isContainerActor(actor)) actor.setInitiative();
 
     // Iterate over custom active effects and handle them
-    const changes = [];
+    const changes: ActiveEffectChange[] = [];
     const itemRegex = new RegExp(`^(system)?.?(items)?.?(skill|specialization|weapon|vehicle-weapon|starship-weapon)s?`);
 
-    for ( const effect of actor.allApplicableEffects() ) {
+    for (const effect of actor.allApplicableEffects()) {
         if (!effect.active) continue;
-        changes.push(...effect.changes.filter((c: any) => c.type === "custom" &&
-            !c.key.match(itemRegex)));
+        changes.push(...effect.changes.filter((c) => c.type === "custom" && !c.key.match(itemRegex)));
     }
 
-    for (const change in changes) {
-        if(changes[change].key.match(itemRegex)) continue;
-        const changeValue = od6sutilities.evaluateChange(changes[change], actor)
-        const origValue = foundry.utils.getProperty(actor, changes[change].key);
-        if (typeof(origValue) === 'undefined' || origValue === null) continue;
-        foundry.utils.setProperty(actor, changes[change].key, changeValue + origValue)
+    for (const change of changes) {
+        if (change.key.match(itemRegex)) continue;
+        const changeValue = od6sutilities.evaluateChange(change, actor);
+        const origValue = foundry.utils.getProperty(actor, change.key);
+        if (typeof origValue === 'undefined' || origValue === null) continue;
+        foundry.utils.setProperty(actor, change.key, changeValue + origValue);
         actor.applyMods();
     }
 
     // Iterate over owned items and apply custom active effects
-    for (const item in actor.items.contents) {
-        const i = actor.items.contents[item];
+    for (const i of actor.items.contents) {
         i.findActiveEffects();
         i.applyMods();
 
         if (i.type === 'skill' || i.type === 'specialization') {
+            const skillSystem = i.system as OD6SSkillItemSystem | OD6SSpecializationItemSystem;
             // `system.score` is the canonical own-progression value (base + mod),
             // already reset by `i.applyMods()` above. `system.total` is the display
             // value that includes the linked attribute (and respects flatSkills /
             // advanced-skill rules). Templates and roll-dialog data-score reads
             // should consume `system.total`; roll-formula consumers add the
             // attribute themselves and therefore stay on `system.score`.
-            const attrKey = typeof i.system.attribute === 'string' ? i.system.attribute : undefined;
-            const attribute = attrKey ? actor.system.attributes?.[attrKey] : undefined;
-            i.system.total = computeSkillDisplayScore({
-                base: i.system.base,
-                mod: i.system.mod,
-                isAdvancedSkill: i.type === 'skill' && i.system.isAdvancedSkill,
+            const attrKey = typeof skillSystem.attribute === 'string' ? skillSystem.attribute : undefined;
+            const attribute = attrKey && !isContainerActor(actor)
+                ? actor.system.attributes?.[attrKey]
+                : undefined;
+            skillSystem.total = computeSkillDisplayScore({
+                base: skillSystem.base,
+                mod: skillSystem.mod,
+                isAdvancedSkill: i.type === 'skill' && (skillSystem as OD6SSkillItemSystem).isAdvancedSkill,
                 attributeScore: attribute?.score,
                 flatSkills: OD6S.flatSkills,
             });
-            i.system.totalText = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(i.system.total));
+            skillSystem.totalText = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(skillSystem.total));
         }
     }
 
-    if (actor.type !== 'container') {
+    if (!isContainerActor(actor)) {
         for (const a in actor.system.attributes) {
             const dice = od6sutilities.getDiceFromScore(actor.system.attributes[a].score);
             actor.system.attributes[a].text = `${od6sutilities.getTextFromDice(dice)}`;
         }
     }
 
-    if (['starship', 'vehicle'].includes(actor.type)) {
+    if (isVehicleActor(actor)) {
         if (actor.system.crew.value > 0) {
             await actor.sendVehicleData();
         }
     }
 }
 
-export function applyMods(actor: any): void {
+export function applyMods(actor: Actor): void {
+    if (isContainerActor(actor)) return;
     const actorData = actor.system;
 
     for (const a in actorData.attributes) {
         actorData.attributes[a].score = actorData.attributes[a].base + actorData.attributes[a].mod;
-        if(actor.type.match(/^(character|npc|creature)/)) {
-            actorData.strengthdamage.score = setStrengthDamageBonus(actor);
+        if (isCharacterActor(actor)) {
+            actor.system.strengthdamage.score = setStrengthDamageBonus(actor);
         }
     }
 
-    if(actor.type.match(/^(character|npc|creature)/)) {
-        actor.system.pr.score = setResistance(actor, 'pr')
+    if (isCharacterActor(actor)) {
+        actor.system.pr.score = setResistance(actor, 'pr');
         actor.system.pr.text = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(actor.system.pr.score));
-        actor.system.er.score = setResistance(actor, 'er')
+        actor.system.er.score = setResistance(actor, 'er');
         actor.system.er.text = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(actor.system.er.score));
-        actor.system.noArmor = {};
-        actor.system.noArmor.mod = 0;
-        actor.system.noArmor.score = setResistance(actor, 'noArmor');
+        actor.system.noArmor = {
+            label: game.i18n.localize("OD6S.RESISTANCE_NO_ARMOR"),
+            mod: 0,
+            score: setResistance(actor, 'noArmor'),
+        };
         actor.system.noArmor.text = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(actor.system.noArmor.score));
-        actor.system.noArmor.label = game.i18n.localize("OD6S.RESISTANCE_NO_ARMOR")
     }
 }
 
-export function setStrengthDamageBonus(actor: any): any {
+export function setStrengthDamageBonus(actor: Actor): number {
+    if (!isCharacterActor(actor)) return 0;
     let damage;
-    if(!actor.type.match(/^(character|npc|creature)/)) return 0;
 
     // If game setting is true, use straight strength score plus modifier
     if (game.settings.get('od6s', 'strength_damage')) {
         return actor.system.attributes?.str.score + actor.system.strengthdamage?.mod;
     }
 
-    const liftSkill = actor.items.find((skill: any) => skill.name === OD6S.strDamSkill);
-    const base = liftSkill ? liftSkill.system.score + actor.system.attributes.str.score : actor.system.attributes.str.score;
+    const liftSkill = actor.items.find((skill) => skill.name === OD6S.strDamSkill);
+    const liftScore = liftSkill && (liftSkill.type === 'skill' || liftSkill.type === 'specialization')
+        ? (liftSkill.system as OD6SSkillItemSystem | OD6SSpecializationItemSystem).score
+        : 0;
+    const base = liftSkill ? liftScore + actor.system.attributes.str.score : actor.system.attributes.str.score;
 
     if (game.settings.get('od6s', 'od6_bonus')) {
         // Use base directly multiplied by the multiplier
@@ -171,11 +185,9 @@ export function setStrengthDamageBonus(actor: any): any {
     return damage;
 }
 
-export function setInitiative(actor: any): any {
-    if (actor.type === 'container' || actor.type === 'base') return
-    if (actor.type === 'vehicle' || actor.type === 'starship') {
-        if (!actor.system.embedded_pilot) return;
-    }
+export function setInitiative(actor: Actor): OD6SCharacterSystem | OD6SVehicleSystem | undefined {
+    if (isContainerActor(actor)) return;
+    if (isVehicleActor(actor) && !actor.system.embedded_pilot.value) return;
     // Base init is the character's perception score.  Special abilities and optional rules may add to it.
     // Using perception can be overridden in system config options
     // 0.7.3 add an option to change the base attribute
@@ -189,17 +201,18 @@ export function setInitiative(actor: any): any {
     return actor.system;
 }
 
-export function setResistance(actor: any, type: any): any {
+export function setResistance(actor: Actor, type: string): number {
+    if (!isCharacterActor(actor)) return 0;
     let dr = 0;
-    if (['vehicle', 'starship', 'container', 'base'].includes(actor.type)) return 0;
 
     // Accumulate DR from equipped and undamaged armor
     if (actor.itemTypes.armor && type !== 'noArmor') {
-        actor.itemTypes.armor.forEach((armor: any) => {
-            if (armor.system.equipped.value) {
-                dr += armor.system[type];
-                if (armor.system.damaged > 0) {
-                    dr -= OD6S.armorDamage[armor.system.damaged].penalty;
+        actor.itemTypes.armor.forEach((armor) => {
+            const armorSystem = armor.system as OD6SArmorItemSystem;
+            if (armorSystem.equipped.value) {
+                dr += (armorSystem as unknown as Record<string, number>)[type];
+                if (armorSystem.damaged !== undefined && armorSystem.damaged > 0) {
+                    dr -= OD6S.armorDamage[armorSystem.damaged].penalty;
                     dr = Math.max(0, dr);
                 }
             }
@@ -207,10 +220,13 @@ export function setResistance(actor: any, type: any): any {
     }
 
     if (OD6S.resistanceOption) {
-        const staminaItem = actor.items.find((skill: any) => skill.name === OD6S.resistanceSkill);
-        const staminaScore = staminaItem ? parseInt(staminaItem.system.score, 10) : 0;
-        const staminaAttr= staminaItem ? staminaItem.system.attribute : 'str';
-        const strScore = parseInt(actor.system.attributes[staminaAttr].score, 10);
+        const staminaItem = actor.items.find((skill) => skill.name === OD6S.resistanceSkill);
+        const staminaSystem = staminaItem && (staminaItem.type === 'skill' || staminaItem.type === 'specialization')
+            ? (staminaItem.system as OD6SSkillItemSystem | OD6SSpecializationItemSystem)
+            : undefined;
+        const staminaScore = staminaSystem ? Number(staminaSystem.score) : 0;
+        const staminaAttr = staminaSystem ? staminaSystem.attribute : 'str';
+        const strScore = Number(actor.system.attributes[staminaAttr].score);
 
         // Default the resistance multiplier if not set or zero
         if (!OD6S.resistanceMultiplier || OD6S.resistanceMultiplier === 0) {
@@ -221,9 +237,11 @@ export function setResistance(actor: any, type: any): any {
             Math.floor((staminaScore + strScore) * OD6S.resistanceMultiplier) :
             Math.ceil((staminaScore + strScore) * OD6S.resistanceMultiplier);
 
-        dr += damageResistance + actor.system[type].mod;
+        const modField = (actor.system as unknown as Record<string, OD6SModScoreField | undefined>)[type];
+        dr += damageResistance + (modField?.mod ?? 0);
     } else {
-        dr += actor.system.attributes.str.score + actor.system[type].mod;
+        const modField = (actor.system as unknown as Record<string, OD6SModScoreField | undefined>)[type];
+        dr += actor.system.attributes.str.score + (modField?.mod ?? 0);
     }
     return dr;
 }

--- a/src/module/actor/actor-helpers/prepare-actor.ts
+++ b/src/module/actor/actor-helpers/prepare-actor.ts
@@ -136,12 +136,11 @@ export function applyMods(actor: Actor): void {
 
     for (const a in actorData.attributes) {
         actorData.attributes[a].score = actorData.attributes[a].base + actorData.attributes[a].mod;
-        if (isCharacterActor(actor)) {
-            actor.system.strengthdamage.score = setStrengthDamageBonus(actor);
-        }
     }
 
     if (isCharacterActor(actor)) {
+        // Compute after the attribute loop so str.score reflects base+mod.
+        actor.system.strengthdamage.score = setStrengthDamageBonus(actor);
         actor.system.pr.score = setResistance(actor, 'pr');
         actor.system.pr.text = od6sutilities.getTextFromDice(od6sutilities.getDiceFromScore(actor.system.pr.score));
         actor.system.er.score = setResistance(actor, 'er');
@@ -178,7 +177,7 @@ export function setStrengthDamageBonus(actor: Actor): number {
         // Calculate based on dice conversion and then apply half dice logic
         const dice = Math.ceil(base / OD6S.pipsPerDice);
         const halfDice = OD6S.strDamRound ? Math.floor(dice / 2) : Math.ceil(dice / 2);
-        damage = (halfDice * OD6S.pipsPerDice) + actor.system.strengthdamage.mod;
+        damage = halfDice * OD6S.pipsPerDice;
     }
 
     damage += actor.system.strengthdamage.mod; // Always add modifier to the damage
@@ -201,7 +200,9 @@ export function setInitiative(actor: Actor): OD6SCharacterSystem | OD6SVehicleSy
     return actor.system;
 }
 
-export function setResistance(actor: Actor, type: string): number {
+export type ResistanceKey = 'pr' | 'er' | 'noArmor';
+
+export function setResistance(actor: Actor, type: ResistanceKey): number {
     if (!isCharacterActor(actor)) return 0;
     let dr = 0;
 

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -6,6 +6,7 @@ import {warnIfSchemaVersionMismatch, SCHEMA_VERSION_KEY} from "../system/schema-
 
 import {resolveRollAction} from "./actor-helpers/roll-action";
 import {prepareBaseActorData, prepareDerivedActorData, applyMods as applyModsHelper, setStrengthDamageBonus as setStrengthDamageBonusHelper, setInitiative as setInitiativeHelper, setResistance as setResistanceHelper} from "./actor-helpers/prepare-actor";
+import type {ResistanceKey} from "./actor-helpers/prepare-actor";
 import {applyDamage as applyDamageHelper, calculateNewDamageLevel as calculateNewDamageLevelHelper, applyWounds as applyWoundsHelper, calculateNewWoundLevel as calculateNewWoundLevelHelper, triggerMortallyWoundedCheck as triggerMortallyWoundedCheckHelper, applyMortallyWoundedFailure as applyMortallyWoundedFailureHelper, applyIncapacitatedFailure as applyIncapacitatedFailureHelper, findFirstWoundLevel as findFirstWoundLevelHelper, getWoundLevelFromBodyPoints as getWoundLevelFromBodyPointsHelper, setWoundLevelFromBodyPoints as setWoundLevelFromBodyPointsHelper} from "./actor-helpers/wounds";
 import {addEmbeddedPilot as addEmbeddedPilotHelper, addToCrew as addToCrewHelper, _verifyAddToCrew as _verifyAddToCrewHelper, removeFromCrew as removeFromCrewHelper, forceRemoveCrewmember as forceRemoveCrewmemberHelper, isCrewMember as isCrewMemberHelper, sendVehicleData as sendVehicleDataHelper, modifyShields as modifyShieldsHelper, vehicleCollision as vehicleCollisionHelper, onCargoHoldItemCreate as onCargoHoldItemCreateHelper} from "./actor-helpers/crew-vehicle";
 import {useCharacterPointOnRoll as useCharacterPointOnRollHelper} from "./actor-helpers/resources";
@@ -248,7 +249,7 @@ export class OD6SActor extends Actor {
         return setWoundLevelFromBodyPointsHelper(this, bp);
     }
 
-    setResistance(type: string) {
+    setResistance(type: ResistanceKey) {
         return setResistanceHelper(this, type);
     }
 

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -20,6 +20,8 @@ interface OD6SAttributeField {
     score: number;
     max?: number;
     min?: number;
+    /** Derived "<n>D+<p>" display text, refreshed each `prepareDerivedData`. */
+    text?: string;
 }
 
 interface OD6SModScoreField {
@@ -27,6 +29,8 @@ interface OD6SModScoreField {
     short_label?: string;
     mod: number;
     score: number;
+    /** Derived "<n>D+<p>" display text, refreshed each `applyMods`. */
+    text?: string;
 }
 
 interface OD6SModField {
@@ -90,6 +94,8 @@ interface OD6SCharacterSystem {
     block: OD6SModScoreField;
     pr: OD6SModScoreField;
     er: OD6SModScoreField;
+    /** Derived "no armor" resistance, recomputed each `applyMods`. */
+    noArmor?: OD6SModScoreField;
     credits: { type: string; label: string; value: number };
     funds: { type: string; label: string; score: number };
     sheetmode: { value: string };
@@ -216,6 +222,8 @@ interface OD6SVehicleSystem {
     };
     roll_mod: number;
     use_wild_die: boolean;
+    /** Initiative state (mirrors `OD6SVehicleCommon.initiative`). */
+    initiative: { type: string; label: string; formula: string; mod: number; score: number };
 }
 
 // ---- Item system data shapes ----
@@ -256,6 +264,10 @@ interface OD6SSkillFields {
     time_taken: string;
     isAdvancedSkill: boolean;
     used: { value: boolean };
+    /** Derived display value (own score + linked attribute), recomputed each `prepareDerivedData`. */
+    total?: number;
+    /** Derived "<n>D+<p>" text for `total`. */
+    totalText?: string;
 }
 
 /** Mixed in by advantage/disadvantage/cybernetic — `advantageFieldsSchema`. */
@@ -345,6 +357,12 @@ interface OD6SSpecialAbilityItemSystem extends OD6SItemBase {}
 interface OD6SArmorItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {
     pr: number;
     er: number;
+    /**
+     * Armor damage level (0-N) used by `setResistance` to subtract a penalty
+     * from the equipped DR. Not in the type-data schema — populated from
+     * legacy world data / active effects only.
+     */
+    damaged?: number;
 }
 
 interface OD6SWeaponItemSystem extends OD6SItemBase, OD6SEquipment, OD6SEquip {

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -592,8 +592,8 @@ interface Actor {
     /** Recalculate initiative score. */
     setInitiative(): void;
 
-    /** Recalculate physical/energy resistance (`type` is "p" | "e"). */
-    setResistance(type: string): void;
+    /** Recalculate physical/energy/no-armor resistance. */
+    setResistance(type: 'pr' | 'er' | 'noArmor'): void;
 
     /** Apply incoming damage; updates BP / wound levels. */
     applyDamage(damage: any): Promise<unknown>;


### PR DESCRIPTION
## Summary

Closes #147.

- Replace the five `actor: any` parameters in `actor-helpers/prepare-actor.ts` with `Actor` plus `isCharacterActor` / `isVehicleActor` / `isContainerActor` narrowing. The dead `'base'` type-string branches are dropped (not in `OD6SActorType`).
- Caught one latent bug the `any` was masking: `setResistance` read `armor.system.damaged > 0` unguarded; that field is not in the armor type-data schema, so the comparison was silently `undefined > 0`. Guarded the access and documented the field as optional/legacy.
- Filled in derived display fields the type-data shapes were missing: `OD6SAttributeField.text?`, `OD6SModScoreField.text?`, `OD6SCharacterSystem.noArmor?`, `OD6SSkillFields.total?`/`totalText?`, and the missing `OD6SVehicleSystem.initiative` (present at runtime via `vehicleCommonSchema`).

`no-explicit-any` warnings: 298 → 283 (−15). `prepare-actor.ts` at zero warnings (DoD).

## Test plan

- [x] `pnpm run check` (lint + typecheck + unit + domain)
- [ ] Smoke: open a character sheet (verify attribute/pr/er/noArmor totals render); open a vehicle sheet with embedded pilot (verify initiative formula renders); open a container actor (no crashes).