### PR TITLE
fix(item): pass `name` to ActiveEffect.create instead of `label`

### DIFF
--- a/src/module/item/item-sheet-helpers/effects.ts
+++ b/src/module/item/item-sheet-helpers/effects.ts
@@ -5,7 +5,7 @@
 
 export async function addEffect(item: Item): Promise<void> {
     const name = game.i18n.localize("OD6S.NEW_ACTIVE_EFFECT");
-    const effect = await item.createEmbeddedDocuments("ActiveEffect", [{label: name}]);
+    const effect = await item.createEmbeddedDocuments("ActiveEffect", [{name}]);
     new foundry.applications.sheets.ActiveEffectConfig({document: effect[0]}).render({force: true});
 }
 


### PR DESCRIPTION
## Summary

- Adding an effect to a weapon/armor/gear item threw:
  `[ActiveEffect] validation errors: SchemaField#_validateRecursive name: may not be undefined`
- Cause: the `addEffect` helper calls `createEmbeddedDocuments("ActiveEffect", [{label: name}])`, but Foundry v11+ renamed `ActiveEffect.label` to `ActiveEffect.name`. The schema's required `name` field was undefined, so creation always failed.
- Fix: pass `{name}` directly. The only other AE creation site (`actor/sheet-helpers/drops.ts`) round-trips via `toObject()` and already has `name`, so no further sites need touching.

Closes #164

## Test plan

- [x] `pnpm run typecheck` — clean
- [ ] Manual: open a weapon, Effects tab → `+` → effect is created and ActiveEffectConfig dialog opens
- [ ] Manual: same for armor and gear