### PR TITLE
refactor(item-sheet): extract per-domain helpers from item-sheet.ts

### DIFF
--- a/src/module/item/item-sheet-helpers/actor-types.ts
+++ b/src/module/item/item-sheet-helpers/actor-types.ts
@@ -1,0 +1,47 @@
+/**
+ * Sheet helpers for the actor-types whitelist on item-group items.
+ * Extracted from item-sheet.ts; behaviour preserved.
+ */
+
+import OD6S from "../../config/config-od6s";
+import {isItemGroupItem} from "../../system/type-guards";
+
+const {DialogV2} = foundry.applications.api;
+
+export async function addActorType(item: Item): Promise<void> {
+    if (!isItemGroupItem(item)) return;
+    const data = {
+        actorTypes: game.od6s.OD6SActor.TYPES.filter((i: string) => !item.system.actor_types.includes(i)),
+    };
+    const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/od6s/templates/item/item-add-actor-type.html", data);
+    const result = await DialogV2.input({
+        window: {title: game.i18n.localize("OD6S.ADD") + " " + game.i18n.localize("OD6S.ACTOR_TYPE")},
+        content,
+        ok: {label: game.i18n.localize("OD6S.ADD")},
+    });
+    if (result?.["actor-type"]) await addActorTypeAction(item, result["actor-type"]);
+}
+
+export async function addActorTypeAction(item: Item, type: string): Promise<void> {
+    if (!isItemGroupItem(item)) return;
+    const actorTypes = [...item.system.actor_types, type];
+    await item.update({id: item.id, system: {actor_types: actorTypes}});
+}
+
+export async function deleteActorType(item: Item, ev: Event): Promise<void> {
+    if (!isItemGroupItem(item)) return;
+    const target = ev.currentTarget as HTMLElement;
+    const type = target.dataset.type;
+    const actorTypes = item.system.actor_types.filter((i: string) => i !== type);
+    const items: OD6STemplateItemEntry[] = [];
+    for (const i of item.system.items as OD6STemplateItemEntry[]) {
+        for (const t of actorTypes) {
+            if (OD6S.allowedItemTypes[t].includes(i.type)) {
+                items.push(i);
+                break;
+            }
+        }
+    }
+    await item.update({id: item.id, system: {actor_types: actorTypes, items}});
+}

--- a/src/module/item/item-sheet-helpers/drop.ts
+++ b/src/module/item/item-sheet-helpers/drop.ts
@@ -47,8 +47,7 @@ export async function onDropItem(
 
         case "weapon":
             if (item.type === "specialization" && isWeaponItem(sheet.item)) {
-                sheet.item.system.stats.specialization = item.name;
-                await sheet.item.update(sheet.item.system, {diff: true});
+                await sheet.item.update({"system.stats.specialization": item.name}, {diff: true});
             }
     }
     return undefined;

--- a/src/module/item/item-sheet-helpers/drop.ts
+++ b/src/module/item/item-sheet-helpers/drop.ts
@@ -1,0 +1,55 @@
+/**
+ * Drag-drop handlers for the item sheet.
+ * Extracted from item-sheet.ts; behaviour preserved.
+ */
+
+import {isWeaponItem} from "../../system/type-guards";
+import {addTemplateItemAction} from "./template-items";
+
+/** Drop payload returned by TextEditor.getDragEventData — type/uuid plus arbitrary extras. */
+type DropData = Record<string, unknown> & {type?: string; uuid?: string};
+
+interface SheetLike {
+    item: Item;
+    render(force?: boolean, options?: object): unknown;
+}
+
+export async function onDrop(sheet: SheetLike, event: DragEvent): Promise<void> {
+    event.preventDefault();
+    let data: DropData;
+    try {
+        data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event) as DropData;
+    } catch {
+        return;
+    }
+
+    let item: Item | undefined;
+    if (data.type === "Item") {
+        item = await onDropItem(sheet, event, data);
+    }
+    if (!item) return;
+
+    await addTemplateItemAction(sheet, item.name, item.type);
+}
+
+export async function onDropItem(
+    sheet: SheetLike,
+    _event: DragEvent,
+    data: DropData,
+): Promise<Item | undefined> {
+    const item = await Item.implementation.fromDropData(data);
+
+    switch (sheet.item.type) {
+        case "item-group":
+        case "species-template":
+        case "character-template":
+            return item;
+
+        case "weapon":
+            if (item.type === "specialization" && isWeaponItem(sheet.item)) {
+                sheet.item.system.stats.specialization = item.name;
+                await sheet.item.update(sheet.item.system, {diff: true});
+            }
+    }
+    return undefined;
+}

