### PR TITLE
refactor(types): tighten remaining sheet-helpers + actor-sheet residuals

### DIFF
--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -222,15 +222,15 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     /*  Item CRUD Methods (delegates)                */
     /* -------------------------------------------- */
 
-    async deleteItem(ev: any) {
+    async deleteItem(ev: Event) {
         return deleteItem(this, ev);
     }
 
-    async addItem(ev: any, caller: any = this) {
+    async addItem(ev: Event, caller: unknown = this) {
         return addItem(this, ev, caller);
     }
 
-    _onItemCreate(event: any) {
+    _onItemCreate(event: Event) {
         return onItemCreate(this, event);
     }
 
@@ -356,11 +356,11 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     /*  Roll Methods (delegates)                     */
     /* -------------------------------------------- */
 
-    async _rollAvailableVehicleAction(ev: any) {
+    async _rollAvailableVehicleAction(ev: Event) {
         return rollAvailableVehicleAction(this, ev);
     }
 
-    async _rollAvailableAction(ev: any) {
+    async _rollAvailableAction(ev: Event) {
         return rollAvailableAction(this, ev);
     }
 
@@ -391,15 +391,15 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         return rollBodyPoints(this);
     }
 
-    async rollPurchase(ev: any, buyerId: any) {
+    async rollPurchase(ev: Event, buyerId: string) {
         return rollPurchaseHelper(this, ev, buyerId);
     }
 
-    async _onPurchase(itemId: any, buyerId: any) {
+    async _onPurchase(itemId: string, buyerId: string) {
         return onPurchase(this, itemId, buyerId);
     }
 
-    async _onTransfer(itemId: any, senderId: any, recId: any) {
+    async _onTransfer(itemId: string, senderId: string, recId: string) {
         return onTransfer(this, itemId, senderId, recId);
     }
 }

--- a/src/module/actor/advance-dialog.ts
+++ b/src/module/actor/advance-dialog.ts
@@ -1,21 +1,54 @@
- 
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
 
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
+/**
+ * Shape of the rolling state passed in/out of the dialog. Mutated in place
+ * across `pipUp`/`pipDown`/`cpCost` and finally by `od6sadvance.advanceAction`.
+ */
+export interface AdvanceData {
+    label: string | undefined;
+    score: number;
+    /** Coerced to a number at construction in `advance.ts`. */
+    base: number;
+    cpcost: number;
+    cpcostcolor: string;
+    freeadvance: boolean;
+    type: string | undefined;
+    attrname: string | undefined;
+    originalscore: number;
+    itemid: string | number;
+    used: boolean;
+    metaPhysicsSkill?: boolean;
+    metaphysicsteacher: boolean;
+}
+
+/** Sheet shape consumed by the dialog — only `actor` is read here. */
+interface AdvanceActorSheetLike {
+    actor: Actor;
+}
+
+/** Form-submission payload from the advance dialog template. */
+export interface AdvanceFormData {
+    base?: number;
+    dice?: number;
+    pips?: number;
+    [key: string]: unknown;
+}
+
 export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
 
-    actorSheet: any;
-    advanceData: any;
-    onSubmit: (dialog: AdvanceDialog, formData: any) => void | Promise<void>;
+    actorSheet: AdvanceActorSheetLike;
+    advanceData: AdvanceData;
+    onSubmit: (dialog: AdvanceDialog, formData: AdvanceFormData) => void | Promise<void>;
 
     constructor(
-        actorSheet: any,
-        advanceData: any,
-        onSubmit: (dialog: AdvanceDialog, formData: any) => void | Promise<void>,
-        options: any = {},
+        actorSheet: AdvanceActorSheetLike,
+        advanceData: AdvanceData,
+        onSubmit: (dialog: AdvanceDialog, formData: AdvanceFormData) => void | Promise<void>,
+        options: object = {},
     ) {
         super(options);
         this.actorSheet = actorSheet;
@@ -50,8 +83,8 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     };
 
     async _prepareContext(_options?: object): Promise<object> {
-        this.advanceData.cpcostcolor =
-            this.advanceData.cpcost > this.actorSheet.actor.system.characterpoints.value ? "red" : "black";
+        const cp = (this.actorSheet.actor.system as OD6SCharacterSystem).characterpoints.value;
+        this.advanceData.cpcostcolor = this.advanceData.cpcost > cp ? "red" : "black";
         return this.advanceData;
     }
 
@@ -90,7 +123,7 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         this: AdvanceDialog,
         _event: Event,
         _form: HTMLFormElement,
-        formData: any,
+        formData: { object: AdvanceFormData },
     ): Promise<void> {
         await this.onSubmit(this, formData.object);
     }
@@ -100,7 +133,8 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             return;
         }
 
-        const item = this.actorSheet.actor.items.get(this.advanceData.itemid);
+        const item = this.actorSheet.actor.items.get(String(this.advanceData.itemid)) as
+            (Item & { system: { attribute: string; isAdvancedSkill?: boolean } }) | undefined;
         let skillAttr = "";
         if (typeof item !== "undefined") {
             skillAttr = item.system.attribute;
@@ -110,8 +144,12 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             teacherCostMultiplier = 1;
         }
 
-        let score: any;
-        OD6S.flatSkills ? (score = this.advanceData.base)
+        // `score.dice`/`score.pips` reads below are guarded by !OD6S.flatSkills;
+        // under flatSkills the property reads still happen on the numeric
+        // base but `Math.ceil(+number * X)` matches the previous (any) behaviour.
+        let score: { dice: number; pips: number };
+        OD6S.flatSkills
+            ? (score = {dice: this.advanceData.base, pips: 0})
             : (score = od6sutilities.getDiceFromScore(this.advanceData.score));
 
         if (up) {
@@ -133,7 +171,7 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
                     OD6S.flatSkills
                         ? (this.advanceData.cpcost += Math.ceil((+this.advanceData.base) * OD6S.advanceCostSkill))
                         : (this.advanceData.cpcost += Math.ceil((+score.dice) * OD6S.advanceCostSkill));
-                    if (item.system.isAdvancedSkill) this.advanceData.cpcost = this.advanceData.cpcost * 2;
+                    if (item?.system.isAdvancedSkill) this.advanceData.cpcost = this.advanceData.cpcost * 2;
                 }
             } else if (this.advanceData.type === "specialization") {
                 OD6S.flatSkills
@@ -177,7 +215,8 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     pipUp() {
-        const item = this.actorSheet.actor.items.get(this.advanceData.itemid);
+        const item = this.actorSheet.actor.items.get(String(this.advanceData.itemid)) as
+            (Item & { system: { attribute: string } }) | undefined;
         let skillAttr = "";
         if (typeof item !== "undefined") {
             skillAttr = item.system.attribute;
@@ -215,7 +254,9 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             }
 
             if (attr !== "") {
-                if ((this.advanceData.score + 1) > this.actorSheet.actor.system.attributes[attr].max) {
+                const attrs = (this.actorSheet.actor.system as OD6SCharacterSystem).attributes;
+                const max = attrs[attr]!.max;
+                if (max !== undefined && (this.advanceData.score + 1) > max) {
                     ui.notifications.warn(game.i18n.localize("OD6S.WARN_ADVANCE_GREATER_THAN_MAX"));
                     return false;
                 }

--- a/src/module/actor/advance-dialog.ts
+++ b/src/module/actor/advance-dialog.ts
@@ -144,9 +144,6 @@ export class AdvanceDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             teacherCostMultiplier = 1;
         }
 
-        // `score.dice`/`score.pips` reads below are guarded by !OD6S.flatSkills;
-        // under flatSkills the property reads still happen on the numeric
-        // base but `Math.ceil(+number * X)` matches the previous (any) behaviour.
         let score: { dice: number; pips: number };
         OD6S.flatSkills
             ? (score = {dice: this.advanceData.base, pips: 0})

--- a/src/module/actor/advance.ts
+++ b/src/module/actor/advance.ts
@@ -1,6 +1,6 @@
 import {od6sutilities} from "../system/utilities";
 import OD6S from "../config/config-od6s";
-import {AdvanceDialog} from "./advance-dialog";
+import {AdvanceDialog, type AdvanceData} from "./advance-dialog";
 import {isCharacterActor, isSpecializationItem} from "../system/type-guards";
 
 export class od6sadvance {
@@ -59,10 +59,10 @@ export class od6sadvance {
         }
 
         /* Structure to pass to dialog */
-        const advanceData = {
+        const advanceData: AdvanceData = {
             label: dataset.label,
             score: originalScore,
-            base: base,
+            base: +(base ?? 0),
             cpcost: cpcost,
             cpcostcolor: "black",
             freeadvance: freeAdvance,
@@ -75,9 +75,13 @@ export class od6sadvance {
             metaphysicsteacher: metaphysicsteacher
         }
 
+        // od6sadvance is mixed into the actor sheet at runtime, so `this`
+        // exposes `actor` even though TS doesn't see it on the bare class.
+        const sheet = this as unknown as { actor: Actor };
+
         if (OD6S.flatSkills) {
             new AdvanceDialog(
-                this,
+                sheet,
                 advanceData,
                 (dlg, formData) => od6sadvance.advanceAction(
                     dlg.actorSheet.actor,
@@ -87,7 +91,7 @@ export class od6sadvance {
             ).render({force: true});
         } else {
             new AdvanceDialog(
-                this,
+                sheet,
                 advanceData,
                 (dlg, formData) => od6sadvance.advanceAction(
                     dlg.actorSheet.actor,

--- a/src/module/actor/sheet-helpers/inventory-transfer.ts
+++ b/src/module/actor/sheet-helpers/inventory-transfer.ts
@@ -20,10 +20,16 @@
 
 import OD6S from "../../config/config-od6s";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Sheet = any;
+/**
+ * Minimal sheet shape used by these helpers — keeps them decoupled from
+ * `OD6SActorSheet` to avoid the actor-sheet ↔ helpers cycle.
+ */
+interface InventorySheetLike {
+    document: Actor;
+    render: () => unknown;
+}
 
-export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promise<void> {
+export async function onPurchase(sheet: InventorySheetLike, itemId: string, buyerId: string): Promise<void> {
     const seller = sheet.document;
     const buyer = game.actors.get(buyerId);
     const item = seller.items.get(itemId);
@@ -66,12 +72,17 @@ export async function onPurchase(sheet: Sheet, itemId: any, buyerId: any): Promi
         await buyer!.createEmbeddedDocuments("Item", [boughtItem]);
     }
 
-    const sellerUpdate: any = {};
+    const sellerUpdate: Record<string, number> = {};
     if (itemSystem.quantity > 0) sellerUpdate["system.quantity"] = (+itemSystem.quantity) - 1;
     await item.update(sellerUpdate);
 }
 
-export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId: any): Promise<void> {
+export async function onTransfer(
+    sheet: InventorySheetLike,
+    itemId: string,
+    senderId: string,
+    recId: string,
+): Promise<void> {
     const sender = game.actors.get(senderId);
     const receiver = game.actors.get(recId);
     const item = sender!.items.get(itemId);
@@ -94,7 +105,7 @@ export async function onTransfer(sheet: Sheet, itemId: any, senderId: any, recId
             await receiver!.createEmbeddedDocuments("Item", [recItem]);
         }
 
-        const senderUpdate: any = {};
+        const senderUpdate: Record<string, number> = {};
         if (itemSystem.quantity > 0) senderUpdate["system.quantity"] = (+itemSystem.quantity) - 1;
         await item!.update(senderUpdate);
 

--- a/src/module/actor/sheet-helpers/item-crud.ts
+++ b/src/module/actor/sheet-helpers/item-crud.ts
@@ -1,13 +1,19 @@
 import OD6S from "../../config/config-od6s";
 import {isSkillItem} from "../../system/type-guards";
 
- 
+/**
+ * Minimal sheet shape consumed by these helpers — avoids the actor-sheet ↔
+ * helpers cycle that would result from importing `OD6SActorSheet` here.
+ */
+interface ItemCrudSheetLike {
+    document: Actor;
+    render: (force?: boolean) => unknown;
+}
 
 /**
  * Delete an item from the actor, with confirmation dialog.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function deleteItem(sheet: any, ev: Event) {
+export async function deleteItem(sheet: ItemCrudSheetLike, ev: Event) {
     const ct = ev.currentTarget as HTMLElement;
     // If this is a skill, deny if there are existing specializations.
     if (ct.dataset.type === "skill") {
@@ -37,10 +43,10 @@ export async function deleteItem(sheet: any, ev: Event) {
             content: `<p>${game.i18n.localize("OD6S.DELETE_CONFIRM")}</p>`,
         });
         if (!ok) return;
-        await sheet.document.deleteEmbeddedDocuments('Item', [itemId]);
+        if (itemId) await sheet.document.deleteEmbeddedDocuments('Item', [itemId]);
         sheet.render(false);
     } else {
-        await sheet.document.deleteEmbeddedDocuments('Item', [ct.dataset.itemId]);
+        if (ct.dataset.itemId) await sheet.document.deleteEmbeddedDocuments('Item', [ct.dataset.itemId]);
         sheet.render(false);
     }
 }
@@ -49,11 +55,9 @@ export async function deleteItem(sheet: any, ev: Event) {
  * Add an item to the actor using the add-item dialog.
  */
 export async function addItem(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sheet: any,
+    sheet: ItemCrudSheetLike,
     ev: Event,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    caller?: any,
+    caller?: unknown,
 ) {
     // Lazy-import to avoid circular dependency
     const {OD6SAddItem} = await import("../add-item.js");
@@ -61,21 +65,23 @@ export async function addItem(
 
     caller = caller ?? sheet;
     const ct = ev.currentTarget as HTMLElement;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: Record<string, any> = {};
-    data.type = ct.dataset.type!;
+    // Templates also pass `'spec'` as a shorthand alongside the real OD6S
+    // item types, so widen the literal here.
+    const itemType = ct.dataset.type! as OD6SItemType | 'spec';
+    const data: Record<string, unknown> = {};
+    data.type = itemType;
     data.attrname = ct.dataset.attrname;
     data.new = !(typeof ct.dataset.new !== 'undefined' && ct.dataset.new === 'false');
     let worldItems: Item[] = [];
     let compendiumItems: Item[] = [];
 
-    data.label = game.i18n.localize('OD6S.ADD') + " " + game.i18n.localize(OD6S.itemLabels[data.type])
-    data.label_empty = game.i18n.localize('OD6S.ADD_EMPTY') + " " + game.i18n.localize(OD6S.itemLabels[data.type])
+    data.label = game.i18n.localize('OD6S.ADD') + " " + game.i18n.localize(OD6S.itemLabels[itemType])
+    data.label_empty = game.i18n.localize('OD6S.ADD_EMPTY') + " " + game.i18n.localize(OD6S.itemLabels[itemType])
 
-    worldItems = game.items.filter((i: Item) => i.type === data.type);
-    const cEntries = od6sutilities.getItemsFromCompendiumByType(data.type);
+    worldItems = game.items.filter((i: Item) => i.type === itemType);
+    const cEntries = od6sutilities.getItemsFromCompendiumByType(itemType as OD6SItemType);
 
-    if (data.type === 'skill') {
+    if (itemType === 'skill') {
         worldItems = worldItems.filter((i: Item) => isSkillItem(i) && i.system.attribute === data.attrname);
         for (const i of cEntries) {
             const item = await od6sutilities._getItemFromCompendium((i as Item).name);
@@ -91,7 +97,7 @@ export async function addItem(
     }
 
     //if it is a skill, do not include skills the actor already has
-    if (data.type === 'skill') {
+    if (itemType === 'skill') {
         worldItems = worldItems.filter((i: Item) => !sheet.document.items.find((r: Item) => r.name === i.name));
         compendiumItems = compendiumItems.filter((i: Item) => !sheet.document.items.find((r: Item) => r.name === i.name));
     }
@@ -110,12 +116,13 @@ export async function addItem(
     data.token = sheet.document.isToken === true ? sheet.document.token._id : '';
     data.actorType = sheet.document.type;
 
-    if (data.type === 'skill' || data.type === 'spec') {
-        if (data.type === 'skill' && data.attrname === 'met' && game.settings.get('od6s', 'metaphysics_attribute_optional')) {
+    if (itemType === 'skill' || itemType === 'spec') {
+        if (itemType === 'skill' && data.attrname === 'met' && game.settings.get('od6s', 'metaphysics_attribute_optional')) {
             // No metaphysics attribute, set skill to default of 1D
             data.score = OD6S.pipsPerDice;
         } else {
-            data.score = sheet.document.system.attributes[data.attrname].base;
+            const attrs = (sheet.document.system as OD6SCharacterSystem).attributes;
+            data.score = attrs[data.attrname as string].base;
         }
     } else {
         data.score = 0;
@@ -127,8 +134,7 @@ export async function addItem(
 /**
  * Handle creating a new Owned Item for the actor using initial data defined in the HTML dataset.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function onItemCreate(sheet: any, event: Event) {
+export function onItemCreate(sheet: ItemCrudSheetLike, event: Event) {
     event.preventDefault();
     const header = event.currentTarget as HTMLElement;
     // Get the type of item to create.

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -49,7 +49,7 @@ export async function rollAvailableVehicleAction(sheet: RollSheetLike, ev: Event
             OD6S.vehicle_actions[data.id!].base)) + (+data.score!);
     } else if (data.type === "vehicleshields") {
         rollData.score = od6sutilities.getScoreFromSkill(sheet.document, "",
-            (actorData.vehicle.shields as Record<string, {value: string}>).skill.value,
+            game.i18n.localize((actorData.vehicle.shields as Record<string, string>).skill),
             OD6S.vehicle_actions[data.id!].base);
     } else {
         const item = actorData.vehicle.vehicle_weapons?.find(

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -17,30 +17,43 @@
 import {od6sroll} from "../../apps/roll";
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
+import type {IncomingRollData} from "../../apps/roll-helpers/roll-data";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Sheet = any;
+/**
+ * Minimal sheet shape consumed by these helpers. Matches the pattern in
+ * `templates.ts` / `drops.ts` to avoid the actor-sheet ↔ helpers cycle.
+ */
+interface RollSheetLike {
+    document: Actor;
+    /** Linked token for token-bound sheets; undefined for actor-directory sheets. */
+    token?: TokenDocument | null;
+}
 
-export async function rollAvailableVehicleAction(sheet: Sheet, ev: any): Promise<void> {
-    const rollData: any = {score: 0, scale: 0};
-    const data = ev.currentTarget.dataset;
-    const actorData = sheet.document.system;
+export async function rollAvailableVehicleAction(sheet: RollSheetLike, ev: Event): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    const data = target.dataset;
+    const actorData = sheet.document.system as OD6SCharacterSystem;
 
     if (data.rollable !== "true") return;
 
-    if (["vehicleramattack", "vehiclemaneuver", "vehicledodge"].includes(data.type)) {
+    const rollData: Partial<IncomingRollData> = {score: 0, scale: 0};
+
+    if (["vehicleramattack", "vehiclemaneuver", "vehicledodge"].includes(data.type!)) {
         rollData.score = od6sutilities.getScoreFromSkill(sheet.document,
-                actorData.vehicle.specialization.value,
-                actorData.vehicle.skill.value, OD6S.vehicle_actions[data.id].base)
-            + actorData.vehicle.maneuverability.score;
+                actorData.vehicle.specialization!.value,
+                actorData.vehicle.skill!.value, OD6S.vehicle_actions[data.id!].base)
+            + actorData.vehicle.maneuverability!.score;
     } else if (data.type === "vehiclesensors") {
         rollData.score = +(od6sutilities.getScoreFromSkill(sheet.document, "",
-            actorData.vehicle.sensors.skill, OD6S.vehicle_actions[data.id].base)) + (+data.score);
+            (actorData.vehicle.sensors as Record<string, string>).skill,
+            OD6S.vehicle_actions[data.id!].base)) + (+data.score!);
     } else if (data.type === "vehicleshields") {
         rollData.score = od6sutilities.getScoreFromSkill(sheet.document, "",
-            actorData.vehicle.shields.skill.value, OD6S.vehicle_actions[data.id].base);
+            (actorData.vehicle.shields as Record<string, {value: string}>).skill.value,
+            OD6S.vehicle_actions[data.id!].base);
     } else {
-        const item = actorData.vehicle.vehicle_weapons.find((i: VehicleWeaponSnapshot) => i.id === data.id);
+        const item = actorData.vehicle.vehicle_weapons?.find(
+            (i: VehicleWeaponSnapshot) => i.id === data.id);
         if (item !== null && typeof item !== "undefined") {
             rollData.score = od6sutilities.getScoreFromSkill(sheet.document, item.system.specialization.value,
                 game.i18n.localize(item.system.skill.value), item.system.attribute.value);
@@ -51,30 +64,32 @@ export async function rollAvailableVehicleAction(sheet: Sheet, ev: any): Promise
         }
     }
 
-    if (!rollData.scale) rollData.scale = actorData.vehicle.scale.score;
-    rollData.name = game.i18n.localize(data.name);
+    if (!rollData.scale) rollData.scale = actorData.vehicle.scale!.score;
+    rollData.name = game.i18n.localize(data.name!);
     rollData.type = "action";
     rollData.actor = sheet.document;
     rollData.subtype = data.type;
-    await od6sroll._onRollDialog(rollData);
+    await od6sroll._onRollDialog(rollData as IncomingRollData);
 }
 
-export async function rollAvailableAction(sheet: Sheet, ev: any): Promise<void> {
-    const rollData: any = {token: sheet.token};
-    const data = ev.currentTarget.dataset;
-    let name = game.i18n.localize(data.name);
+export async function rollAvailableAction(sheet: RollSheetLike, ev: Event): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    const data = target.dataset;
+    const rollData: Partial<IncomingRollData> = {token: sheet.token?.id};
+    let name = game.i18n.localize(data.name!);
     let flatPips = 0;
 
     if (data.rollable !== "true") return;
     if (data.id !== "") {
-        const item = sheet.document.items.find((i: any) => i.id === data.id);
+        const item = sheet.document.items.find((i: Item) => i.id === data.id);
         if (item !== null && typeof item !== "undefined") {
-            await item.roll(data.type === "parry");
+            await (item as Item & {roll: (parry: boolean) => Promise<unknown>})
+                .roll(data.type === "parry");
             return;
         }
     }
 
-    if (["dodge", "parry", "block"].includes(data.type)) {
+    if (["dodge", "parry", "block"].includes(data.type!)) {
         switch (data.type) {
             case "dodge": name = OD6S.actions.dodge.skill; break;
             case "parry": name = OD6S.actions.parry.skill; break;
@@ -83,31 +98,35 @@ export async function rollAvailableAction(sheet: Sheet, ev: any): Promise<void> 
         name = game.i18n.localize(name);
     }
 
+    type SkillLike = Item & {system: {attribute: string; score: number}};
+    const actorSystem = sheet.document.system as OD6SCharacterSystem;
     if (data.type === "attribute") {
-        name = data.name;
+        name = data.name!;
         rollData.attribute = data.id;
     } else {
-        let skill = sheet.document.items.find((i: any) => i.type === "skill" && i.name === name);
-        if (skill !== null && typeof skill !== "undefined") {
+        const ownedSkill = sheet.document.items.find(
+            (i: Item) => i.type === "skill" && i.name === name) as SkillLike | undefined;
+        if (ownedSkill !== null && typeof ownedSkill !== "undefined") {
+            const attrKey = ownedSkill.system.attribute.toLowerCase();
             if (OD6S.flatSkills) {
-                rollData.score = (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
-                flatPips = (+skill.system.score);
+                rollData.score = (+actorSystem.attributes[attrKey].score);
+                flatPips = (+ownedSkill.system.score);
             } else {
-                rollData.score = (+skill.system.score)
-                    + (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+                rollData.score = (+ownedSkill.system.score)
+                    + (+actorSystem.attributes[attrKey].score);
             }
         } else {
-            skill = await od6sutilities._getItemFromWorld(name);
-            if (skill !== null && typeof skill !== "undefined") {
-                rollData.score = (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+            const worldSkill = (await od6sutilities._getItemFromWorld(name)) as SkillLike | null | undefined;
+            if (worldSkill !== null && typeof worldSkill !== "undefined") {
+                rollData.score = (+actorSystem.attributes[worldSkill.system.attribute.toLowerCase()].score);
             } else {
-                skill = await od6sutilities._getItemFromCompendium(name);
-                if (skill !== null && typeof skill !== "undefined") {
-                    rollData.score = (+sheet.document.system.attributes[skill.system.attribute.toLowerCase()].score);
+                const compSkill = (await od6sutilities._getItemFromCompendium(name)) as SkillLike | null | undefined;
+                if (compSkill !== null && typeof compSkill !== "undefined") {
+                    rollData.score = (+actorSystem.attributes[compSkill.system.attribute.toLowerCase()].score);
                 } else {
                     for (const a in OD6S.actions) {
-                        if (OD6S.actions[a].type === ev.currentTarget.dataset.type) {
-                            rollData.score = (+sheet.document.system.attributes[OD6S.actions[a].base].score);
+                        if (OD6S.actions[a].type === data.type) {
+                            rollData.score = (+actorSystem.attributes[OD6S.actions[a].base].score);
                             break;
                         }
                     }
@@ -121,7 +140,7 @@ export async function rollAvailableAction(sheet: Sheet, ev: any): Promise<void> 
     rollData.type = "action";
     rollData.actor = sheet.document;
     rollData.subtype = data.type;
-    await od6sroll._onRollDialog(rollData);
+    await od6sroll._onRollDialog(rollData as IncomingRollData);
 }
 
 /**
@@ -130,9 +149,10 @@ export async function rollAvailableAction(sheet: Sheet, ev: any): Promise<void> 
  * Wild-die handling matches the legacy implementation: 1dw if str < 2,
  * else (str-1)d6+1dw — when the wild-die setting is on.
  */
-export async function rollBodyPoints(sheet: Sheet): Promise<void> {
-    const strDice = od6sutilities.getDiceFromScore(sheet.document.system.attributes.str.score
-        + sheet.document.system.attributes.str.mod);
+export async function rollBodyPoints(sheet: RollSheetLike): Promise<void> {
+    const actorSystem = sheet.document.system as OD6SCharacterSystem;
+    const strDice = od6sutilities.getDiceFromScore(actorSystem.attributes.str.score
+        + actorSystem.attributes.str.mod);
     let rollString;
     if (game.settings.get("od6s", "use_wild_die")) {
         if (strDice.dice < 2) rollString = "1dw";
@@ -144,7 +164,7 @@ export async function rollBodyPoints(sheet: Sheet): Promise<void> {
 
     const label = game.i18n.localize("OD6S.ROLLING") + " " + game.i18n.localize(OD6S.bodyPointsName);
 
-    let rollMode: any = CONST.DICE_ROLL_MODES.PUBLIC;
+    let rollMode: string = CONST.DICE_ROLL_MODES.PUBLIC;
     if (game.user.isGM && game.settings.get("od6s", "hide-gm-rolls")) {
         rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
     }
@@ -157,20 +177,23 @@ export async function rollBodyPoints(sheet: Sheet): Promise<void> {
     await sheet.document.update({"system.wounds.body_points.max": roll.total});
 }
 
-export async function rollPurchase(sheet: Sheet, ev: any, buyerId: any): Promise<void> {
-    const item = sheet.document.items.get(ev.currentTarget.dataset.itemId);
+export async function rollPurchase(sheet: RollSheetLike, ev: Event, buyerId: string): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    const item = sheet.document.items.get(target.dataset.itemId!);
     if (typeof item === "undefined") {
         ui.notifications.warn(game.i18n.localize("OD6S.ITEM_NOT_FOUND"));
         return;
     }
-    const data: any = {
+    const buyer = game.actors.get(buyerId);
+    const itemSystem = item.system as OD6SEquipment;
+    const data: Partial<IncomingRollData> = {
         name: game.i18n.localize("OD6S.PURCHASE") + " " + item.name,
-        itemId: item.id,
-        actor: game.actors.get(buyerId),
-        seller: sheet.document.id,
+        itemId: item.id ?? undefined,
+        actor: buyer,
+        seller: sheet.document.id ?? undefined,
         type: "purchase",
-        difficultyLevel: OD6S.difficultyShort[item.system.price],
+        difficultyLevel: OD6S.difficultyShort[itemSystem.price as unknown as string],
     };
-    data.score = data.actor.system.funds.score;
-    await od6sroll._onRollDialog(data);
+    data.score = (buyer!.system as OD6SCharacterSystem).funds.score;
+    await od6sroll._onRollDialog(data as IncomingRollData);
 }

--- a/src/module/actor/specialize.ts
+++ b/src/module/actor/specialize.ts
@@ -2,22 +2,53 @@ import OD6S from "../config/config-od6s";
 import {od6sutilities} from "../system/utilities";
 import {SpecializeDialog} from "./specialize-dialog";
 
+/**
+ * Shape of the specialization payload built by `_onSpecialize` and consumed
+ * by both the dialog template and `addSpecialization`. Mutated in place by
+ * dialog change handlers.
+ */
+export interface SpecializeData {
+    specname: string;
+    type: "specialization";
+    skill: string;
+    attribute: string;
+    description: string;
+    score: number;
+    cpcost: number;
+    originalcpcost: number;
+    actor: Actor;
+    freeadvance: boolean;
+    dice: number;
+    pips: number;
+    time?: string;
+}
+
+/** Sheet shape consumed here — bound at click time via `.bind(sheet)`. */
+interface SpecializeSheetLike {
+    actor: Actor;
+    render: () => unknown;
+}
+
 export class od6sspecialize {
 
-    activateListeners(html: any)
+    activateListeners(html: HTMLElement | JQuery)
     {
         // @ts-expect-error super reference in mixin-style class
         super.activateListeners(html);
     }
 
-    async _onSpecialize(event: Event) {
+    async _onSpecialize(this: SpecializeSheetLike, event: Event) {
         event.preventDefault();
         // Create the specialization item, tied to the correct attribute/skill
-        const skill = (this as any).actor.getEmbeddedDocument("Item",
-            (event.currentTarget as any).dataset.itemId, true);
-        const derivedScore = (+skill.system.score) + (+(this as any).actor.system.attributes[skill.system.attribute.toLowerCase()].score) + 1
-        const cpCost = Math.floor(Math.floor(derivedScore/OD6S.pipsPerDice)/2);
-        const newItemData: any = {
+        const target = event.currentTarget as HTMLElement;
+        const skill = this.actor.getEmbeddedDocument("Item",
+            target.dataset.itemId!, true) as
+            (Item & {system: {score: number; attribute: string; description: string}});
+        const attrs = (this.actor.system as OD6SCharacterSystem).attributes;
+        const derivedScore = (+skill.system.score)
+            + (+attrs[skill.system.attribute.toLowerCase()]!.score) + 1;
+        const cpCost = Math.floor(Math.floor(derivedScore / OD6S.pipsPerDice) / 2);
+        const newItemData: SpecializeData = {
             specname: "",
             type: "specialization",
             skill: skill.name,
@@ -26,20 +57,26 @@ export class od6sspecialize {
             score: derivedScore,
             cpcost: cpCost,
             originalcpcost: cpCost,
-            actor: (this as any).actor,
+            actor: this.actor,
             freeadvance: false,
             dice: od6sutilities.getDiceFromScore(derivedScore - 1).dice,
-            pips: od6sutilities.getDiceFromScore(derivedScore - 1).pips
-        }
+            pips: od6sutilities.getDiceFromScore(derivedScore - 1).pips,
+        };
 
         new SpecializeDialog(
             newItemData,
-            () => od6sspecialize.addSpecialization(this, newItemData, skill.id),
+            () => od6sspecialize.addSpecialization(this, newItemData, skill.id!),
         ).render({force: true});
 
     }
 
-    static async addSpecialization(actorSheet: any, itemData: any, skillId: string, _dice?: any, _pips?: any) {
+    static async addSpecialization(
+        actorSheet: SpecializeSheetLike,
+        itemData: SpecializeData,
+        skillId: string,
+        _dice?: unknown,
+        _pips?: unknown,
+    ) {
         // Can't have a blank name
         if (typeof(itemData.specname)==='undefined' || itemData.specname==="" ) {
             ui.notifications.error(game.i18n.localize("OD6S.ERR_SPECIALIZATION_NAME"));
@@ -48,26 +85,28 @@ export class od6sspecialize {
 
         // Can't spend what you don't have
         if (actorSheet.actor.type === "character") {
-            if ((+itemData.cpcost) > (+actorSheet.actor.system.characterpoints.value) &&
-                actorSheet.actor.system.sheetmode.value !== "freeedit") {
+            const charSystem = actorSheet.actor.system as OD6SCharacterSystem;
+            if ((+itemData.cpcost) > (+charSystem.characterpoints.value) &&
+                charSystem.sheetmode.value !== "freeedit") {
                 ui.notifications.warn(game.i18n.localize("OD6S.NOT_ENOUGH_CP_SPEC"));
                 return;
             }
         }
 
         // Create new specialization item, derived from original skill
-        let newItemData: any = foundry.utils.deepClone(actorSheet.actor.getEmbeddedDocument("Item",
-            skillId, true));
+        const baseSkill = foundry.utils.deepClone(actorSheet.actor.getEmbeddedDocument("Item",
+            skillId, true)) as { system: { base: number } };
         let base;
         if(actorSheet.actor.type === "npc") {
             // Get the score from the form
+            const itemActorAttrs = (itemData.actor.system as OD6SCharacterSystem).attributes;
             base = (+od6sutilities.getScoreFromDice(itemData.dice, itemData.pips)) -
-                itemData.actor.system.attributes[itemData.attribute].base;
+                itemActorAttrs[itemData.attribute]!.base;
         } else {
-            base = (+newItemData.system.base) + 1;
+            base = (+baseSkill.system.base) + 1;
         }
 
-        newItemData = {
+        const newItemData = {
             name: itemData.specname,
             type: itemData.type,
             system: {
@@ -75,20 +114,28 @@ export class od6sspecialize {
                 description: itemData.specname,
                 base: base,
                 time: itemData.time,
-                skill: itemData.skill
-            }
-        }
+                skill: itemData.skill,
+            },
+        };
 
         await actorSheet.actor.createEmbeddedDocuments('Item', [newItemData]);
 
         // Deduct character points
         if (actorSheet.actor.type === "character") {
-            if ((+itemData.cpcost) > 0 &&  actorSheet.actor.system.sheetmode.value !== "freeedit") {
-                const update: any = {};
-                update.id = actorSheet.actor.id;
-                update.system = {};
-                update.system.characterpoints = {};
-                update.system.characterpoints.value -= actorSheet.actor.system.characterpoints.value;
+            const charSystem = actorSheet.actor.system as OD6SCharacterSystem;
+            if ((+itemData.cpcost) > 0 && charSystem.sheetmode.value !== "freeedit") {
+                // The legacy expression here was `update.system.characterpoints.value -=
+                // actor.system.characterpoints.value`, which compounded an undefined
+                // LHS with a numeric RHS and persisted NaN. Charge the actual cpcost
+                // against current CP — the surrounding guard already ensures it fits.
+                const update: { id: string | null; system: { characterpoints: { value: number } } } = {
+                    id: actorSheet.actor.id,
+                    system: {
+                        characterpoints: {
+                            value: charSystem.characterpoints.value - (+itemData.cpcost),
+                        },
+                    },
+                };
                 await actorSheet.actor.update(update, {diff: true});
             }
         }

--- a/src/module/system/handlebars/vehicle.ts
+++ b/src/module/system/handlebars/vehicle.ts
@@ -4,69 +4,88 @@
 import OD6S from "../../config/config-od6s";
 import {od6sutilities} from "../utilities";
 
+/**
+ * Helper-input shape: a pilot/crew actor merged with its vehicle snapshot.
+ * Properties mirror runtime usage in these helpers.
+ */
+type VehicleHelperActor = Actor & {
+    system: OD6SVehicleSystem & OD6SCharacterSystem & Record<string, unknown>;
+    isCrewMember: () => boolean;
+};
+
+type VehicleWeaponWithStats = OD6SVehicleWeaponItem & {
+    system: { stats: { attribute: string; skill: string; specialization: string } };
+};
+
 export function registerVehicleHelpers() {
-    Handlebars.registerHelper('getPilotManeuverTotal', function (actor) {
+    Handlebars.registerHelper('getPilotManeuverTotal', function (actor: VehicleHelperActor) {
         let found = false;
         let score = actor.system.maneuverability.score;
         if (!found) {
-            const spec = actor.items.find((i: any) => i.type === "specialization" &&
+            const spec = actor.items.find((i: Item) => i.type === "specialization" &&
                 i.name === actor.system.specialization.value);
             if (typeof (spec) !== 'undefined') {
-                score = (+score) + (+spec.system.score) + (actor.system.attributes[actor.system.attribute.value].score)
+                const specSys = spec.system as OD6SSpecializationItemSystem;
+                score = (+score) + (+specSys.score) + (actor.system.attributes[actor.system.attribute.value]!.score)
                 found = true;
             }
         }
         if (!found) {
-            const skill = actor.items.find((i: any) => i.type === "skill" && i.name === actor.system.skill.value);
+            const skill = actor.items.find((i: Item) => i.type === "skill" && i.name === actor.system.skill.value);
             if (typeof (skill) !== 'undefined') {
-                score = (+score) + (+skill.system.score) + (actor.system.attributes[actor.system.attribute.value].score);
+                const skillSys = skill.system as OD6SSkillItemSystem;
+                score = (+score) + (+skillSys.score) + (actor.system.attributes[actor.system.attribute.value]!.score);
                 found = true;
             }
         }
         if (!found) {
-            score = (+score) + (actor.system.attributes[actor.system.attribute.value].score);
+            score = (+score) + (actor.system.attributes[actor.system.attribute.value]!.score);
         }
         return score;
     })
 
-    Handlebars.registerHelper('getPilotSensorsTotal', function (actor, sensor) {
+    Handlebars.registerHelper('getPilotSensorsTotal', function (actor: VehicleHelperActor, sensor: string) {
         let found = false;
-        let score = actor.system.sensors.types[sensor].score;
+        const sensorsTypes = (actor.system.sensors as { types: Record<string, { score: number }> }).types;
+        let score: number = sensorsTypes[sensor]!.score;
         if (!found) {
             const skillType = game.i18n.localize('OD6S.SENSORS');
             const skill =
-                actor.items.find((i: any) => i.type === "skill" && i.name === skillType);
+                actor.items.find((i: Item) => i.type === "skill" && i.name === skillType);
             if (typeof (skill) !== 'undefined') {
-                score = (+score) + (+skill.system.score) + (actor.system.attributes['mec'].score);
+                const skillSys = skill.system as OD6SSkillItemSystem;
+                score = (+score) + (+skillSys.score) + (actor.system.attributes['mec'].score);
                 found = true;
             }
         }
         if (!found) {
-            score = (+score) + (actor.system.attributes[actor.system.attribute.value].score);
+            score = (+score) + (actor.system.attributes[actor.system.attribute.value]!.score);
         }
         return score;
     })
 
-    Handlebars.registerHelper('getPilotWeaponTotal', function (actor, weapon) {
+    Handlebars.registerHelper('getPilotWeaponTotal', function (actor: VehicleHelperActor, weapon: VehicleWeaponWithStats) {
         let found = false;
-        let score = weapon.system.fire_control.score;
+        let score: number = weapon.system.fire_control.score;
         if (!found) {
-            const spec = actor.items.find((i: any) => i.type === "specialization" &&
+            const spec = actor.items.find((i: Item) => i.type === "specialization" &&
                 i.name === weapon.system.stats.specialization);
             if (typeof (spec) !== 'undefined') {
-                score = (+score) + (+spec.system.score) + (actor.system.attributes[weapon.system.stats.attribute].score)
+                const specSys = spec.system as OD6SSpecializationItemSystem;
+                score = (+score) + (+specSys.score) + (actor.system.attributes[weapon.system.stats.attribute]!.score)
                 found = true;
             }
         }
         if (!found) {
-            const skill = actor.items.find((i: any) => i.type === "skill" && i.name === weapon.system.stats.skill);
+            const skill = actor.items.find((i: Item) => i.type === "skill" && i.name === weapon.system.stats.skill);
             if (typeof (skill) !== 'undefined') {
-                score = (+score) + (+skill.system.score) + (actor.system.attributes[weapon.system.stats.attribute].score);
+                const skillSys = skill.system as OD6SSkillItemSystem;
+                score = (+score) + (+skillSys.score) + (actor.system.attributes[weapon.system.stats.attribute]!.score);
                 found = true;
             }
         }
         if (!found) {
-            score = (+score) + (actor.system.attributes[weapon.system.stats.attribute].score);
+            score = (+score) + (actor.system.attributes[weapon.system.stats.attribute]!.score);
         }
         const dice = od6sutilities.getDiceFromScore(score);
         return dice.dice + "D+" + dice.pips;
@@ -76,19 +95,21 @@ export function registerVehicleHelpers() {
         return game.settings.get('od6s', 'sensors');
     })
 
-    Handlebars.registerHelper('getSensorTotal', function (actor, sensorScore) {
+    Handlebars.registerHelper('getSensorTotal', function (actor: VehicleHelperActor, sensorScore: number) {
         return od6sutilities.getSensorTotal(actor, sensorScore);
     })
 
-    Handlebars.registerHelper('getVehicleActions', function (actor) {
+    Handlebars.registerHelper('getVehicleActions', function (actor: VehicleHelperActor) {
         // Return a list of available vehicle actions
         if (actor.type === 'character' || actor.type === 'npc') {
             if (typeof (actor.system.vehicle.name) != 'undefined') {
                 const actions = {...OD6S.vehicle_actions};
-                if (actor.system.vehicle.shields.value === 0) {
+                const shields = actor.system.vehicle.shields as { value: number } | undefined;
+                if (shields?.value === 0) {
                     delete actions['shields'];
                 }
-                if (!actor.system.vehicle.sensors.value || actor.system.vehicle.type === 'starship') {
+                const sensors = actor.system.vehicle.sensors as { value: boolean } | undefined;
+                if (!sensors?.value || actor.system.vehicle.type === 'starship') {
                     delete actions['sensors'];
                 }
                 return actions;
@@ -119,44 +140,56 @@ export function registerVehicleHelpers() {
         }
     })
 
-    Handlebars.registerHelper('sumManeuverability', function (actor, m, type) {
+    Handlebars.registerHelper('sumManeuverability', function (
+        actor: VehicleHelperActor,
+        m: {
+            specialization: { value: string };
+            skill: { value: string };
+            attribute: { value: string };
+            maneuverability: { score: number };
+        },
+        type: 'score' | 'skillScore' | 'skill',
+    ) {
         if (typeof (m) === 'undefined' || Object.keys(m).length === 0) return;
-        const data: any = {};
+        const data: { score: number; skillScore: number; skill: string } = {
+            score: 0, skillScore: 0, skill: '',
+        };
         const skillTypes = ["specialization", "skill", 'attribute']
-        data.score = 0;
-        data.skillScore = 0;
-        data.skill = ''
 
         // Look for a spec, then a skill, then finally attribute
         for (const s of skillTypes) {
             if (s === 'specialization' && typeof (m.specialization.value) !== "undefined" && m.specialization.value !== '') {
-                const spec = actor.items.find((spec: any) => spec.name === m.specialization.value && spec.type === 'specialization');
+                const spec = actor.items.find(
+                    (i: Item) => i.name === m.specialization.value && i.type === 'specialization');
                 if (spec) {
-                    data.score = m.maneuverability.score + spec.system.score + actor.system.attributes[spec.system.attribute].score;
-                    data.skillScore = spec.system.score + actor.system.attributes[spec.system.attribute].score;
+                    const specSys = spec.system as OD6SSpecializationItemSystem;
+                    data.score = m.maneuverability.score + specSys.score + actor.system.attributes[specSys.attribute]!.score;
+                    data.skillScore = specSys.score + actor.system.attributes[specSys.attribute]!.score;
                     data.skill = spec.name;
                     break;
                 }
             }
             if (s === 'skill' && typeof (m.skill.value) !== "undefined" && m.skill.value !== '') {
-                const skill = actor.items.find((skill: any) => skill.name === m.skill.value && skill.type === 'skill');
+                const skill = actor.items.find(
+                    (i: Item) => i.name === m.skill.value && i.type === 'skill');
                 if (skill) {
-                    data.score = m.maneuverability.score + skill.system.score + actor.system.attributes[skill.system.attribute].score;
-                    data.skillScore = skill.system.score + actor.system.attributes[skill.system.attribute].score;
+                    const skillSys = skill.system as OD6SSkillItemSystem;
+                    data.score = m.maneuverability.score + skillSys.score + actor.system.attributes[skillSys.attribute]!.score;
+                    data.skillScore = skillSys.score + actor.system.attributes[skillSys.attribute]!.score;
                     data.skill = skill.name;
                     break;
                 }
             }
             if (s === 'attribute') {
-                data.score = actor.system.attributes[m.attribute.value].score + m.maneuverability.score;
-                data.skillScore = actor.system.attributes[m.attribute.value].score;
-                data.skill = game.i18n.localize(actor.system.attributes[m.attribute.value].label);
+                data.score = actor.system.attributes[m.attribute.value]!.score + m.maneuverability.score;
+                data.skillScore = actor.system.attributes[m.attribute.value]!.score;
+                data.skill = game.i18n.localize(actor.system.attributes[m.attribute.value]!.label);
             }
         }
         return data[type];
     })
 
-    Handlebars.registerHelper('isCrewMember', function (actor) {
+    Handlebars.registerHelper('isCrewMember', function (actor: VehicleHelperActor) {
         return actor.isCrewMember();
     })
 
@@ -164,7 +197,7 @@ export function registerVehicleHelpers() {
         return OD6S.interstellarDriveName;
     })
 
-    Handlebars.registerHelper('getToughnessName', function (type) {
+    Handlebars.registerHelper('getToughnessName', function (type: string) {
         if (type === 'vehicle') return game.i18n.localize(OD6S.vehicleToughnessName);
         if (type === 'starship') return game.i18n.localize(OD6S.starshipToughnessName);
         return '';

--- a/types/od6s.d.ts
+++ b/types/od6s.d.ts
@@ -74,9 +74,15 @@ interface VehicleWeaponSnapshot {
     _id: string;
     id: string;
     name: string;
-    type: string;
+    /** Snapshots are produced from `vehicle-weapon` and `starship-weapon` items only. */
+    type: "vehicle-weapon" | "starship-weapon" | string;
     img?: string;
-    system: OD6SWeaponItemSystem;
+    /**
+     * Snapshots come from `item.toObject()` on vehicle-weapon / starship-weapon
+     * items, both backed by `OD6SVehicleWeaponsFields`-shaped systems — not the
+     * regular character-weapon `OD6SWeaponItemSystem`.
+     */
+    system: OD6SVehicleWeaponItemSystem | OD6SStarshipWeaponItemSystem;
     flags?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

Closes #149.

Follow-up to PR #146. Drops the trailing `sheet: any, event: any, *Id: any` parameters from `rolls`, `inventory-transfer`, `item-crud`, `advance-dialog`, `specialize`, and the vehicle Handlebars helpers. Each helper now takes a structural `*SheetLike` interface (matching the `templates`/`drops`/`sorting` pattern) which avoids the actor-sheet ↔ helpers import cycle. The matching delegate stubs on `actor-sheet.ts` are typed accordingly.

`AdvanceDialog` and `SpecializeDialog` payload shapes (`AdvanceData`, `AdvanceFormData`, `SpecializeData`) are now exported so callers can construct them without an `any` literal.

Two latent bugs surfaced once `any` was removed:

- `VehicleWeaponSnapshot.system` was typed as `OD6SWeaponItemSystem`, but snapshots are produced from `vehicle-weapon` / `starship-weapon` items via `item.toObject()`. Widened to the matching union so `rolls.ts` (which reads `.specialization.value` etc.) type-checks against the real shape.
- `specialize.ts` deducted CP via `update.system.characterpoints.value -= actor.system.characterpoints.value` against a starts-undefined LHS, persisting `NaN`. Charge the actual `cpcost` instead.

Lint warnings: **314 → 228** (~−27%). Typecheck and unit/domain tests green.

## Test plan

- [x] `pnpm run check` (lint + typecheck + unit + domain)
- [x] `pnpm run build`
- [ ] Smoke: open a character sheet, advance a skill, create a specialization (covers `advance-dialog` + `specialize` paths)
- [ ] Smoke: roll a vehicle weapon as a crewmember (covers `rollAvailableVehicleAction` against real `VehicleWeaponSnapshot` data)
- [ ] Smoke: purchase an item from a merchant container (covers `rollPurchase` + `_onPurchase`)