### PR TITLE
chore+test: env-overridable Taskfile knobs and #159 PM-mid-edit smoke probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,13 @@ FOUNDRY_USERNAME=your-foundryvtt-username
 FOUNDRY_PASSWORD=your-foundryvtt-password
 FOUNDRY_LICENSE_KEY=AAAA-BBBB-CCCC-DDDD-EEEE-FFFF
 FOUNDRY_ADMIN_KEY=your-admin-password
+
+# Optional: host port the Foundry container publishes (defaults to 30000)
+# and the URL the Playwright smoke specs talk to. Override these together
+# if 30000 is taken on your machine.
+# FOUNDRY_PORT=30030
+# FOUNDRY_URL=http://localhost:30030
+
+# Optional: containerd namespace for nerdctl (Rancher Desktop ships
+# `default` for plain containers, `k8s.io` for k8s-integrated ones).
+# NERDCTL_NAMESPACE=default

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ FOUNDRY_ADMIN_KEY=your-admin-password
 # Optional: containerd namespace for nerdctl (Rancher Desktop ships
 # `default` for plain containers, `k8s.io` for k8s-integrated ones).
 # NERDCTL_NAMESPACE=default
+
+# Optional: pin the Foundry image tag (defaults to floating `14`). Match
+# this to system.json `compatibility.verified` for reproducible runs.
+# FOUNDRY_VERSION=14.361

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `compatibility.verified` to Foundry **14.361** (current
+  recommended build).
+
 ## [2.6.0] - 2026-05-09
 
 Internal-quality release: socket transport consolidated onto socketlib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+### Fixed