--- a/src/module/item/item-sheet-helpers/edit-fields.ts
+++ b/src/module/item/item-sheet-helpers/edit-fields.ts
@@ -1,0 +1,121 @@
+/**
+ * Sheet helpers for the dice/pip numeric editors on item sheets
+ * (skill base, specialization base, weapon damage/stun/fire-control, armor pr/er).
+ * Extracted from item-sheet.ts; behaviour preserved.
+ */
+
+import {od6sutilities} from "../../system/utilities";
+
+interface SheetLike {
+    item: Item;
+    actor: Actor | null;
+    render(force?: boolean, options?: object): unknown;
+}
+
+function rerollScore(
+    inputId: string,
+    inputValue: string,
+    oldDice: {dice: number; pips: number},
+    diceKey: string,
+    pipsKey: string,
+): number | undefined {
+    if (inputId === diceKey) return od6sutilities.getScoreFromDice(Number(inputValue), oldDice.pips);
+    if (inputId === pipsKey) return od6sutilities.getScoreFromDice(oldDice.dice, Number(inputValue));
+    return undefined;
+}
+
+export async function editSkill(sheet: SheetLike, event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const input = event.target as HTMLInputElement;
+    const itemId = target.dataset.itemId;
+    const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.base ?? 0));
+    const newScore = rerollScore(input.id, input.value, oldDice, "dice", "pips");
+    if (sheet.actor != null) {
+        await sheet.actor.updateEmbeddedDocuments("Item", [{id: itemId, _id: itemId, "system.base": newScore}]);
+        await sheet.item.sheet.render(false, {log: true});
+    } else {
+        await sheet.item.update({id: sheet.item.id, _id: sheet.item.id, "system.base": newScore});
+    }
+}
+
+export async function editSpecialization(sheet: SheetLike, event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const input = event.target as HTMLInputElement;
+    const itemId = target.dataset.itemId;
+    const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+    const newScore = rerollScore(input.id, input.value, oldDice, "system.die.dice", "system.die.pips");
+    if (sheet.actor != null) {
+        await sheet.actor.updateEmbeddedDocuments("Item", [{id: itemId, _id: itemId, "system.base": newScore}]);
+        await sheet.item.sheet.render(false, {log: true});
+    } else {
+        await sheet.item.update({id: itemId, "system.base": newScore}, {diff: true});
+    }
+}
+
+async function editScoreField(
+    sheet: SheetLike,
+    event: Event,
+    embeddedSystemPatch: (newDamage: number | undefined) => Record<string, unknown>,
+    standaloneFieldPath: string,
+): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const input = event.target as HTMLInputElement;
+    const itemId = target.dataset.itemId;
+    if (target.dataset.score === "") target.dataset.score = "0";
+    const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+    const newDamage = rerollScore(input.id, input.value, oldDice, "dice", "pips");
+
+    if (sheet.actor != null) {
+        await sheet.actor.updateEmbeddedDocuments("Item", [{_id: itemId, system: embeddedSystemPatch(newDamage)}]);
+    } else {
+        await sheet.item.update({[standaloneFieldPath]: newDamage}, {diff: true});
+    }
+}
+
+export function editWeaponDamage(sheet: SheetLike, event: Event): Promise<void> {
+    return editScoreField(sheet, event, (n) => ({damage: {score: n}}), "system.damage.score");
+}
+
+export function editWeaponStunDamage(sheet: SheetLike, event: Event): Promise<void> {
+    return editScoreField(sheet, event, (n) => ({stun: {score: n}}), "system.stun.score");
+}
+
+export async function editWeaponFireControl(sheet: SheetLike, event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const input = event.target as HTMLInputElement;
+    const itemId = target.dataset.itemId;
+    if (target.dataset.score === "") target.dataset.score = "0";
+    const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
+    const newScore = rerollScore(input.id, input.value, oldDice, "dice", "pips");
+
+    if (sheet.actor != null) {
+        await sheet.actor.updateEmbeddedDocuments("Item",
+            [{id: itemId, _id: itemId, "system.fire_control.score": newScore}]);
+    } else {
+        await sheet.item.update({id: sheet.item.id, "system.fire_control.score": newScore}, {diff: true});
+    }
+}
+
+export async function editArmor(sheet: SheetLike, event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const input = event.target as HTMLInputElement;
+    const itemId = target.dataset.itemId;
+    const system: {pr?: number; er?: number} = {};
+    const oldPrDice = od6sutilities.getDiceFromScore(Number(target.dataset.pr ?? 0));
+    const oldErDice = od6sutilities.getDiceFromScore(Number(target.dataset.er ?? 0));
+    if (input.id === "prDice") {
+        system.pr = od6sutilities.getScoreFromDice(Number(input.value), oldPrDice.pips);
+    } else if (input.id === "prPips") {
+        system.pr = od6sutilities.getScoreFromDice(oldPrDice.dice, Number(input.value));
+    } else if (input.id === "erDice") {
+        system.er = od6sutilities.getScoreFromDice(Number(input.value), oldErDice.pips);
+    } else if (input.id === "erPips") {
+        system.er = od6sutilities.getScoreFromDice(oldErDice.dice, Number(input.value));
+    }
+    const update = {id: itemId, _id: itemId, system};
+    if (sheet.actor != null) {
+        await sheet.actor.updateEmbeddedDocuments("Item", [update]);
+    } else {
+        await sheet.item.update(update);
+    }
+}

--- a/src/module/item/item-sheet-helpers/effects.ts
+++ b/src/module/item/item-sheet-helpers/effects.ts
@@ -1,0 +1,24 @@
+/**
+ * Sheet helpers for embedded ActiveEffect documents on items.
+ * Extracted from item-sheet.ts; behaviour preserved.
+ */
+
+export async function addEffect(item: Item): Promise<void> {
+    const name = game.i18n.localize("OD6S.NEW_ACTIVE_EFFECT");
+    const effect = await item.createEmbeddedDocuments("ActiveEffect", [{label: name}]);
+    new foundry.applications.sheets.ActiveEffectConfig({document: effect[0]}).render({force: true});
+}
+
+export async function editEffect(item: Item, ev: Event): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    const effectId = target.dataset.effectId;
+    if (!effectId) return;
+    const effect = item.getEmbeddedDocument("ActiveEffect", effectId);
+    if (!effect) return;
+    new foundry.applications.sheets.ActiveEffectConfig({document: effect}).render({force: true});
+}
+
+export async function deleteEffect(item: Item, ev: Event): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    await item.deleteEmbeddedDocuments("ActiveEffect", [target.dataset.effectId!]);
+}

