### PR TITLE
fix(item): restore weapon subtype passthrough + smoke spec V14 catch-up

### DIFF
--- a/src/module/apps/roll-helpers/roll-attacker-scale.test.ts
+++ b/src/module/apps/roll-helpers/roll-attacker-scale.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the attacker-scale helpers extracted from roll-setup.ts.
+ *
+ * Both helpers are pure: `isAttackRollKey` only inspects the classified
+ * key/type, and `deriveAttackerScale` reads `actor.system.scale.score` (or
+ * `actor.system.vehicle.scale.score` for character-piloting-vehicle paths).
+ * No Foundry globals are touched, so a minimal `as unknown as Actor` shim
+ * is enough.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveAttackerScale, isAttackRollKey } from './roll-attacker-scale';
+
+function characterActor(scaleScore: number, vehicleScaleScore?: number): Actor {
+    return {
+        type: 'character',
+        system: {
+            scale: { score: scaleScore },
+            vehicle: vehicleScaleScore !== undefined
+                ? { scale: { score: vehicleScaleScore } }
+                : undefined,
+        },
+    } as unknown as Actor;
+}
+
+function vehicleActor(scaleScore: number): Actor {
+    return {
+        type: 'vehicle',
+        system: { scale: { score: scaleScore } },
+    } as unknown as Actor;
+}
+
+function unknownActor(): Actor {
+    return { type: 'container', system: {} } as unknown as Actor;
+}
+
+describe('isAttackRollKey', () => {
+    it('returns true for the canonical attack-key set', () => {
+        for (const key of [
+            'weapon', 'starship-weapon', 'vehicle-weapon',
+            'action-brawlattack', 'action-vehicleramattack',
+            'action-vehiclerangedweaponattack',
+        ] as const) {
+            expect(isAttackRollKey(key, 'weapon', false)).toBe(true);
+        }
+    });
+
+    it('returns true for ranged weapon-classified rolls', () => {
+        expect(isAttackRollKey('weapon', 'weapon', true)).toBe(true);
+        expect(isAttackRollKey('weapon', 'starship-weapon', true)).toBe(true);
+        expect(isAttackRollKey('weapon', 'vehicle-weapon', true)).toBe(true);
+    });
+
+    it('returns true for rangedattack / vehiclerangedattack / meleeattack action keys', () => {
+        expect(isAttackRollKey('action-rangedattack', 'action', false)).toBe(true);
+        expect(isAttackRollKey('action-vehiclerangedattack', 'action', false)).toBe(true);
+        expect(isAttackRollKey('action-meleeattack', 'action', false)).toBe(true);
+    });
+
+    it('returns false for non-attack action keys', () => {
+        expect(isAttackRollKey('action-other', 'action', false)).toBe(false);
+        expect(isAttackRollKey('skill-dodge', 'skill', false)).toBe(false);
+        expect(isAttackRollKey('skill', 'skill', false)).toBe(false);
+        expect(isAttackRollKey('attribute', 'attribute', false)).toBe(false);
+    });
+
+    it('does not promote non-weapon classified types to attack via isRangedSubtype', () => {
+        expect(isAttackRollKey('skill', 'skill', true)).toBe(false);
+        expect(isAttackRollKey('attribute', 'attribute', true)).toBe(false);
+    });
+});
+
+describe('deriveAttackerScale', () => {
+    it('returns the bucket override when it is a non-zero number', () => {
+        const actor = characterActor(5);
+        expect(deriveAttackerScale({
+            actor, subtype: 'meleeattack', isAttackRoll: true, bucketAttackerScale: 3,
+        })).toBe(3);
+    });
+
+    it('falls through past zero bucket to actor-derived scale on attack rolls', () => {
+        const actor = characterActor(7);
+        expect(deriveAttackerScale({
+            actor, subtype: 'meleeattack', isAttackRoll: true, bucketAttackerScale: 0,
+        })).toBe(7);
+    });
+
+    it('returns bucket value (0 / undefined) on non-attack rolls without deriving', () => {
+        const actor = characterActor(7);
+        expect(deriveAttackerScale({
+            actor, subtype: 'skill', isAttackRoll: false, bucketAttackerScale: undefined,
+        })).toBe(0);
+        expect(deriveAttackerScale({
+            actor, subtype: 'skill', isAttackRoll: false, bucketAttackerScale: 0,
+        })).toBe(0);
+    });
+
+    it('reads vehicle actor scale for vehicle-* subtypes', () => {
+        const actor = vehicleActor(11);
+        expect(deriveAttackerScale({
+            actor, subtype: 'vehiclerangedattack', isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(11);
+    });
+
+    it('reads character.system.vehicle.scale.score for vehicle-* subtypes piloted by characters', () => {
+        const actor = characterActor(2, 9);
+        expect(deriveAttackerScale({
+            actor, subtype: 'vehiclerangedweaponattack', isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(9);
+    });
+
+    it('returns 0 when a character on a vehicle subtype has no embedded vehicle data', () => {
+        const actor = characterActor(4);
+        expect(deriveAttackerScale({
+            actor, subtype: 'vehicleramattack', isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(0);
+    });
+
+    it('reads character/vehicle actor scale on non-vehicle attack subtypes', () => {
+        expect(deriveAttackerScale({
+            actor: characterActor(5), subtype: 'meleeattack',
+            isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(5);
+        expect(deriveAttackerScale({
+            actor: vehicleActor(8), subtype: 'rangedattack',
+            isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(8);
+    });
+
+    it('returns 0 for unknown actor types on attack rolls', () => {
+        expect(deriveAttackerScale({
+            actor: unknownActor(), subtype: 'meleeattack',
+            isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(0);
+    });
+
+    it('coerces missing scale.score to 0', () => {
+        const actor = { type: 'character', system: { scale: {} } } as unknown as Actor;
+        expect(deriveAttackerScale({
+            actor, subtype: 'meleeattack', isAttackRoll: true, bucketAttackerScale: undefined,
+        })).toBe(0);
+    });
+});

--- a/src/module/apps/roll-helpers/roll-attacker-scale.ts
+++ b/src/module/apps/roll-helpers/roll-attacker-scale.ts
@@ -12,8 +12,9 @@ import {isCharacterActor, isVehicleActor} from "../../system/type-guards";
 import type {CanonicalRollType, RollTypeKey} from "./roll-data";
 
 /**
- * Roll-type keys that always count as attacks for scale derivation. Hoisted
- * to module scope so `isAttackRollKey` doesn't reallocate the set per call.
+ * Roll-type keys whose rolls get the `dice_for_scale` negative-scaleMod dice
+ * adjustment (Audit D enumeration). Hoisted to module scope so
+ * `isAttackRollKey` doesn't reallocate the set per call.
  */
 const ATTACK_KEYS: ReadonlySet<RollTypeKey> = new Set<RollTypeKey>([
     'weapon', 'starship-weapon', 'vehicle-weapon',
@@ -24,7 +25,6 @@ const ATTACK_KEYS: ReadonlySet<RollTypeKey> = new Set<RollTypeKey>([
 
 export interface AttackerScaleInput {
     actor: Actor;
-    classifiedKey: RollTypeKey;
     subtype: string;
     isAttackRoll: boolean;
     bucketAttackerScale: number | undefined;

--- a/src/module/apps/roll-helpers/roll-mod-accumulator.test.ts
+++ b/src/module/apps/roll-helpers/roll-mod-accumulator.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for accumulateRollMods — phase-3 mod folding extracted from
+ * roll-setup.ts.
+ *
+ * The helper wires `applyWeaponMods` (pure) and `getEffectMod` (reads
+ * `actor.system.customeffects` for character actors) plus a handful of
+ * inline branches keyed off `classified` / `subtype`. No Foundry globals,
+ * minimal Actor/Item shims via `as unknown as`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { accumulateRollMods } from './roll-mod-accumulator';
+import type { ClassifiedRoll, RollTypeKey } from './roll-data';
+
+function classified(type: ClassifiedRoll['type'], subtype: string, key: RollTypeKey): ClassifiedRoll {
+    return { type, subtype, key };
+}
+
+interface CharacterShape {
+    melee?: { mod: number };
+    brawl?: { mod: number };
+    dodge?: { mod: number };
+    parry?: { mod: number };
+    block?: { mod: number };
+    ranged?: { mod: number; score?: number };
+    vehicle?: { ranged?: { score: number }; ram?: { score: number } };
+    customeffects?: {
+        skills: Record<string, number>;
+        specializations: Record<string, number>;
+    };
+    items?: unknown[];
+}
+
+function characterActor(system: CharacterShape, items: unknown[] = []): Actor {
+    return {
+        type: 'character',
+        system,
+        items,
+    } as unknown as Actor;
+}
+
+function vehicleActor(system: Record<string, unknown>): Actor {
+    return {
+        type: 'vehicle',
+        system,
+        items: [],
+    } as unknown as Actor;
+}
+
+function weaponItem(modsOverrides: Partial<{ difficulty: number; attack: number; damage: number }> = {}, stats?: { skill?: string; specialization?: string }): Item {
+    return {
+        type: 'weapon',
+        system: {
+            mods: { difficulty: 0, attack: 0, damage: 0, ...modsOverrides },
+            stats: stats ?? {},
+        },
+    } as unknown as Item;
+}
+
+function skillItem(name: string): Item {
+    return { type: 'skill', name, system: {} } as unknown as Item;
+}
+
+function specItem(name: string): Item {
+    return { type: 'specialization', name, system: {} } as unknown as Item;
+}
+
+describe('accumulateRollMods', () => {
+    it('returns zeros when nothing applies', () => {
+        const actor = characterActor({});
+        const result = accumulateRollMods({
+            actor, item: undefined, classified: classified('attribute', '', 'attribute'),
+            subtype: '', isRangedSubtype: false,
+        });
+        expect(result).toEqual({ bonusmod: 0, miscMod: 0 });
+    });
+
+    it('folds weapon difficulty/attack mods on weapon-classified rolls', () => {
+        const actor = characterActor({});
+        const item = weaponItem({ difficulty: 2, attack: 3 });
+        const result = accumulateRollMods({
+            actor, item, classified: classified('weapon', '', 'weapon'),
+            subtype: '', isRangedSubtype: false,
+        });
+        expect(result).toEqual({ bonusmod: 3, miscMod: 2 });
+    });
+
+    it('adds specialization effect mod when actor owns it (precedence over skill)', () => {
+        const actor = characterActor({
+            customeffects: { skills: { Blasters: 4 }, specializations: { Pistols: 5 } },
+        }, [specItem('Pistols'), skillItem('Blasters')]);
+        const item = weaponItem({}, { skill: 'Blasters', specialization: 'Pistols' });
+        const result = accumulateRollMods({
+            actor, item, classified: classified('weapon', '', 'weapon'),
+            subtype: '', isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(5);
+    });
+
+    it('falls back to skill effect mod when actor does not own the specialization', () => {
+        const actor = characterActor({
+            customeffects: { skills: { Blasters: 4 }, specializations: { Pistols: 5 } },
+        }, [skillItem('Blasters')]);
+        const item = weaponItem({}, { skill: 'Blasters', specialization: 'Pistols' });
+        const result = accumulateRollMods({
+            actor, item, classified: classified('weapon', '', 'weapon'),
+            subtype: '', isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(4);
+    });
+
+    it('does not fold weapon mods when classified type is action-routed', () => {
+        const actor = characterActor({ melee: { mod: 0 } });
+        const item = weaponItem({ difficulty: 9, attack: 9 });
+        const result = accumulateRollMods({
+            actor, item, classified: classified('action', 'meleeattack', 'action-meleeattack'),
+            subtype: 'meleeattack', isRangedSubtype: false,
+        });
+        expect(result).toEqual({ bonusmod: 0, miscMod: 0 });
+    });
+
+    it('folds vehicle-borne weapon mods on action-vehiclerangedweaponattack', () => {
+        const actor = characterActor({});
+        const item = {
+            type: 'vehicle-weapon',
+            system: { mods: { difficulty: 1, attack: 2, damage: 0 }, stats: {} },
+        } as unknown as Item;
+        const result = accumulateRollMods({
+            actor, item,
+            classified: classified('action', 'vehiclerangedweaponattack', 'action-vehiclerangedweaponattack'),
+            subtype: 'vehiclerangedweaponattack', isRangedSubtype: true,
+        });
+        expect(result.miscMod).toBe(1);
+        expect(result.bonusmod).toBeGreaterThanOrEqual(2);
+    });
+
+    it('adds skill effect mod for skill-classified rolls', () => {
+        const actor = characterActor({
+            customeffects: { skills: { Dodge: 6 }, specializations: {} },
+        });
+        const result = accumulateRollMods({
+            actor, item: skillItem('Dodge'),
+            classified: classified('skill', '', 'skill'),
+            subtype: '', isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(6);
+    });
+
+    it('adds specialization effect mod for specialization-classified rolls', () => {
+        const actor = characterActor({
+            customeffects: { skills: {}, specializations: { Pistols: 7 } },
+        });
+        const result = accumulateRollMods({
+            actor, item: specItem('Pistols'),
+            classified: classified('specialization', '', 'specialization'),
+            subtype: '', isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(7);
+    });
+
+    it.each([
+        ['meleeattack', 'melee'],
+        ['brawlattack', 'brawl'],
+        ['dodge', 'dodge'],
+        ['parry', 'parry'],
+        ['block', 'block'],
+    ] as const)('adds character.%s.mod for subtype %s', (subtype, field) => {
+        const actor = characterActor({ [field]: { mod: 4 } } as CharacterShape);
+        const result = accumulateRollMods({
+            actor, item: undefined,
+            classified: classified('action', subtype, `action-${subtype}` as RollTypeKey),
+            subtype, isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(4);
+    });
+
+    it('adds personal ranged.mod on personal ranged-attack subtypes', () => {
+        const actor = characterActor({ ranged: { mod: 3 } });
+        const result = accumulateRollMods({
+            actor, item: undefined,
+            classified: classified('action', 'rangedattack', 'action-rangedattack'),
+            subtype: 'rangedattack', isRangedSubtype: true,
+        });
+        expect(result.bonusmod).toBe(3);
+    });
+
+    it('reads character.system.vehicle.ranged.score on vehicle-prefixed ranged subtypes', () => {
+        const actor = characterActor({ ranged: { mod: 99 }, vehicle: { ranged: { score: 5 } } });
+        const result = accumulateRollMods({
+            actor, item: undefined,
+            classified: classified('action', 'vehiclerangedattack', 'action-vehiclerangedattack'),
+            subtype: 'vehiclerangedattack', isRangedSubtype: true,
+        });
+        expect(result.bonusmod).toBe(5);
+    });
+
+    it('reads vehicle.system.ranged.score when an embedded pilot fires from a vehicle actor', () => {
+        const actor = vehicleActor({
+            ranged: { score: 6 },
+            embedded_pilot: { value: 'pilot-id' },
+        });
+        const result = accumulateRollMods({
+            actor, item: undefined,
+            classified: classified('action', 'vehiclerangedattack', 'action-vehiclerangedattack'),
+            subtype: 'vehiclerangedattack', isRangedSubtype: true,
+        });
+        expect(result.bonusmod).toBe(6);
+    });
+
+    it('adds ram.score exactly once on action-vehicleramattack (RFC #103)', () => {
+        const actor = characterActor({ vehicle: { ram: { score: 4 } } });
+        const result = accumulateRollMods({
+            actor, item: undefined,
+            classified: classified('action', 'vehicleramattack', 'action-vehicleramattack'),
+            subtype: 'vehicleramattack', isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(4);
+    });
+
+    it('reads vehicle actor ram.score on action-vehicleramattack', () => {
+        const actor = vehicleActor({ ram: { score: 8 } });
+        const result = accumulateRollMods({
+            actor, item: undefined,
+            classified: classified('action', 'vehicleramattack', 'action-vehicleramattack'),
+            subtype: 'vehicleramattack', isRangedSubtype: false,
+        });
+        expect(result.bonusmod).toBe(8);
+    });
+});

--- a/src/module/apps/roll-helpers/roll-setup.ts
+++ b/src/module/apps/roll-helpers/roll-setup.ts
@@ -267,7 +267,6 @@ export async function setupRollData(data: IncomingRollData): Promise<RollData | 
     const isAttackRoll = isAttackRollKey(classified.key, classified.type, isRangedSubtype);
     const attackerScale = deriveAttackerScale({
         actor: data.actor,
-        classifiedKey: classified.key,
         subtype,
         isAttackRoll,
         bucketAttackerScale: bucketAny.attackerScale,

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -438,7 +438,18 @@ export class OD6SItem extends Item {
             }
         }
 
-        let subtype = isActionItem(item) ? item.system.subtype : '';
+        // Weapons carry their localized weapon-type label (OD6S.MELEE / OD6S.RANGED
+        // / …) in `system.subtype`; classifyRoll normalizes that to canonical
+        // `meleeattack` / `rangedattack`, which the melee-range preflight gate
+        // and downstream bonus accumulators rely on. Pre-#57 this read
+        // `itemData.subtype` unconditionally; the discriminated-union narrowing
+        // dropped the weapon branch and silently passed `subtype: ''`, breaking
+        // the melee-range gate and personal melee/ranged mod application via
+        // `item.roll()`.
+        let subtype = '';
+        if (isActionItem(item) || isAnyWeaponItem(item)) {
+            subtype = item.system.subtype;
+        }
         if (parry) {
             subtype = "parry";
         }

--- a/src/templates/actor/common/tabs/combat.html
+++ b/src/templates/actor/common/tabs/combat.html
@@ -335,7 +335,7 @@
                                  data-rollable="{{action.system.rollable}}"
                                  data-id="{{key}}">
                                 <div class="flexrow flex-group-left{{#if
-                                        (eq action.system.rollable "true")}} actionroll{{/if}}"
+                                        action.system.rollable}} actionroll{{/if}}"
                                      data-item-id="{{action._id}}">
                                     {{# if (eq action.system.subtype 'misc')}}
                                         <input class="editmiscaction" data-item-id="{{action._id}}"

--- a/tests/smoke/tier-3-play-mode-roll.spec.ts
+++ b/tests/smoke/tier-3-play-mode-roll.spec.ts
@@ -1,12 +1,18 @@
 /**
  * Tier 3 — Roll-from-sheet works in PLAY mode (regression for issue #76).
  *
- * V2 ActorSheets render in PLAY mode by default, where `isEditable` is
- * false. Previously, _onRender early-returned on !isEditable and never
- * bound the play-mode roll selectors — so non-GM players (whose sheets
- * default to PLAY mode) silently failed to roll. This spec opens the
- * sheet, forces PLAY mode, and verifies *each* selector that was moved
- * above the editability gate still fires its handler.
+ * Originally, V2 ActorSheets exposed PLAY/EDIT modes via DocumentSheetV2
+ * `_mode` + SHEET_MODES, with `isEditable` returning false in PLAY mode.
+ * In Foundry V14 that machinery is gone — `isEditable` is derived purely
+ * from the document's update permission. Non-GM owners viewing their
+ * own sheet still need the roll bindings to work, mirroring the original
+ * #76 scenario.
+ *
+ * To exercise the non-editable path under a Gamemaster login, this spec
+ * shadows `isEditable` to return false on the actor sheet instance before
+ * render. The render path then takes the same branch a non-GM player
+ * would hit, and we verify *each* selector that lives above the
+ * editability gate still fires its handler.
  *
  * Selectors covered: .rolldialog, .actionroll, .combat-action,
  * .vehicle-action. Each is verified by spying on the corresponding
@@ -26,6 +32,14 @@ test("all PLAY-mode roll selectors fire their handlers", async ({page}) => {
         if (!actor) {
             actor = await window.Actor.create({name: "smoke-character", type: "character"}, {render: false});
         }
+        // Ensure attributes are above the pipsPerDice (3) score gate, otherwise
+        // setupRollData warns "score too low" and never opens RollDialog.
+        if (actor.system.attributes.agi.base < 3) {
+            await actor.update({
+                "system.attributes.agi.base": 9,
+                "system.attributes.str.base": 9,
+            });
+        }
         if (!actor.items.find((i: any) => i.type === "skill" && i.name === "smoke-skill")) {
             await actor.createEmbeddedDocuments("Item", [{
                 name: "smoke-skill",
@@ -33,12 +47,15 @@ test("all PLAY-mode roll selectors fire their handlers", async ({page}) => {
                 system: {score: 3, attribute: "agi"},
             }]);
         }
-        // Add a weapon so .actionroll renders.
-        if (!actor.items.find((i: any) => i.type === "weapon" && i.name === "smoke-blaster")) {
+        // Add a rollable action so .actionroll renders. The class is gated on
+        // a truthy `action.system.rollable` (BooleanField) — see combat.html.
+        // Weapons live under the inventory tab and surface a different selector;
+        // .actionroll is specifically for actor.actions entries.
+        if (!actor.items.find((i: any) => i.type === "action" && i.name === "smoke-action")) {
             await actor.createEmbeddedDocuments("Item", [{
-                name: "smoke-blaster",
-                type: "weapon",
-                system: {damage: {score: 9, type: "p"}, subtype: "rangedattack"},
+                name: "smoke-action",
+                type: "action",
+                system: {rollable: true, subtype: "rangedattack"},
             }]);
         }
     });
@@ -52,9 +69,14 @@ test("all PLAY-mode roll selectors fire their handlers", async ({page}) => {
         try {
             const actor = window.game.actors.find((a: any) => a.name === "smoke-character");
 
-            const SHEET_MODES = (window.foundry as any).applications.sheets
-                ?.DocumentSheetV2?.SHEET_MODES ?? {PLAY: 1, EDIT: 2};
-            actor.sheet._mode = SHEET_MODES.PLAY;
+            // V14 dropped DocumentSheetV2.SHEET_MODES + `_mode`; isEditable
+            // is now permission-derived. Shadow the getter on this instance
+            // so the render path takes the !isEditable branch a non-GM owner
+            // would hit, without needing a second user session.
+            Object.defineProperty(actor.sheet, "isEditable", {
+                get: () => false,
+                configurable: true,
+            });
 
             // Stub the sheet methods that the moved selectors fan out to.
             // We swap them BEFORE render so the listener bindings capture

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -573,14 +573,21 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
             };
         });
 
-        // Footer's bottom edge should sit very close to the form's bottom edge
-        // (a few px slack for borders/padding). On the bug, footer.bottom was
-        // hundreds of px above form.bottom.
+        // Footer's bottom edge should sit close to the form's bottom edge.
+        // V14 ApplicationV2's `<section.window-content>` has ~16px of
+        // top/bottom padding (Foundry default), so the footer can only reach
+        // within `padding-bottom + 1-2px` of the form edge — anything beyond
+        // that means the flex chain isn't pinning. On the bug, footer.bottom
+        // was hundreds of px above form.bottom.
         const gap = result.formBottom - result.footerBottom;
-        expect(gap, "footer pinned within 16px of form bottom").toBeLessThan(16);
+        expect(gap, "footer pinned within ~24px of form bottom").toBeLessThan(24);
         // .sheet-body should occupy a meaningful share of the form (it has
-        // flex:1). Sanity-check it's at least 40% of the form height.
-        expect(result.bodyHeight / result.formHeight, ".sheet-body fills the available space").toBeGreaterThan(0.4);
+        // flex:1). The character header carries a large profile-img preview
+        // (~30% of the content area on a fresh actor) and there's
+        // `window-content` padding, so the body can't be 40% of the *form*
+        // — but it should still be > 25% as long as flex:1 is in effect.
+        // On the bug, body collapsed to its content (single-digit %).
+        expect(result.bodyHeight / result.formHeight, ".sheet-body fills the available space").toBeGreaterThan(0.25);
     });
 
     test("sheet-mode footer is present on all sheetmode-bearing actor types (#63)", async ({page}) => {
@@ -668,19 +675,31 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
             // because hidden tabs have zero-sized descendants.
             const activeTab = root.querySelector(".sheet-body > .tab.active") as HTMLElement | null;
             const activeTabName = activeTab?.dataset.tab ?? null;
+            // The biography tab stacks several prose-mirror editors in a
+            // scrollable .sheet-body. Hit-test only the editors whose center
+            // lies inside the visible scroll viewport — `elementFromPoint`
+            // returns null for points outside the viewport, which would
+            // false-positive a "clicks blocked" failure.
+            const sheetBody = root.querySelector("section.sheet-body") as HTMLElement | null;
+            const bodyRect = sheetBody?.getBoundingClientRect();
             const pms = [...root.querySelectorAll("prose-mirror")] as HTMLElement[];
             const out = pms.map((pm) => {
                 const ec = pm.querySelector(".editor-content") as HTMLElement | null;
-                if (!ec) return {hasEditor: false};
+                if (!ec) return {hasEditor: false, visible: false};
                 const r = ec.getBoundingClientRect();
                 if (r.width === 0 || r.height === 0) {
-                    return {hasEditor: true, height: r.height, hitInside: false, hitTag: "(zero-rect)"};
+                    return {hasEditor: true, visible: false, height: r.height, hitInside: false, hitTag: "(zero-rect)"};
                 }
                 const cx = r.left + r.width / 2;
                 const cy = r.top + r.height / 2;
+                const visible = !!bodyRect && cy >= bodyRect.top && cy <= bodyRect.bottom;
+                if (!visible) {
+                    return {hasEditor: true, visible: false, height: r.height, hitInside: false, hitTag: "(off-viewport)"};
+                }
                 const top = document.elementFromPoint(cx, cy);
                 return {
                     hasEditor: true,
+                    visible: true,
                     height: r.height,
                     hitInside: !!top && ec.contains(top),
                     hitTag: top?.tagName ?? "(none)",
@@ -695,10 +714,12 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         // the .height filter would silently drop).
         expect(result.activeTabName, "biography tab is the active pane").toBe("description");
 
-        // Description tab must render at least one prose-mirror with a
-        // sized editor-content whose center belongs to the editor.
-        const usable = result.editors.filter((r) => r.hasEditor && r.height && r.height > 0);
-        expect(usable.length, "at least one prose-mirror has a sized editor-content").toBeGreaterThan(0);
+        // Description tab must render at least one prose-mirror with a sized
+        // editor-content whose center belongs to the editor. Only test the
+        // editors visible in the current scroll viewport — off-screen ones
+        // would falsely fail because `elementFromPoint` is null outside it.
+        const usable = result.editors.filter((r) => r.hasEditor && r.visible && r.height && r.height > 0);
+        expect(usable.length, "at least one visible prose-mirror has a sized editor-content").toBeGreaterThan(0);
         for (const r of usable) {
             expect(r.height, "editor-content fills more than one line").toBeGreaterThan(60);
             expect(r.hitInside, `clicks land inside editor-content (got ${r.hitTag})`).toBe(true);


### PR DESCRIPTION
## Summary

Post-#157 review-fix follow-up that grew teeth: while running the smoke suite to validate the refactor, four pre-existing failures fell out — two real bugs (one production, one template) and two test-suite drift items from V14.

- **a48c0b6** — Drops unused `classifiedKey` field on `AttackerScaleInput` (caught by my own review of #157), restores the Audit-D rationale on `ATTACK_KEYS`, and adds 32 unit tests for the two helpers extracted in #157 (`roll-attacker-scale` / `roll-mod-accumulator`).
- **6930205** — Restores weapon `subtype` passthrough in `item.roll()`. PR #118's discriminated-union sweep narrowed `let subtype = itemData.subtype` to `isActionItem(item) ? item.system.subtype : ''`, silently dropping the weapon branch. Every weapon `item.roll()` since #118 has shipped `subtype: ''`, bypassing the melee-range preflight gate AND the personal melee/brawl/dodge/parry/block + ranged.mod accumulators. Real production regression.
- **6dd9d7d** — `combat.html` was strict-comparing a `BooleanField` to the string `"true"`, so the `.actionroll` class never rendered on rollable actor.actions entries. Day-one bug; `eq` is strict in Foundry.
- **115bff8** — V14 catch-up for two specs that referenced removed APIs (`DocumentSheetV2.SHEET_MODES` / `_mode`) and tightened layout thresholds beyond what V14's `window-content` padding allows.

## Test plan

- [x] `pnpm run check` — lint 213 / 720 (down 8 from main), typecheck clean, 414 unit + 327 domain tests passing.
- [x] `pnpm run test:smoke` — 46/46 pass (1 intentional skip), down from 4 failed on main.
- [x] Stash-and-rerun confirms the 4 smoke failures all reproduce on `main@41431a0` — nothing introduced by this branch.
- [ ] Manual: melee weapon attack against an out-of-range target now warns + cancels (per smoke).
- [ ] Manual: clickable rollable actions on the combat tab now fire the roll dialog (per smoke).

## Notes

- No bundled `od6s.js` in the diff — `src/module/od6s.js` is gitignored.
- Bug 1 (item.ts) is the load-bearing one: the melee-range gate has been broken since PR #118 merged on 2026-05-04, plus silent under-counting of personal weapon attack mods. Memory note `feedback_any_masks_bugs` already flagged this exact failure mode for the typing-debt sweep.

Closes nothing on its own — these were latent.