### PR TITLE
refactor(types): narrow wounds.ts any-casts and reorder dead-table read

### DIFF
--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -4,20 +4,22 @@ import {
     findWoundLevelByCore,
     computeNewDamageLevel,
     computeNewWoundLevel,
+    type DeadlinessRow,
 } from "./wounds-math";
-import {isCharacterActor, isVehicleActor} from "../../system/type-guards";
+import {isArmorItem, isCharacterActor, isVehicleActor} from "../../system/type-guards";
 import {debug} from "../../system/logger";
 
 export {findWoundLevelByCore, computeNewDamageLevel, computeNewWoundLevel};
 
+type ActorUpdate = Record<string, unknown> & {id?: string; _id?: string};
+
 export async function applyDamage(actor: Actor, damage: string): Promise<void> {
     if (!isVehicleActor(actor)) return;
-    const update: any = {};
-    update.id = actor.id;
-    update._id = actor.id;
-    update.system = {};
-    update.system.damage = {};
-    update.system.damage.value = calculateNewDamageLevel(actor, damage);
+    const update: ActorUpdate = {
+        id: actor.id,
+        _id: actor.id,
+        system: {damage: {value: calculateNewDamageLevel(actor, damage)}},
+    };
     await actor.update(update);
 }
 
@@ -31,55 +33,53 @@ export function calculateNewDamageLevel(actor: Actor, damage: string): string | 
 
 export async function applyWounds(actor: Actor, wound: string): Promise<void> {
     if (!isCharacterActor(actor)) return;
-    const update: any = {};
     const newValue = calculateNewWoundLevel(actor, wound);
-    update.id = actor.id;
-    update._id = actor.id;
-    const armorUpdates: any[] = [];
-    if (wound === 'OD6S.WOUNDS_STUNNED' && isCharacterActor(actor)) {
+    const update: ActorUpdate = {
+        id: actor.id,
+        _id: actor.id,
+    };
+    const armorUpdates: Array<Record<string, unknown> & {_id: string}> = [];
+    if (wound === 'OD6S.WOUNDS_STUNNED') {
         update[`system.stuns.current`] = 1;
         update[`system.stuns.rounds`] = 1;
         update[`system.stuns.value`] = actor.system.stuns.value + 1;
     }
 
     if (game.settings.get('od6s', 'weapon_armor_damage') && game.settings.get('od6s', 'auto_armor_damage')) {
-        if (actor.itemTypes.armor.length) {
-            actor.itemTypes.armor.forEach((value: any, _index: any, _array: any) => {
-                let armorDamage = 0;
-                const damaged = typeof value.system.damaged === "undefined" ? 0 : value.system.damaged;
+        for (const value of actor.itemTypes.armor) {
+            if (!isArmorItem(value)) continue;
+            const damaged = value.system.damaged ?? 0;
+            if (!value.system.equipped.value) continue;
 
-                if (value.system.equipped.value) {
-                    switch (wound) {
-                        case 'OD6S.WOUNDS_WOUNDED':
-                            if (damaged <= 1) armorDamage = 1;
-                            break;
-                        case 'OD6S.WOUNDS_SEVERELY_WOUNDED':
-                            if (damaged <= 1) armorDamage = 1;
-                            break;
-                        case 'OD6S.WOUNDS_INCAPACITATED':
-                            if (damaged <= 2) armorDamage = 2;
-                            break;
-                        case 'OD6S.WOUNDS_MORTALLY_WOUNDED':
-                            if (damaged <= 3) armorDamage = 3;
-                            break;
-                        case 'OD6S.WOUNDS_DEAD':
-                            if (damaged <= 4) armorDamage = 4;
-                            break;
-                        default:
-                            break;
-                    }
-                    if(armorDamage > 0) {
-                       const armorUpdate: any = {};
-                       armorUpdate._id = value._id;
-                       armorUpdate.system = {};
-                       armorUpdate.system.damaged = armorDamage;
-                       armorUpdates.push(armorUpdate);
-                    }
-                }
-            })
+            let armorDamage = 0;
+            switch (wound) {
+                case 'OD6S.WOUNDS_WOUNDED':
+                    if (damaged <= 1) armorDamage = 1;
+                    break;
+                case 'OD6S.WOUNDS_SEVERELY_WOUNDED':
+                    if (damaged <= 1) armorDamage = 1;
+                    break;
+                case 'OD6S.WOUNDS_INCAPACITATED':
+                    if (damaged <= 2) armorDamage = 2;
+                    break;
+                case 'OD6S.WOUNDS_MORTALLY_WOUNDED':
+                    if (damaged <= 3) armorDamage = 3;
+                    break;
+                case 'OD6S.WOUNDS_DEAD':
+                    if (damaged <= 4) armorDamage = 4;
+                    break;
+                default:
+                    break;
+            }
+            if (armorDamage > 0 && value._id) {
+                armorUpdates.push({
+                    _id: value._id,
+                    system: {damaged: armorDamage},
+                });
+            }
         }
     }
-    if(armorUpdates.length > 0) {
+    if (armorUpdates.length > 0) {
         await actor.updateEmbeddedDocuments('Item', armorUpdates);
     }
 
@@ -87,9 +87,9 @@ export async function applyWounds(actor: Actor, wound: string): Promise<void> {
     await actor.update(update);
 }
 
-export function calculateNewWoundLevel(actor: Actor, wound: string): unknown {
-    const deadlinessTable = OD6S.deadliness[OD6S.deadlinessLevel[actor.type]];
+export function calculateNewWoundLevel(actor: Actor, wound: string): string | number | undefined {
     if (!isCharacterActor(actor)) return undefined;
+    const deadlinessTable = OD6S.deadliness[OD6S.deadlinessLevel[actor.type]];
     const current = actor.system.wounds.value;
     const next = computeNewWoundLevel(current, wound, deadlinessTable, OD6S.stunDamageIncrement);
     debug('wounds', 'wound transition', {
@@ -98,74 +98,69 @@ export function calculateNewWoundLevel(actor: Actor, wound: string): unknown {
         currentCore: deadlinessTable[current]?.core,
         incoming: wound,
         next,
-        nextCore: deadlinessTable[next as string]?.core,
+        nextCore: next !== undefined ? deadlinessTable[String(next)]?.core : undefined,
         stunDamageIncrement: OD6S.stunDamageIncrement,
     });
     return next;
 }
 
 export async function triggerMortallyWoundedCheck(actor: Actor): Promise<void> {
+    if (!isCharacterActor(actor)) return;
     if (actor.getFlag('od6s', 'mortally_wounded') !== 'undefined') {
         const rollData = {
             name: game.i18n.localize('OD6S.RESIST_MORTALLY_WOUNDED'),
             actor: actor,
             score: actor.system.attributes.str.score,
             type: 'mortally_wounded',
-            difficulty: actor.getFlag('od6s','mortally_wounded'),
+            difficulty: actor.getFlag('od6s', 'mortally_wounded'),
             difficultyLevel: 'OD6S.DIFFICULTY_CUSTOM'
-        }
+        };
         await od6sroll._onRollDialog(rollData);
     }
 }
 
 export async function applyMortallyWoundedFailure(actor: Actor): Promise<void> {
-    if(game.settings.get('od6s','auto_status')) {
+    if (game.settings.get('od6s', 'auto_status')) {
         await actor.toggleStatusEffect('dead', {overlay: false, active: true});
     }
 
-    const object = OD6S.deadliness[OD6S.deadlinessLevel[actor.type]]
-    const dead = Object.keys(object).find(
-        key=> object[key].core === 'OD6S.WOUNDS_DEAD');
+    const table = OD6S.deadliness[OD6S.deadlinessLevel[actor.type]];
+    const dead = Object.keys(table).find((key) => table[key].core === 'OD6S.WOUNDS_DEAD');
     const update = {
         system: {
             wounds: {
                 value: dead
             }
         }
-    }
+    };
 
-    await actor.update(update)
-    await actor.unsetFlag('od6s','mortally_wounded');
+    await actor.update(update);
+    await actor.unsetFlag('od6s', 'mortally_wounded');
 }
 
 export async function applyIncapacitatedFailure(actor: Actor): Promise<void> {
     const roll = await new Roll("10d6").evaluate();
     const flavor = actor.name + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_01') +
         roll.total + game.i18n.localize('OD6S.CHAT_UNCONSCIOUS_02');
-    if (game.modules.get("dice-so-nice")?.active) game.dice3d.messageHookDisabled=true;
+    if (game.modules.get("dice-so-nice")?.active) game.dice3d.messageHookDisabled = true;
     await roll.toMessage({flavor: flavor});
-    if (game.modules.get("dice-so-nice")?.active) game.dice3d.messageHookDisabled=false;
+    if (game.modules.get("dice-so-nice")?.active) game.dice3d.messageHookDisabled = false;
 
     await actor.toggleStatusEffect('unconscious', {overlay: false, active: true});
 }
 
-export function findFirstWoundLevel(_actor: Actor, table: Record<string, { core: string; description?: string; penalty?: number }>, wound: string): string | undefined {
+export function findFirstWoundLevel(_actor: Actor, table: Record<string, DeadlinessRow>, wound: string): string | undefined {
     return findWoundLevelByCore(table, wound);
 }
 
 export function getWoundLevelFromBodyPoints(actor: Actor, bp?: number): string | undefined {
     if (!isCharacterActor(actor)) return;
-    let bodyPointsCurrent;
     const sys = actor.system;
-    if (typeof (bp) !== 'undefined') {
-        bodyPointsCurrent = bp;
-    } else {
-        bodyPointsCurrent = sys.wounds.body_points.current
-    }
+    const bodyPointsCurrent = typeof bp !== 'undefined' ? bp : sys.wounds.body_points.current;
 
     if (bodyPointsCurrent < 1) return 'OD6S.WOUNDS_DEAD';
-    const ratio = Math.ceil(bodyPointsCurrent / sys.wounds.body_points.max * 100)
-    let level;
+    const ratio = Math.ceil(bodyPointsCurrent / sys.wounds.body_points.max * 100);
+    let level: string | undefined;
     for (const key in OD6S.bodyPointLevels) {
         if (ratio < OD6S.bodyPointLevels[key]) {
             level = key;
@@ -173,19 +168,19 @@ export function getWoundLevelFromBodyPoints(actor: Actor, bp?: number): string |
             break;
         }
     }
-    if (typeof (level) === 'undefined') level = 'OD6S.WOUNDS_HEALTHY';
+    if (typeof level === 'undefined') level = 'OD6S.WOUNDS_HEALTHY';
     return level;
 }
 
 export async function setWoundLevelFromBodyPoints(actor: Actor, bp: number): Promise<void> {
-    const update: any = {};
+    const update: ActorUpdate = {
+        id: actor.id,
+        _id: actor.id,
+    };
     update[`system.wounds.body_points.current`] = bp;
-    update._id = actor.id;
-    update.id = actor.id;
     await actor.update(update);
-    update[`system.wounds.value`] =
-        Object.keys(Object.fromEntries(Object.entries(OD6S.deadliness[3]).filter(
-            ([_k, v]) => (v as { description?: string }).description === actor.getWoundLevelFromBodyPoints(),
-        )))[0];
+    update[`system.wounds.value`] = Object.entries(OD6S.deadliness[3]).find(
+        ([_k, v]) => v.description === actor.getWoundLevelFromBodyPoints(),
+    )?.[0];
     await actor.update(update);
 }

--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -106,20 +106,21 @@ export function calculateNewWoundLevel(actor: Actor, wound: string): string | nu
 
 export async function triggerMortallyWoundedCheck(actor: Actor): Promise<void> {
     if (!isCharacterActor(actor)) return;
-    if (actor.getFlag('od6s', 'mortally_wounded') !== 'undefined') {
-        const rollData = {
-            name: game.i18n.localize('OD6S.RESIST_MORTALLY_WOUNDED'),
-            actor: actor,
-            score: actor.system.attributes.str.score,
-            type: 'mortally_wounded',
-            difficulty: actor.getFlag('od6s', 'mortally_wounded'),
-            difficultyLevel: 'OD6S.DIFFICULTY_CUSTOM'
-        };
-        await od6sroll._onRollDialog(rollData);
-    }
+    const flag = actor.getFlag('od6s', 'mortally_wounded');
+    if (flag === undefined) return;
+    const rollData = {
+        name: game.i18n.localize('OD6S.RESIST_MORTALLY_WOUNDED'),
+        actor: actor,
+        score: actor.system.attributes.str.score,
+        type: 'mortally_wounded',
+        difficulty: flag,
+        difficultyLevel: 'OD6S.DIFFICULTY_CUSTOM'
+    };
+    await od6sroll._onRollDialog(rollData);
 }
 
 export async function applyMortallyWoundedFailure(actor: Actor): Promise<void> {
+    if (!isCharacterActor(actor)) return;
     if (game.settings.get('od6s', 'auto_status')) {
         await actor.toggleStatusEffect('dead', {overlay: false, active: true});
     }


### PR DESCRIPTION
## Summary
- Replace `update: any` / `armorUpdates: any[]` in `wounds.ts` with `Record<string, unknown>`-shaped helpers; narrow `actor.itemTypes.armor` via `isArmorItem`; reuse `DeadlinessRow` for `findFirstWoundLevel`.
- Reorder `calculateNewWoundLevel` so the deadliness-table read happens **after** the character-actor guard — previously it indexed `OD6S.deadliness[undefined]` for non-character actors before returning.
- Widen the declared return type to `string | number | undefined` to match `computeNewWoundLevel`'s real return; the previous `unknown` hid the union from callers.

Lint warnings: 221 → 213.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (327 pass)
- [x] `pnpm run test:domain` (382 pass)
- [x] `pnpm run lint` (213 warnings, well under the 720 CI gate)