--- a/src/module/item/item-sheet-helpers/labels.ts
+++ b/src/module/item/item-sheet-helpers/labels.ts
@@ -1,0 +1,44 @@
+/**
+ * Sheet helpers for the freeform `system.labels` map on items.
+ * Extracted from item-sheet.ts; behaviour preserved.
+ */
+
+const {DialogV2} = foundry.applications.api;
+
+export async function addLabel(item: Item): Promise<void> {
+    const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/od6s/templates/item/item-add-label.html",
+        {id: item.id});
+    const result = await DialogV2.input({
+        window: {title: game.i18n.localize("OD6S.ADD") + " " + game.i18n.localize("OD6S.LABEL") + "!"},
+        content,
+        ok: {label: game.i18n.localize("OD6S.ADD")},
+    });
+    if (result?.key) await addLabelAction(item, result.key, result.value);
+}
+
+export async function addLabelAction(item: Item, key: string, value: string): Promise<void> {
+    if (item.system.labels[key]) {
+        ui.notifications.warn(game.i18n.localize("OD6S.LABEL_ALREADY_EXISTS"));
+        return;
+    }
+    await item.update({id: item.id, [`system.labels.${key}`]: value});
+}
+
+export async function editLabel(item: Item, ev: Event): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    const input = ev.target as HTMLInputElement;
+    await item.update({
+        id: item.id,
+        [`system.labels.${target.dataset.key}`]: input.value,
+    });
+}
+
+export async function deleteLabel(item: Item, ev: Event): Promise<void> {
+    const target = ev.currentTarget as HTMLElement;
+    await item.update({
+        id: item.id,
+        system: item.system,
+        [`system.labels.-=${target.dataset.key}`]: null,
+    });
+}