+
+- Armor `system.damaged` is now declared on `ArmorData.defineSchema()`
+  (#67 follow-up): the field was referenced by the armor sheet
+  template, by the wound helper's `auto_armor_damage` path, and by the
+  manual `<select>` on the armor sheet, but never declared on the
+  DataModel. V14's strict `TypeDataModel` silently dropped the field
+  on every update, so manual *and* automatic armor damage tracking
+  were no-ops. Surfaced by the hermetic #67 regression spec after it
+  was refactored to flip `weapon_armor_damage` on for the probe.
+- `<select>` `selected` comparison in the armor / weapon /
+  starship-weapon / vehicle-weapon item-sheet templates coerces the
+  iterated key to a number before comparing against the stored
+  `system.damaged` value. The keys arrive as strings (`for…in` over
+  the levels record) while `damaged` is a `NumberField`, so the strict
+  `eq` helper never matched and the browser silently fell back to the
+  first `<option>` on every re-render.
+
 ### Changed
 
 - Bump `compatibility.verified` to Foundry **14.361** (current

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,10 @@ version: "3"
 dotenv: [".env"]
 
 vars:
-  FOUNDRY_VERSION: "14"
+  # Foundry image tag. Defaults to the floating `14` major; pin to a
+  # specific build (e.g. `14.361`) via .env when you want reproducible
+  # runs against the system.json `compatibility.verified` value.
+  FOUNDRY_VERSION: '{{.FOUNDRY_VERSION | default "14"}}'
   CONTAINER_NAME: od6s-foundry
   # Host port for the Foundry container. Override per-machine via .env
   # (FOUNDRY_PORT=30030) when 30000 is squatted by another process.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,19 +1,28 @@
 version: "3"
 
+dotenv: [".env"]
+
 vars:
   FOUNDRY_VERSION: "14"
   CONTAINER_NAME: od6s-foundry
-  FOUNDRY_PORT: "30000"
+  # Host port for the Foundry container. Override per-machine via .env
+  # (FOUNDRY_PORT=30030) when 30000 is squatted by another process.
+  FOUNDRY_PORT: '{{.FOUNDRY_PORT | default "30000"}}'
   FOUNDRY_DATA: "{{.ROOT_DIR}}/.foundry-data"
-  # Auto-detect container runtime: prefer docker, fall back to nerdctl (Rancher Desktop containerd)
+  # Containerd namespace for nerdctl. Rancher Desktop ships with `default`
+  # for plain containers and `k8s.io` for the k8s integration; pin it
+  # explicitly so commands aren't sensitive to ambient state. Override via
+  # .env (NERDCTL_NAMESPACE=k8s.io) if your container lives elsewhere.
+  NERDCTL_NAMESPACE: '{{.NERDCTL_NAMESPACE | default "default"}}'
+  # Resolve the container runtime once. Prefer docker; fall back to
+  # `nerdctl --namespace=<ns>` so every downstream invocation targets the
+  # same namespace without each task remembering to pass the flag.
   CONTAINER_RT:
     sh: |
       if docker info >/dev/null 2>&1; then echo docker
-      elif nerdctl info >/dev/null 2>&1; then echo nerdctl
+      elif nerdctl info >/dev/null 2>&1; then echo "nerdctl --namespace={{.NERDCTL_NAMESPACE}}"
       else echo none
       fi
-
-dotenv: [".env"]
 
 tasks:
   default:

--- a/src/module/data/item/armor.ts
+++ b/src/module/data/item/armor.ts
@@ -12,6 +12,7 @@ export default class ArmorData extends foundry.abstract.TypeDataModel {
       ...equipSchema(),
       pr: new fields.NumberField({ initial: 0 }),
       er: new fields.NumberField({ initial: 0 }),
+      damaged: new fields.NumberField({ initial: 0 }),
       label: new fields.StringField({ initial: "OD6S.CHAR_ARMOR" }),
     };
   }

--- a/src/system.json
+++ b/src/system.json
@@ -5,7 +5,7 @@
   "version": "2.6.0",
   "compatibility": {
     "minimum": "14",
-    "verified": "14.360",
+    "verified": "14.361",
     "maximum": "14"
   },
   "documentTypes": {

--- a/src/templates/item/item-armor-sheet.html
+++ b/src/templates/item/item-armor-sheet.html
@@ -36,7 +36,7 @@
                         <select name="system.damaged" id="item.system.damaged">
                             
                                 {{#each (getArmorDamageLevels) as |level key|}}
-                                    <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
+                                    <option value="{{ key }}" {{#if (eq (add 0 key) @root.item.system.damaged)}}selected{{/if}}>
                                         {{localize level}}
                                     </option>
                                 {{/each}}

--- a/src/templates/item/item-starship-weapon-sheet.html
+++ b/src/templates/item/item-starship-weapon-sheet.html
@@ -37,7 +37,7 @@
                             <select name="system.damaged" id="item.system.damaged">
                                 
                                     {{#each (getWeaponDamageLevels) as |level key|}}
-                                        <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq (add 0 key) @root.item.system.damaged)}}selected{{/if}}>
                                             {{localize level}}
                                         </option>
                                     {{/each}}

--- a/src/templates/item/item-vehicle-weapon-sheet.html
+++ b/src/templates/item/item-vehicle-weapon-sheet.html
@@ -37,7 +37,7 @@
                             <select name="system.damaged" id="item.system.damaged">
                                 
                                     {{#each (getWeaponDamageLevels) as |level key|}}
-                                        <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
+                                        <option value="{{ key }}" {{#if (eq (add 0 key) @root.item.system.damaged)}}selected{{/if}}>
                                             {{localize level}}
                                         </option>
                                     {{/each}}

--- a/src/templates/item/item-weapon-sheet.html
+++ b/src/templates/item/item-weapon-sheet.html
@@ -54,7 +54,7 @@
                                 <select name="system.damaged" id="item.system.damaged">
                                     
                                         {{#each (getWeaponDamageLevels) as |level key|}}
-                                            <option value="{{ key }}" {{#if (eq key @root.item.system.damaged)}}selected{{/if}}>
+                                            <option value="{{ key }}" {{#if (eq (add 0 key) @root.item.system.damaged)}}selected{{/if}}>
                                                 {{localize level}}
                                             </option>
                                         {{/each}}

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -1045,4 +1045,130 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
         expect(result.metaphysics, "metaphysics toggle not reset by DOM rename").toBe(true);
         expect(result.gender, "gender content not reset by DOM rename").toBe("seed-gender");
     });
+
+    test("rename while bio prose-mirror has unsaved draft does not blank stored bio (#159)", async ({page}) => {
+        // Probe for the leading hypothesis on #159: user types into the bio
+        // <prose-mirror> but has not clicked PM's own toolbar save when they
+        // change the name input; submitOnChange fires; what does the form
+        // submit harvest for the PM-bound fields?
+        //
+        // Acceptable outcomes:
+        //   (a) stored description equals the pre-edit seed — PM submitted
+        //       its committed value; the user's draft is dropped (a known
+        //       Foundry quirk, not data loss).
+        //   (b) stored description equals the typed draft — PM submitted
+        //       its live editor content.
+        //
+        // The bug case this test guards against:
+        //   (c) stored description is empty — PM submitted "" while there
+        //       was real content both in the document and in the editor.
+        //       That is the symptom owlsten reported as "the sheet was
+        //       reset".
+        await loginAndWaitReady(page);
+        await ensureCharacter(page);
+
+        const result = await evalInWorld(page, async () => {
+            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+            const SEED_DESC = "<p>seed-description-body</p>";
+            const SEED_PERS = "<p>seed-personality-body</p>";
+            const SEED_BG = "<p>seed-background-body</p>";
+            await actor.update({
+                name: "smoke-persist",
+                system: {
+                    characterpoints: {value: 9},
+                    description: {content: SEED_DESC},
+                    personality: {content: SEED_PERS},
+                    background: {content: SEED_BG},
+                    gender: {content: "seed-gender"},
+                },
+            });
+
+            const sheet: any = actor.sheet;
+            // Land on biography tab so the PMs are mounted with non-zero rects.
+            (sheet.tabGroups ??= {}).primary = "description";
+            await sheet.render(true);
+            await new Promise((r) => setTimeout(r, 500));
+
+            const root = sheet.element as HTMLElement;
+            const descPM = root.querySelector(
+                'prose-mirror[name="system.description.content"]',
+            ) as HTMLElement | null;
+            const editor = descPM?.querySelector(".editor-content") as HTMLElement | null;
+            if (!descPM || !editor) {
+                await sheet.close();
+                return {found: false};
+            }
+
+            // Simulate "user is mid-edit in PM": focus the contenteditable,
+            // mutate its innerHTML, dispatch input. We do NOT click the PM's
+            // own save button. This mirrors typing into bio without leaving
+            // the editor.
+            editor.focus();
+            editor.innerHTML = "<p>typed-draft-but-not-saved</p>";
+            editor.dispatchEvent(new InputEvent("input", {bubbles: true, inputType: "insertText"}));
+            await new Promise((r) => setTimeout(r, 100));
+
+            // Snapshot what the PM's form-facing value attribute holds *before*
+            // the rename submit — useful for diagnosing which value the form
+            // serialization picks up.
+            const pmValueAttrBefore = (descPM as any).getAttribute?.("value") ?? null;
+
+            // Now drive the name change. submitOnChange fires; the whole form
+            // is harvested, including all three PMs.
+            const nameInput = root.querySelector('input[name="name"]') as HTMLInputElement;
+            nameInput.value = "rename-during-bio-draft";
+            nameInput.dispatchEvent(new Event("change", {bubbles: true}));
+            await new Promise((r) => setTimeout(r, 1200));
+
+            const after = window.game.actors.get(actor.id);
+            const snapshot = {
+                found: true,
+                pmValueAttrBefore,
+                name: after.name,
+                description: after.system.description.content,
+                personality: after.system.personality.content,
+                background: after.system.background.content,
+                characterpoints: after.system.characterpoints.value,
+                gender: after.system.gender.content,
+                seedDesc: SEED_DESC,
+                seedPers: SEED_PERS,
+                seedBg: SEED_BG,
+            };
+            await sheet.close();
+            return snapshot;
+        });
+
+        if (!result.found) {
+            test.skip(true, "description prose-mirror not present on the rendered sheet");
+            return;
+        }
+
+        // Hard assertions — the bug case (#159 hypothesis).
+        expect(result.name, "name change persisted").toBe("rename-during-bio-draft");
+        expect(result.description, "description must not be blanked by submit during bio draft")
+            .not.toBe("");
+        expect(result.description, "description must not collapse to an empty PM doc")
+            .not.toMatch(/^<p>(<br\s*\/?>)?<\/p>$/);
+        expect(result.personality, "personality (untouched PM) must survive the rename submit")
+            .toBe(result.seedPers);
+        expect(result.background, "background (untouched PM) must survive the rename submit")
+            .toBe(result.seedBg);
+        expect(result.characterpoints, "unrelated numeric field survives rename + bio-draft").toBe(9);
+        expect(result.gender, "unrelated text field survives rename + bio-draft").toBe("seed-gender");
+
+        // Soft characterization — log which of (a) committed seed vs.
+        // (b) live draft the form actually submitted, so a future failure
+        // here surfaces a behavior change in Foundry's PM form serialization.
+        const tookSeed = result.description === result.seedDesc;
+        const tookDraft = result.description?.includes("typed-draft-but-not-saved");
+        // eslint-disable-next-line no-console
+        console.log("[#159 PM-mid-edit probe]", {
+            tookSeed, tookDraft,
+            descriptionAfter: result.description,
+            pmValueAttrBefore: result.pmValueAttrBefore,
+        });
+        expect(tookSeed || tookDraft,
+            "description after rename is either committed seed or typed draft, not unrelated content")
+            .toBe(true);
+    });
 });

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -488,57 +488,77 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
 
     test("armor sheet damaged <select> persists non-default level (#67)", async ({page}) => {
         // Sister coverage to the weapon-subtype and starship-damage tests
-        // for the broader each-block sweep (#67). Pick a non-first option
-        // so the bug actually surfaces — the stored value would otherwise
-        // happen to match the first <option> rendered.
+        // for the broader each-block sweep (#67). The armor `damaged`
+        // <select> is gated by the optional rule `weapon_armor_damage`,
+        // which defaults off in fresh worlds — so the spec flips the
+        // setting on for the duration of the probe and restores it
+        // afterwards. If the select is still missing with the rule on,
+        // that's a real template regression and we want the assertion to
+        // fail, not a silent skip.
         await loginAndWaitReady(page);
         await ensureCharacter(page);
 
         const result = await evalInWorld(page, async () => {
-            const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
-            for (const i of actor.items.filter((x: any) => x.name?.startsWith("smoke-armor-67"))) {
-                await i.delete();
+            const prevSetting = window.game.settings.get("od6s", "weapon_armor_damage");
+            if (!prevSetting) {
+                await window.game.settings.set("od6s", "weapon_armor_damage", true);
             }
-            const [armor] = await actor.createEmbeddedDocuments("Item", [{
-                name: "smoke-armor-67",
-                type: "armor",
-            }]);
-            await armor.sheet.render(true);
-            await new Promise((r) => setTimeout(r, 300));
-            const root = armor.sheet.element as HTMLElement;
-            const sel = root.querySelector('select[name="system.damaged"]') as HTMLSelectElement | null;
-            if (!sel) {
+            try {
+                const actor = window.game.actors.find((a: any) => a.name === "smoke-persist");
+                for (const i of actor.items.filter((x: any) => x.name?.startsWith("smoke-armor-67"))) {
+                    await i.delete();
+                }
+                const [armor] = await actor.createEmbeddedDocuments("Item", [{
+                    name: "smoke-armor-67",
+                    type: "armor",
+                }]);
+                await armor.sheet.render(true);
+                await new Promise((r) => setTimeout(r, 300));
+                const root = armor.sheet.element as HTMLElement;
+                const sel = root.querySelector(
+                    'select[name="system.damaged"]',
+                ) as HTMLSelectElement | null;
+                if (!sel) {
+                    await armor.sheet.close();
+                    await armor.delete();
+                    return {selectPresent: false};
+                }
+                const initial = sel.value;
+                const target = [...sel.options].find((o) => o.value !== initial)?.value;
+                if (!target) {
+                    await armor.sheet.close();
+                    await armor.delete();
+                    return {selectPresent: true, target: null};
+                }
+                sel.value = target;
+                sel.dispatchEvent(new Event("change", {bubbles: true}));
+                await new Promise((r) => setTimeout(r, 500));
+
+                const storedAfter = actor.items.get(armor.id).system.damaged;
+                const selAfter = (root.querySelector(
+                    'select[name="system.damaged"]',
+                ) as HTMLSelectElement | null)?.value ?? null;
+
                 await armor.sheet.close();
                 await armor.delete();
-                return {found: false};
+                return {selectPresent: true, target, storedAfter, selAfter};
+            } finally {
+                if (!prevSetting) {
+                    await window.game.settings.set("od6s", "weapon_armor_damage", false);
+                }
             }
-            const initial = sel.value;
-            const target = [...sel.options].find((o) => o.value !== initial)?.value;
-            if (!target) {
-                await armor.sheet.close();
-                await armor.delete();
-                return {found: false};
-            }
-            sel.value = target;
-            sel.dispatchEvent(new Event("change", {bubbles: true}));
-            await new Promise((r) => setTimeout(r, 500));
-
-            const storedAfter = actor.items.get(armor.id).system.damaged;
-            const selAfter = (root.querySelector(
-                'select[name="system.damaged"]',
-            ) as HTMLSelectElement | null)?.value ?? null;
-
-            await armor.sheet.close();
-            await armor.delete();
-            return {found: true, target, storedAfter, selAfter};
         });
 
-        if (!result.found) {
-            test.skip(true, "armor damaged <select> not present");
-            return;
-        }
-        expect(result.storedAfter, "stored damaged matches user selection").toBe(result.target);
-        expect(result.selAfter, "<select> reflects stored damaged after submit").toBe(result.target);
+        expect(result.selectPresent,
+            "armor `damaged` <select> must render when weapon_armor_damage is on (template regression?)")
+            .toBe(true);
+        expect(result.target,
+            "armor damage config must expose more than one level (deadliness config?)")
+            .toBeTruthy();
+        expect(String(result.storedAfter),
+            "stored damaged matches user selection").toBe(result.target);
+        expect(result.selAfter,
+            "<select> reflects stored damaged after submit").toBe(result.target);
     });
 
     test("sheet-mode footer pins to the bottom of the form (#63)", async ({page}) => {

--- a/tests/smoke/tier-3-sheet-persistence.spec.ts
+++ b/tests/smoke/tier-3-sheet-persistence.spec.ts
@@ -1169,18 +1169,23 @@ test.describe("Tier 3 — sheet field persistence (#27)", () => {
             .not.toBe("");
         expect(result.description, "description must not collapse to an empty PM doc")
             .not.toMatch(/^<p>(<br\s*\/?>)?<\/p>$/);
+        // Match the payload, not the exact serialization — PM may normalize
+        // whitespace / empty-doc shapes on submit even when the data is
+        // preserved, so strict toBe(seedPers/seedBg) is brittle without
+        // adding signal.
         expect(result.personality, "personality (untouched PM) must survive the rename submit")
-            .toBe(result.seedPers);
+            .toContain("seed-personality-body");
         expect(result.background, "background (untouched PM) must survive the rename submit")
-            .toBe(result.seedBg);
+            .toContain("seed-background-body");
         expect(result.characterpoints, "unrelated numeric field survives rename + bio-draft").toBe(9);
         expect(result.gender, "unrelated text field survives rename + bio-draft").toBe("seed-gender");
 
         // Soft characterization — log which of (a) committed seed vs.
         // (b) live draft the form actually submitted, so a future failure
         // here surfaces a behavior change in Foundry's PM form serialization.
-        const tookSeed = result.description === result.seedDesc;
-        const tookDraft = result.description?.includes("typed-draft-but-not-saved");
+        // Match on payload substrings for the same PM-normalization reason.
+        const tookSeed = !!result.description?.includes("seed-description-body");
+        const tookDraft = !!result.description?.includes("typed-draft-but-not-saved");
         // eslint-disable-next-line no-console
         console.log("[#159 PM-mid-edit probe]", {
             tookSeed, tookDraft,


### PR DESCRIPTION
## Summary
- Taskfile: resolve container runtime once with explicit `nerdctl --namespace=…` and let `FOUNDRY_PORT` / `NERDCTL_NAMESPACE` be overridden from `.env`, so the same tasks work on machines where 30000 is taken or where the target container lives outside the default containerd namespace.
- Smoke: add a tier-3 persistence spec that exercises the leading hypothesis on #159 — typing into the biography `<prose-mirror>` without committing PM's own save, then triggering `submitOnChange` via the name input. Asserts the description is neither blanked nor collapsed to an empty PM doc, that untouched PM fields and unrelated scalars survive, and characterizes whether the form harvested the committed seed or the live draft.

Refs #159.

## Test plan
- [ ] `task` commands honor `FOUNDRY_PORT` / `NERDCTL_NAMESPACE` from `.env` on a machine where 30000 is occupied
- [ ] `pnpm run test:smoke -- -g "rename while bio prose-mirror"` runs against the local Foundry world
- [ ] Spec passes (or fails loudly with the diagnostic `[#159 PM-mid-edit probe]` log) to confirm or refute the blanking hypothesis