### PR TITLE
fix(settings): unwrap nested form in 5 legacy config templates

### DIFF
--- a/src/templates/settings/active-attributes.html
+++ b/src/templates/settings/active-attributes.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div>
     {{#each settings as |setting s|}}
         <div class="form-group">
             <label for="{{setting.key}}">{{localize setting.name}}</label>
@@ -28,4 +28,4 @@
     <div class="submit">
         <button type="submit" name="close" data-action="closeForm">{{localize "Submit"}}</button>
     </div>
-</form>
+</div>

--- a/src/templates/settings/attributes-sorting.html
+++ b/src/templates/settings/attributes-sorting.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div>
 
     <ul class="attributes-sort">
         {{#each attributes as |attribute|}}
@@ -15,4 +15,4 @@
     <div class="submit">
       <button type="submit" name="close" data-action="closeForm">{{localize "Submit"}}</button>
     </div>
-</form>
+</div>

--- a/src/templates/settings/custom-fields.html
+++ b/src/templates/settings/custom-fields.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div>
     {{#each settings as |setting s|}}
         <div class="form-group">
             <label for="{{setting.key}}">{{localize setting.name}}</label>
@@ -51,4 +51,4 @@
     <div class="submit">
         <button type="submit" name="close" data-action="closeForm">{{localize "Submit"}}</button>
     </div>
-</form>
+</div>

--- a/src/templates/settings/initiative-settings.html
+++ b/src/templates/settings/initiative-settings.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div>
     {{#each settings as |setting s|}}
         <div class="form-group">
             <label for="{{setting.key}}">{{localize setting.name}}</label>
@@ -29,4 +29,4 @@
     <div class="submit">
       <button type="submit" name="close" data-action="closeForm">{{localize "Submit"}}</button>
     </div>
-</form>
+</div>

--- a/src/templates/settings/wild-die.html
+++ b/src/templates/settings/wild-die.html
@@ -1,4 +1,4 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
+<div>
     {{#each settings as |setting s|}}
         {{#if (eq setting.key 'use_wild_die')}}
             <div class="form-group">
@@ -45,4 +45,4 @@
     <div class="submit">
         <button type="submit" name="close" data-action="closeForm">{{localize "Submit"}}</button>
     </div>
-</form>
+</div>


### PR DESCRIPTION
## Summary

- Five settings dialogs (Custom Fields, Wild Die, Active Attributes, Attributes Sorting, Initiative) silently dropped user input — typing a value or toggling a checkbox didn't persist.
- Root cause: each template wrapped its content in a `<form>`, but the ApplicationV2 root is already a form (`tag: "form"`). HTML5 ignores the inner `<form>` open tag and treats the inner `</form>` as closing the outer, detaching every input from the form the submit handler reads. `submitOnChange` then fires with empty data and `game.settings.set` is never called with the user's value.
- Same root cause already fixed for `settings-v2.html` in 82888b6 (the V2 pilot). These five legacy templates were missed by that pass.
- Fix: swap the outer `<form ... onsubmit="event.preventDefault();">` for `<div>` (and the matching closer) to match the documented V2 pattern in `config-rules.ts`.

Closes #161
Closes #162

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] Full Playwright smoke suite — 50/50 with fix applied (one flake on initial run, passed on retarget; baseline without fix also 50/50, so no regression)
- [ ] Manual: open Game Settings → OpenD6 Space → Configure Wild Die, change values, click Submit, reopen — values persist
- [ ] Manual: open Game Settings → OpenD6 Space → Add Custom Fields, add labels, click Submit, reopen — values persist and field appears on character sheet