--- a/src/module/item/item-sheet-helpers/template-items.ts
+++ b/src/module/item/item-sheet-helpers/template-items.ts
@@ -27,7 +27,7 @@ async function getGameItemsByType(
 export async function addTemplateItem(sheet: SheetLike, event: Event): Promise<void> {
     const target = event.currentTarget as HTMLElement;
     const type = target.dataset.type!;
-    const templateItems = await Promise.all(await getGameItemsByType(type));
+    const templateItems = await getGameItemsByType(type);
     const content = await foundry.applications.handlebars.renderTemplate(
         "systems/od6s/templates/item/item-template-add.html",
         {templateItems});

--- a/src/module/item/item-sheet-helpers/template-items.ts
+++ b/src/module/item/item-sheet-helpers/template-items.ts
@@ -1,0 +1,154 @@
+/**
+ * Sheet helpers for the nested `system.items` array on template-shaped items
+ * (item-group, character-template, species-template) and the attribute
+ * editor on template items.
+ * Extracted from item-sheet.ts; behaviour preserved.
+ */
+
+import OD6S from "../../config/config-od6s";
+import {od6sutilities} from "../../system/utilities";
+import {isItemGroupItem, isTemplateLikeItem} from "../../system/type-guards";
+
+const {DialogV2} = foundry.applications.api;
+
+interface SheetLike {
+    item: Item;
+    render(force?: boolean, options?: object): unknown;
+}
+
+async function getGameItemsByType(
+    type: string,
+): Promise<Array<{_id: string; name: string; type: string; description?: string}>> {
+    const compendia = await od6sutilities.getItemsFromCompendiumByType(type as OD6SItemType);
+    const world = await od6sutilities.getItemsFromWorldByType(type as OD6SItemType);
+    return [...compendia, ...world].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function addTemplateItem(sheet: SheetLike, event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const type = target.dataset.type!;
+    const templateItems = await Promise.all(await getGameItemsByType(type));
+    const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/od6s/templates/item/item-template-add.html",
+        {templateItems});
+    const label = game.i18n.localize(game.system.template.Item[type].label);
+    const result = await DialogV2.input({
+        window: {title: game.i18n.localize("OD6S.ADD") + " " + label + "!"},
+        content,
+        ok: {label: game.i18n.localize("OD6S.ADD")},
+    });
+    if (result?.itemname) await addTemplateItemAction(sheet, result.itemname, type);
+}
+
+export async function addTemplateItemAction(sheet: SheetLike, name: string, type: string): Promise<void> {
+    const item = sheet.item;
+    if (isItemGroupItem(item)) {
+        let allowed = false;
+        for (const [key, items] of Object.entries(OD6S.allowedItemTypes)) {
+            if (item.system.actor_types.includes(key)) {
+                for (const i of items as string[]) {
+                    if (OD6S.templateItemTypes["item-group"].includes(i)) {
+                        allowed = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!allowed) return;
+    } else if (!OD6S.templateItemTypes[item.type].includes(type)) {
+        return;
+    }
+
+    if (!isTemplateLikeItem(item)) return;
+    const sourceItem = await od6sutilities.getItemByName(name);
+    const description = sourceItem?.system.description ?? "";
+    const newItem: OD6STemplateItemEntry = {name, type, description};
+    (item.system.items as OD6STemplateItemEntry[]).push(newItem);
+    await item.update({id: item.id, system: item.system}, {diff: true});
+    await sheet.render();
+}
+
+export async function editTemplateItem(sheet: SheetLike, event: Event): Promise<void> {
+    if (!isTemplateLikeItem(sheet.item)) return;
+    const target = event.currentTarget as HTMLElement;
+    const items = sheet.item.system.items as OD6STemplateItemEntry[];
+    const item = items.find((i) => i.name === target.dataset.name);
+    const itemData = {name: target.dataset.name, type: target.dataset.type, description: item?.description};
+    const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/od6s/templates/item/item-template-item-edit.html",
+        itemData);
+    const label = game.i18n.localize(game.system.template.Item[target.dataset.type!].label);
+    const result = await DialogV2.input({
+        window: {title: game.i18n.localize("OD6S.EDIT") + " " + label + "!"},
+        content,
+        ok: {label: game.i18n.localize("OD6S.EDIT")},
+    });
+    if (typeof result?.itemdesc === "string") {
+        await editTemplateItemAction(sheet, result.itemdesc, event);
+    }
+}
+
+export async function editTemplateItemAction(sheet: SheetLike, desc: string, event: Event): Promise<void> {
+    if (!isTemplateLikeItem(sheet.item)) return;
+    const target = event.currentTarget as HTMLElement;
+    const data = target.dataset;
+    const newItem: OD6STemplateItemEntry = {name: data.name!, type: data.type!, description: desc};
+    const items = sheet.item.system.items as OD6STemplateItemEntry[];
+    const itemIndex = items.findIndex((i) => i.name === data.name && i.type === data.type);
+    if (itemIndex < 0) return;
+    items[itemIndex] = newItem;
+    await sheet.item.update({id: sheet.item.id, system: sheet.item.system}, {diff: false});
+    await sheet.render();
+}
+
+export async function deleteTemplateItem(sheet: SheetLike, event: Event): Promise<void> {
+    if (!isTemplateLikeItem(sheet.item)) return;
+    const item = sheet.item;
+    const result = await DialogV2.confirm({
+        window: {title: game.i18n.localize("OD6S.DELETE")},
+        content: `<p>${game.i18n.localize("OD6S.DELETE_CONFIRM")}</p>`,
+    });
+    if (!result) return;
+
+    const target = event.currentTarget as HTMLElement;
+    const items = item.system.items as OD6STemplateItemEntry[];
+    const itemIndex = items.findIndex(
+        (i) => i.name === target.dataset.name && i.type === target.dataset.type);
+    if (itemIndex < 0) return;
+    items.splice(itemIndex, 1);
+    await item.update({id: item.id, system: item.system}, {diff: true});
+    await sheet.render();
+}
+
+export async function editTemplateAttribute(sheet: SheetLike, event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const score = target.dataset.score;
+    const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/od6s/templates/item/item-attribute-edit.html",
+        {score});
+    const result = await DialogV2.input({
+        window: {title: game.i18n.localize("OD6S.EDIT") + " " + target.dataset.label + "!"},
+        content,
+        ok: {label: game.i18n.localize("OD6S.EDIT_ATTRIBUTE")},
+    });
+    if (result) await editAttributeAction(sheet, result.dice, result.pips, event);
+}
+
+export async function editAttributeAction(
+    sheet: SheetLike,
+    dice: string,
+    pips: string,
+    event: Event,
+): Promise<void> {
+    const newScore = od6sutilities.getScoreFromDice(Number(dice), Number(pips));
+    const target = event.currentTarget as HTMLElement;
+    const attrname = target.dataset.attrname!;
+    const attributes = (sheet.item.system as {attributes: Record<string, unknown>}).attributes;
+    switch (target.dataset.sub) {
+        case "base": attributes[attrname] = newScore; break;
+        case "min": (attributes[attrname] as {min: number}).min = newScore; break;
+        case "max": (attributes[attrname] as {max: number}).max = newScore; break;
+    }
+    await sheet.item.update({id: sheet.item.id, system: sheet.item.system}, {diff: true});
+    await sheet.render();
+}

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -1,21 +1,23 @@
- 
-import {od6sutilities} from "../system/utilities";
+
 import {bindPrimaryTabs} from "../system/utilities/bind-tabs";
-import OD6S from "../config/config-od6s";
-import {isItemGroupItem, isTemplateLikeItem, isWeaponItem} from "../system/type-guards";
+import * as labels from "./item-sheet-helpers/labels";
+import * as effects from "./item-sheet-helpers/effects";
+import * as actorTypes from "./item-sheet-helpers/actor-types";
+import * as editFields from "./item-sheet-helpers/edit-fields";
+import * as templateItems from "./item-sheet-helpers/template-items";
+import * as drop from "./item-sheet-helpers/drop";
 
-
-const {HandlebarsApplicationMixin, DialogV2} = foundry.applications.api;
+const {HandlebarsApplicationMixin} = foundry.applications.api;
 const ItemSheetV2 = foundry.applications.sheets.ItemSheetV2;
-
-/** Drop payload returned by TextEditor.getDragEventData — type/uuid plus arbitrary extras. */
-type DropData = Record<string, unknown> & { type?: string; uuid?: string };
 
 /**
  * OD6S item sheet — ApplicationV2 with HandlebarsApplicationMixin.
  *
  * Template path is dynamic per item.type, so we override _renderHTML to
  * load the right template instead of declaring a multi-PARTS entry per type.
+ *
+ * Per-domain handlers live in `item-sheet-helpers/`; this class wires them
+ * to DOM events and exposes them as methods for legacy callers.
  */
 export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 
@@ -65,443 +67,32 @@ export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
         await super._onRender(context, options);
 
         const root = this.element as HTMLElement;
-
         bindPrimaryTabs(this, root);
 
         if (!this.isEditable) return;
         const $ = (sel: string): NodeListOf<HTMLElement> => root.querySelectorAll(sel);
 
-        $(".editskill").forEach((el) => el.addEventListener("change", this._editSkill.bind(this)));
-        $(".editspecialization").forEach((el) => el.addEventListener("change", this._editSpecialization.bind(this)));
-        $(".editweapondamage").forEach((el) => el.addEventListener("change", this._editWeaponDamage.bind(this)));
-        $(".editweaponstun").forEach((el) => el.addEventListener("change", this._editWeaponStunDamage.bind(this)));
-        $(".editweaponfirecontrol").forEach((el) => el.addEventListener("change", this._editWeaponFireControl.bind(this)));
-        $(".editarmor").forEach((el) => el.addEventListener("change", this._editArmor.bind(this)));
-        $(".edittemplateattribute").forEach((el) => el.addEventListener("click", this._editTemplateAttribute.bind(this)));
-        $(".template-item-add").forEach((el) => el.addEventListener("click", this._addTemplateItem.bind(this)));
-        $(".template-item-edit").forEach((el) => el.addEventListener("click", this._editTemplateItem.bind(this)));
-        $(".template-item-delete").forEach((el) => el.addEventListener("click", this._deleteTemplateItem.bind(this)));
-        $(".effect-add").forEach((el) => el.addEventListener("click", this._addEffect.bind(this)));
-        $(".effect-edit").forEach((el) => el.addEventListener("click", this._editEffect.bind(this)));
-        $(".effect-delete").forEach((el) => el.addEventListener("click", this._deleteEffect.bind(this)));
-        $(".label-add").forEach((el) => el.addEventListener("click", this._addLabel.bind(this)));
-        $(".label-edit").forEach((el) => el.addEventListener("change", this._editLabel.bind(this)));
-        $(".label-delete").forEach((el) => el.addEventListener("click", this._deleteLabel.bind(this)));
-        $(".add-actor-type").forEach((el) => el.addEventListener("click", this._addActorType.bind(this)));
-        $(".delete-actor-type").forEach((el) => el.addEventListener("click", this._deleteActorType.bind(this)));
+        $(".editskill").forEach((el) => el.addEventListener("change", (e) => editFields.editSkill(this, e)));
+        $(".editspecialization").forEach((el) => el.addEventListener("change", (e) => editFields.editSpecialization(this, e)));
+        $(".editweapondamage").forEach((el) => el.addEventListener("change", (e) => editFields.editWeaponDamage(this, e)));
+        $(".editweaponstun").forEach((el) => el.addEventListener("change", (e) => editFields.editWeaponStunDamage(this, e)));
+        $(".editweaponfirecontrol").forEach((el) => el.addEventListener("change", (e) => editFields.editWeaponFireControl(this, e)));
+        $(".editarmor").forEach((el) => el.addEventListener("change", (e) => editFields.editArmor(this, e)));
+        $(".edittemplateattribute").forEach((el) => el.addEventListener("click", (e) => templateItems.editTemplateAttribute(this, e)));
+        $(".template-item-add").forEach((el) => el.addEventListener("click", (e) => templateItems.addTemplateItem(this, e)));
+        $(".template-item-edit").forEach((el) => el.addEventListener("click", (e) => templateItems.editTemplateItem(this, e)));
+        $(".template-item-delete").forEach((el) => el.addEventListener("click", (e) => templateItems.deleteTemplateItem(this, e)));
+        $(".effect-add").forEach((el) => el.addEventListener("click", () => effects.addEffect(this.document)));
+        $(".effect-edit").forEach((el) => el.addEventListener("click", (e) => effects.editEffect(this.document, e)));
+        $(".effect-delete").forEach((el) => el.addEventListener("click", (e) => effects.deleteEffect(this.document, e)));
+        $(".label-add").forEach((el) => el.addEventListener("click", () => labels.addLabel(this.item)));
+        $(".label-edit").forEach((el) => el.addEventListener("change", (e) => labels.editLabel(this.item, e)));
+        $(".label-delete").forEach((el) => el.addEventListener("click", (e) => labels.deleteLabel(this.item, e)));
+        $(".add-actor-type").forEach((el) => el.addEventListener("click", () => actorTypes.addActorType(this.item)));
+        $(".delete-actor-type").forEach((el) => el.addEventListener("click", (e) => actorTypes.deleteActorType(this.item, e)));
     }
-
-    /* -------------------------------------------- */
-    /*  Drag & Drop                                 */
-    /* -------------------------------------------- */
 
     async _onDrop(event: DragEvent): Promise<void> {
-        event.preventDefault();
-        let data: DropData;
-        try {
-            data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event) as DropData;
-        } catch {
-            return;
-        }
-
-        let item: Item | undefined;
-        if (data.type === "Item") {
-            item = await this._onDropItem(event, data);
-        }
-        if (!item) return;
-
-        await this._addTemplateItemAction(item.name, item.type, this);
-    }
-
-    async _onDropItem(_event: DragEvent, data: DropData): Promise<Item | undefined> {
-        const item = await Item.implementation.fromDropData(data);
-
-        switch (this.item.type) {
-            case "item-group":
-            case "species-template":
-            case "character-template":
-                return item;
-
-            case "weapon":
-                if (item.type === "specialization" && isWeaponItem(this.item)) {
-                    this.item.system.stats.specialization = item.name;
-                    await this.item.update(this.item.system, {diff: true});
-                }
-        }
-        return undefined;
-    }
-
-    /* -------------------------------------------- */
-    /*  Action handlers                             */
-    /* -------------------------------------------- */
-
-    async _addActorType(): Promise<void> {
-        if (!isItemGroupItem(this.item)) return;
-        const item = this.item;
-        const data = {
-            actorTypes: game.od6s.OD6SActor.TYPES.filter((i: string) => !item.system.actor_types.includes(i)),
-        };
-        const content = await foundry.applications.handlebars.renderTemplate(
-            "systems/od6s/templates/item/item-add-actor-type.html", data);
-        const result = await DialogV2.input({
-            window: {title: game.i18n.localize("OD6S.ADD") + " " + game.i18n.localize("OD6S.ACTOR_TYPE")},
-            content,
-            ok: {label: game.i18n.localize("OD6S.ADD")},
-        });
-        if (result?.["actor-type"]) await this._addActorTypeAction(result["actor-type"]);
-    }
-
-    async _addActorTypeAction(type: string): Promise<void> {
-        if (!isItemGroupItem(this.item)) return;
-        const item = this.item;
-        const actorTypes = [...item.system.actor_types, type];
-        await item.update({id: item.id, system: {actor_types: actorTypes}});
-    }
-
-    async _deleteActorType(ev: Event): Promise<void> {
-        if (!isItemGroupItem(this.item)) return;
-        const item = this.item;
-        const target = ev.currentTarget as HTMLElement;
-        const type = target.dataset.type;
-        const actorTypes = item.system.actor_types.filter((i: string) => i !== type);
-        const items: OD6STemplateItemEntry[] = [];
-        for (const i of item.system.items as OD6STemplateItemEntry[]) {
-            for (const t of actorTypes) {
-                if (OD6S.allowedItemTypes[t].includes(i.type)) {
-                    items.push(i);
-                    break;
-                }
-            }
-        }
-        await this.item.update({id: item.id, system: {actor_types: actorTypes, items}});
-    }
-
-    async _addLabel(): Promise<void> {
-        const content = await foundry.applications.handlebars.renderTemplate(
-            "systems/od6s/templates/item/item-add-label.html",
-            {id: this.item.id});
-        const result = await DialogV2.input({
-            window: {title: game.i18n.localize("OD6S.ADD") + " " + game.i18n.localize("OD6S.LABEL") + "!"},
-            content,
-            ok: {label: game.i18n.localize("OD6S.ADD")},
-        });
-        if (result?.key) await this._addLabelAction(result.key, result.value);
-    }
-
-    async _addLabelAction(key: string, value: string): Promise<void> {
-        if (this.item.system.labels[key]) {
-            ui.notifications.warn(game.i18n.localize("OD6S.LABEL_ALREADY_EXISTS"));
-            return;
-        }
-        await this.item.update({id: this.item.id, [`system.labels.${key}`]: value});
-    }
-
-    async _editLabel(ev: Event): Promise<void> {
-        const target = ev.currentTarget as HTMLElement;
-        const input = ev.target as HTMLInputElement;
-        await this.item.update({
-            id: this.item.id,
-            [`system.labels.${target.dataset.key}`]: input.value,
-        });
-    }
-
-    async _deleteLabel(ev: Event): Promise<void> {
-        const target = ev.currentTarget as HTMLElement;
-        await this.item.update({
-            id: this.item.id,
-            system: this.item.system,
-            [`system.labels.-=${target.dataset.key}`]: null,
-        });
-    }
-
-    async _addEffect(): Promise<void> {
-        const name = game.i18n.localize("OD6S.NEW_ACTIVE_EFFECT");
-        const effect = await this.document.createEmbeddedDocuments("ActiveEffect", [{label: name}]);
-        new foundry.applications.sheets.ActiveEffectConfig({document: effect[0]}).render({force: true});
-    }
-
-    async _editEffect(ev: Event): Promise<void> {
-        const target = ev.currentTarget as HTMLElement;
-        const effectId = target.dataset.effectId;
-        if (!effectId) return;
-        const effect = this.document.getEmbeddedDocument("ActiveEffect", effectId);
-        if (!effect) return;
-        new foundry.applications.sheets.ActiveEffectConfig({document: effect}).render({force: true});
-    }
-
-    async _deleteEffect(ev: Event): Promise<void> {
-        const target = ev.currentTarget as HTMLElement;
-        await this.document.deleteEmbeddedDocuments("ActiveEffect", [target.dataset.effectId!]);
-    }
-
-    /* -------------------------------------------- */
-    /*  Numeric edit handlers (skill/spec/damage…)   */
-    /* -------------------------------------------- */
-
-    async _editSkill(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const input = event.target as HTMLInputElement;
-        const itemId = target.dataset.itemId;
-        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.base ?? 0));
-        let newScore: number | undefined;
-        if (input.id === "dice") {
-            newScore = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
-        } else if (input.id === "pips") {
-            newScore = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
-        }
-        if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [{id: itemId, _id: itemId, "system.base": newScore}]);
-            await this.item.sheet.render(false, {log: true});
-        } else {
-            await this.item.update({id: this.item.id, _id: this.item.id, "system.base": newScore});
-        }
-    }
-
-    async _editSpecialization(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const input = event.target as HTMLInputElement;
-        const itemId = target.dataset.itemId;
-        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
-        let newScore: number | undefined;
-        if (input.id === "system.die.dice") {
-            newScore = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
-        } else if (input.id === "system.die.pips") {
-            newScore = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
-        }
-        if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [{id: itemId, _id: itemId, "system.base": newScore}]);
-            await this.item.sheet.render(false, {log: true});
-        } else {
-            await this.item.update({id: itemId, "system.base": newScore}, {diff: true});
-        }
-    }
-
-    async _editWeaponDamage(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const input = event.target as HTMLInputElement;
-        const itemId = target.dataset.itemId;
-        if (target.dataset.score === "") target.dataset.score = "0";
-        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
-        let newDamage: number | undefined;
-        if (input.id === "dice") newDamage = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
-        else if (input.id === "pips") newDamage = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
-
-        if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [{_id: itemId, system: {damage: {score: newDamage}}}]);
-        } else {
-            await this.item.update({"system.damage.score": newDamage}, {diff: true});
-        }
-    }
-
-    async _editWeaponStunDamage(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const input = event.target as HTMLInputElement;
-        const itemId = target.dataset.itemId;
-        if (target.dataset.score === "") target.dataset.score = "0";
-        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
-        let newDamage: number | undefined;
-        if (input.id === "dice") newDamage = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
-        else if (input.id === "pips") newDamage = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
-
-        if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [{_id: itemId, system: {stun: {score: newDamage}}}]);
-        } else {
-            await this.item.update({"system.stun.score": newDamage}, {diff: true});
-        }
-    }
-
-    async _editWeaponFireControl(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const input = event.target as HTMLInputElement;
-        const itemId = target.dataset.itemId;
-        if (target.dataset.score === "") target.dataset.score = "0";
-        const oldDice = od6sutilities.getDiceFromScore(Number(target.dataset.score ?? 0));
-        let newScore: number | undefined;
-        if (input.id === "dice") newScore = od6sutilities.getScoreFromDice(Number(input.value), oldDice.pips);
-        else if (input.id === "pips") newScore = od6sutilities.getScoreFromDice(oldDice.dice, Number(input.value));
-
-        if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item",
-                [{id: itemId, _id: itemId, "system.fire_control.score": newScore}]);
-        } else {
-            await this.item.update({id: this.item.id, "system.fire_control.score": newScore}, {diff: true});
-        }
-    }
-
-    async _editArmor(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const input = event.target as HTMLInputElement;
-        const itemId = target.dataset.itemId;
-        const system: { pr?: number; er?: number } = {};
-        const oldPrDice = od6sutilities.getDiceFromScore(Number(target.dataset.pr ?? 0));
-        const oldErDice = od6sutilities.getDiceFromScore(Number(target.dataset.er ?? 0));
-        if (input.id === "prDice") {
-            system.pr = od6sutilities.getScoreFromDice(Number(input.value), oldPrDice.pips);
-        } else if (input.id === "prPips") {
-            system.pr = od6sutilities.getScoreFromDice(oldPrDice.dice, Number(input.value));
-        } else if (input.id === "erDice") {
-            system.er = od6sutilities.getScoreFromDice(Number(input.value), oldErDice.pips);
-        } else if (input.id === "erPips") {
-            system.er = od6sutilities.getScoreFromDice(oldErDice.dice, Number(input.value));
-        }
-        const update = {id: itemId, _id: itemId, system};
-        if (this.actor != null) {
-            await this.actor.updateEmbeddedDocuments("Item", [update]);
-        } else {
-            await this.item.update(update);
-        }
-    }
-
-    /* -------------------------------------------- */
-    /*  Template item handlers                       */
-    /* -------------------------------------------- */
-
-    async _getGameItemsByType(
-        type: string,
-    ): Promise<Array<{_id: string; name: string; type: string; description?: string}>> {
-        const compendia = await od6sutilities.getItemsFromCompendiumByType(type as OD6SItemType);
-        const world = await od6sutilities.getItemsFromWorldByType(type as OD6SItemType);
-        const data = [...compendia, ...world];
-        return data.sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    async _addTemplateItem(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const type = target.dataset.type!;
-        const templateItems = await Promise.all(await this._getGameItemsByType(type));
-        const content = await foundry.applications.handlebars.renderTemplate(
-            "systems/od6s/templates/item/item-template-add.html",
-            {templateItems});
-        const label = game.i18n.localize(
-            game.system.template.Item[type].label);
-        const result = await DialogV2.input({
-            window: {title: game.i18n.localize("OD6S.ADD") + " " + label + "!"},
-            content,
-            ok: {label: game.i18n.localize("OD6S.ADD")},
-        });
-        if (result?.itemname) await this._addTemplateItemAction(result.itemname, type, this);
-    }
-
-    async _addTemplateItemAction(name: string, type: string, itemSheet: OD6SItemSheet): Promise<void> {
-        if (isItemGroupItem(this.item)) {
-            const item = this.item;
-            let allowed = false;
-            for (const [key, items] of Object.entries(OD6S.allowedItemTypes)) {
-                if (item.system.actor_types.includes(key)) {
-                    for (const i of (items as string[])) {
-                        if (OD6S.templateItemTypes["item-group"].includes(i)) {
-                            allowed = true;
-                            break;
-                        }
-                    }
-                }
-            }
-            if (!allowed) return;
-        } else if (!OD6S.templateItemTypes[this.item.type].includes(type)) {
-            return;
-        }
-
-        if (!isTemplateLikeItem(itemSheet.item)) return;
-        const sheetItem = itemSheet.item;
-        const item = await od6sutilities.getItemByName(name);
-        const description = item?.system.description ?? "";
-        const newItem: OD6STemplateItemEntry = {name, type, description};
-        (sheetItem.system.items as OD6STemplateItemEntry[]).push(newItem);
-        await sheetItem.update(
-            {id: sheetItem.id, system: sheetItem.system},
-            {diff: true});
-        await this.render();
-    }
-
-    async _editTemplateItem(event: Event): Promise<void> {
-        if (!isTemplateLikeItem(this.item)) return;
-        const target = event.currentTarget as HTMLElement;
-        const items = this.item.system.items as OD6STemplateItemEntry[];
-        const item = items.find((i) => i.name === target.dataset.name);
-        const itemData = {name: target.dataset.name, type: target.dataset.type, description: item?.description};
-        const content = await foundry.applications.handlebars.renderTemplate(
-            "systems/od6s/templates/item/item-template-item-edit.html",
-            itemData);
-        const label = game.i18n.localize(
-            game.system.template.Item[target.dataset.type!].label);
-        const result = await DialogV2.input({
-            window: {title: game.i18n.localize("OD6S.EDIT") + " " + label + "!"},
-            content,
-            ok: {label: game.i18n.localize("OD6S.EDIT")},
-        });
-        if (typeof result?.itemdesc === "string") {
-            await this._editTemplateItemAction(result.itemdesc, event, this);
-        }
-    }
-
-    async _editTemplateItemAction(desc: string, event: Event, itemSheet: OD6SItemSheet): Promise<void> {
-        if (!isTemplateLikeItem(itemSheet.item)) return;
-        const target = event.currentTarget as HTMLElement;
-        const data = target.dataset;
-        const newItem: OD6STemplateItemEntry = {name: data.name!, type: data.type!, description: desc};
-        const items = itemSheet.item.system.items as OD6STemplateItemEntry[];
-        const itemIndex = items.findIndex((i) => i.name === data.name && i.type === data.type);
-        if (itemIndex < 0) return;
-        items[itemIndex] = newItem;
-        await itemSheet.item.update(
-            {id: itemSheet.item.id, system: itemSheet.item.system},
-            {diff: false});
-        await this.render();
-    }
-
-    async _deleteTemplateItem(event: Event): Promise<void> {
-        if (!isTemplateLikeItem(this.item)) return;
-        const item = this.item;
-        const result = await DialogV2.confirm({
-            window: {title: game.i18n.localize("OD6S.DELETE")},
-            content: `<p>${game.i18n.localize("OD6S.DELETE_CONFIRM")}</p>`,
-        });
-        if (!result) return;
-
-        const target = event.currentTarget as HTMLElement;
-        const items = item.system.items as OD6STemplateItemEntry[];
-        const itemIndex = items.findIndex(
-            (i) => i.name === target.dataset.name && i.type === target.dataset.type);
-        if (itemIndex < 0) return;
-        items.splice(itemIndex, 1);
-        await item.update(
-            {id: item.id, system: item.system},
-            {diff: true});
-        await this.render();
-    }
-
-    async _editTemplateAttribute(event: Event): Promise<void> {
-        const target = event.currentTarget as HTMLElement;
-        const score = target.dataset.score;
-        const content = await foundry.applications.handlebars.renderTemplate(
-            "systems/od6s/templates/item/item-attribute-edit.html",
-            {score});
-        const result = await DialogV2.input({
-            window: {title: game.i18n.localize("OD6S.EDIT") + " " + target.dataset.label + "!"},
-            content,
-            ok: {label: game.i18n.localize("OD6S.EDIT_ATTRIBUTE")},
-        });
-        if (result) await this._editAttributeAction(result.dice, result.pips, event, this);
-    }
-
-    async _editAttributeAction(
-        dice: string,
-        pips: string,
-        event: Event,
-        itemSheet: OD6SItemSheet,
-    ): Promise<void> {
-        const newScore = od6sutilities.getScoreFromDice(Number(dice), Number(pips));
-        const target = event.currentTarget as HTMLElement;
-        const attrname = target.dataset.attrname!;
-        const attributes = (itemSheet.item.system as { attributes: Record<string, unknown> }).attributes;
-        switch (target.dataset.sub) {
-            case "base": attributes[attrname] = newScore; break;
-            case "min": (attributes[attrname] as { min: number }).min = newScore; break;
-            case "max": (attributes[attrname] as { max: number }).max = newScore; break;
-        }
-        await itemSheet.item.update(
-            {id: itemSheet.item.id, system: itemSheet.item.system},
-            {diff: true});
-        await this.render();
+        return drop.onDrop(this, event);
     }
 }

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -17,7 +17,7 @@ const ItemSheetV2 = foundry.applications.sheets.ItemSheetV2;
  * load the right template instead of declaring a multi-PARTS entry per type.
  *
  * Per-domain handlers live in `item-sheet-helpers/`; this class wires them
- * to DOM events and exposes them as methods for legacy callers.
+ * to DOM events and delegates without holding handler state.
  */
 export class OD6SItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
 


### PR DESCRIPTION
## Summary
- Mirror the #83 actor-sheet decomposition on `item-sheet.ts` (507 LOC). Handler bodies move to six focused modules under `src/module/item/item-sheet-helpers/`:
  - `labels.ts`, `effects.ts`, `actor-types.ts`, `edit-fields.ts`, `template-items.ts`, `drop.ts`.
- `item-sheet.ts` becomes a thin coordinator (98 LOC) that wires DOM events to helpers.
- The repeated dice/pip score-from-input pattern in `edit-fields.ts` is consolidated into a small `rerollScore` local helper without changing per-handler semantics.

Pure structural refactor — no rule changes, no behaviour changes. Lint count unchanged (221).

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (327 pass)
- [x] `pnpm run test:domain` (382 pass)
- [x] `pnpm run lint` (221 warnings; well under 720 CI gate)
- [ ] Smoke: open one of each item type's sheet, verify dice/pip editors, label add/edit/delete, effect lifecycle, template-item add/edit/delete, drag-drop into item-group/template