### PR TITLE
fix(effects): wire delete/toggle on actor sheet + clean orphan effects

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1075,6 +1075,7 @@
   "OD6S.TOOLTIP_VEHICLE_WEAPON_ARC": "Comma-delimited list of firing arcs (front,rear,left,right)",
   "OD6S.TOOLTIP_VEHICLE_WEAPON_CREW": "Number of crew required to fire the weapon",
   "OD6S.TOOLTIP_VEHICLE_WEAPON_SCALE": "Scale value of the weapon; if 0 then the scale of the vehicle will be used",
+  "OD6S.TOGGLE_EFFECT": "Enable / Disable Effect",
   "OD6S.TOTAL": "Total",
   "OD6S.TO": "To",
   "OD6S.TOUGHNESS": "Toughness",

--- a/src/module/actor/actor-sheet.ts
+++ b/src/module/actor/actor-sheet.ts
@@ -142,9 +142,13 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         // Roll triggers must be bound for any owner regardless of edit mode —
         // V2 sheets render in PLAY mode by default (isEditable === false), but
         // rolling a skill/attack is a play-mode action. See issue #76.
+        // Effect management (edit/delete/toggle) is similarly a play-mode
+        // action; gating it behind edit mode hid the trash icon's behavior
+        // (#165) since the template still rendered it.
         if (this.actor.isOwner) {
             registerRollListeners(root, this);
             registerCombatRollListeners(root, this);
+            registerEffectListeners(root, this);
         }
 
         if (!this.isEditable) return;
@@ -193,7 +197,6 @@ export class OD6SActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         registerCombatActionListeners(root, this);
         registerVehicleListeners(root, this);
         registerScoreListeners(root, this);
-        registerEffectListeners(root, this);
         registerDragListeners(root, this);
     }
 

--- a/src/module/actor/sheet-listeners/effects.ts
+++ b/src/module/actor/sheet-listeners/effects.ts
@@ -22,6 +22,15 @@ export function registerEffectListeners(
             await sheet.document.deleteEmbeddedDocuments('ActiveEffect', [ct.dataset.effectId]);
         }));
 
+    // Toggle Effect disabled state (enable / disable in place)
+    root.querySelectorAll<HTMLElement>('.effect-toggle').forEach((elem) =>
+        elem.addEventListener('click', async (ev: Event) => {
+            const ct = ev.currentTarget as HTMLElement;
+            const effect = sheet.document.effects.get(ct.dataset.effectId);
+            if (!effect) return;
+            await effect.update({disabled: !effect.disabled});
+        }));
+
     // Activate a manifestation
     root.querySelectorAll<HTMLElement>('.active-checkbox').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {

--- a/src/module/actor/sheet-listeners/effects.ts
+++ b/src/module/actor/sheet-listeners/effects.ts
@@ -22,13 +22,16 @@ export function registerEffectListeners(
             await sheet.document.deleteEmbeddedDocuments('ActiveEffect', [ct.dataset.effectId]);
         }));
 
-    // Toggle Effect disabled state (enable / disable in place)
+    // Toggle Effect disabled state (enable / disable in place). Sheet
+    // needs an explicit re-render so the toggle icon + disabled styling
+    // reflect the new state without waiting for the next render trigger.
     root.querySelectorAll<HTMLElement>('.effect-toggle').forEach((elem) =>
         elem.addEventListener('click', async (ev: Event) => {
             const ct = ev.currentTarget as HTMLElement;
             const effect = sheet.document.effects.get(ct.dataset.effectId);
             if (!effect) return;
             await effect.update({disabled: !effect.disabled});
+            sheet.render();
         }));
 
     // Activate a manifestation

--- a/src/module/hooks/actor-hooks.ts
+++ b/src/module/hooks/actor-hooks.ts
@@ -227,6 +227,10 @@ export function registerActorHooks() {
     // item. Without this cleanup, deleting the weapon/armor leaves the
     // effect orphaned on the actor (#165).
     Hooks.on('preDeleteItem', async (item, _options, _userId) => {
+        // Hooks fire on every connected client; only one client must run
+        // the cleanup or non-owners spam permission errors. The acting GM
+        // owns the canonical delete and runs the sweep.
+        if (game.users.activeGM !== game.user) return;
         const actor = item.parent;
         if (!actor || !('effects' in actor)) return;
         const orphanIds: string[] = [];

--- a/src/module/hooks/actor-hooks.ts
+++ b/src/module/hooks/actor-hooks.ts
@@ -226,11 +226,13 @@ export function registerActorHooks() {
     // produce actor-embedded effects whose `origin` points at the source
     // item. Without this cleanup, deleting the weapon/armor leaves the
     // effect orphaned on the actor (#165).
-    Hooks.on('preDeleteItem', async (item, _options, _userId) => {
+    Hooks.on('preDeleteItem', async (item, _options, userId) => {
         // Hooks fire on every connected client; only one client must run
-        // the cleanup or non-owners spam permission errors. The acting GM
-        // owns the canonical delete and runs the sweep.
-        if (game.users.activeGM !== game.user) return;
+        // the cleanup or non-initiators spam permission errors. Gate on
+        // the user who initiated the delete (they had owner permission to
+        // delete the item, so they own the actor's effects too). Works
+        // in GM-less sessions, unlike a `game.users.activeGM` check.
+        if (game.user.id !== userId) return;
         const actor = item.parent;
         if (!actor || !('effects' in actor)) return;
         const orphanIds: string[] = [];

--- a/src/module/hooks/actor-hooks.ts
+++ b/src/module/hooks/actor-hooks.ts
@@ -219,6 +219,25 @@ export function registerActorHooks() {
         }
     })
 
+    // When an item embedded on an actor is deleted, also remove any
+    // ActiveEffects on the actor that originated from that item. Foundry
+    // v11+ no longer auto-copies item effects to the parent actor, but
+    // OD6S still has paths (drops.onDropActiveEffect, legacy worlds) that
+    // produce actor-embedded effects whose `origin` points at the source
+    // item. Without this cleanup, deleting the weapon/armor leaves the
+    // effect orphaned on the actor (#165).
+    Hooks.on('preDeleteItem', async (item, _options, _userId) => {
+        const actor = item.parent;
+        if (!actor || !('effects' in actor)) return;
+        const orphanIds: string[] = [];
+        for (const effect of actor.effects) {
+            if (effect.origin === item.uuid) orphanIds.push(effect.id);
+        }
+        if (orphanIds.length) {
+            await actor.deleteEmbeddedDocuments('ActiveEffect', orphanIds);
+        }
+    })
+
     Hooks.on('updateActiveEffect', async (effect) => {
         await od6sutilities.handleEffectChange(effect);
     })

--- a/src/templates/actor/common/tabs/data.html
+++ b/src/templates/actor/common/tabs/data.html
@@ -127,12 +127,17 @@
             <h2>{{localize 'OD6S.ACTOR_EFFECTS'}}</h2>
             <ul class="effects-list">
                 {{#each actor.effects as |effect key|}}
-                <li class="actor-effect" data-effect-id="effect.id">
+                <li class="actor-effect" data-effect-id="{{effect.id}}">
                     <div class="grid data-grid">
-                        <div class="flexrow flex-group-left" title="{{effect.description}}">{{effect.name}}</div>
+                        <div class="flexrow flex-group-left {{#if effect.disabled}}disabled{{/if}}"
+                             title="{{effect.description}}">{{effect.name}}</div>
                         <div class="item-controls flexrow flex-group-center"
                              data-effect-id="{{effect.id}}"
                              data-type="item">
+                            <a class="item-control effect-toggle small-font" data-effect-id="{{effect.id}}"
+                               title="{{localize 'OD6S.TOGGLE_EFFECT'}}">
+                                <i class="fas {{#if effect.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
+                            </a>
                             <a class="item-control effect-edit small-font" data-effect-id="{{effect.id}}"
                                title="{{localize 'OD6S.EDIT_EFFECT'}}">
                                 <i class="fas fa-edit"></i>

--- a/src/templates/actor/common/tabs/special-abilities.html
+++ b/src/templates/actor/common/tabs/special-abilities.html
@@ -134,14 +134,24 @@
                     <div class="grid grid-2col">
                         {{#each actor.effects as |effect key|}}
                             <li class="effect flexrow">
-                                <div class="flexrow flex-group-left edit-effect
-                                    {{#if effect.disabled}}disabled{{/if}}"
-                                     data-effect-id="{{effect.id}}"
-                                     {{#if effect.name}}
-                                        title="{{effect.name}}">{{effect.name}}
-                                     {{ else }}
-                                         title="{{effect.label}}">{{effect.label}}
-                                     {{/if}}
+                                <div class="flexrow flex-group-left {{#if effect.disabled}}disabled{{/if}}"
+                                     title="{{effect.name}}">{{effect.name}}</div>
+                                <div class="item-controls flexrow flex-group-right">
+                                    <a class="item-control effect-toggle small-font"
+                                       data-effect-id="{{effect.id}}"
+                                       title="{{localize 'OD6S.TOGGLE_EFFECT'}}">
+                                        <i class="fas {{#if effect.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
+                                    </a>
+                                    <a class="item-control effect-edit small-font"
+                                       data-effect-id="{{effect.id}}"
+                                       title="{{localize 'OD6S.EDIT_EFFECT'}}">
+                                        <i class="fas fa-edit"></i>
+                                    </a>
+                                    <a class="item-control effect-delete small-font"
+                                       data-effect-id="{{effect.id}}"
+                                       title="{{localize 'OD6S.DELETE_EFFECT'}}">
+                                        <i class="fas fa-trash"></i>
+                                    </a>
                                 </div>
                             </li>
                         {{/each}}

--- a/tests/smoke/tier-3-active-effects.spec.ts
+++ b/tests/smoke/tier-3-active-effects.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Tier 3 — Active Effect management on items and actors.
+ *
+ * Regressions covered:
+ *
+ *   #164 — Adding an effect to a weapon used to throw
+ *          `[ActiveEffect] validation errors: ... name: may not be undefined`
+ *          because the addEffect helper passed `{label}` instead of `{name}`.
+ *
+ *   #165 — Existing effects on the character sheet could not be deleted or
+ *          toggled. The special-abilities tab rendered effects with no
+ *          delete/toggle controls; the data-tab trash button only had its
+ *          listener attached when the sheet was in EDIT mode. Deleting an
+ *          item that owned an effect on the actor left the effect orphaned.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("addEffect helper creates an ActiveEffect with name field (#164)", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const stale = window.game.items.filter((i: any) => i.name === "smoke-effect-weapon")
+            .map((i: any) => i.id);
+        if (stale.length) await window.Item.deleteDocuments(stale);
+
+        const weapon = await window.Item.create(
+            {name: "smoke-effect-weapon", type: "weapon"},
+            {render: false},
+        );
+
+        const errs: string[] = [];
+        try {
+            await weapon.createEmbeddedDocuments("ActiveEffect", [{
+                name: window.game.i18n.localize("OD6S.NEW_ACTIVE_EFFECT"),
+            }]);
+        } catch (e) {
+            errs.push((e as Error).message);
+        }
+
+        const effects = [...weapon.effects.contents];
+        const out = {
+            errs,
+            count: effects.length,
+            firstName: effects[0]?.name ?? null,
+        };
+        await weapon.delete();
+        return out;
+    });
+
+    expect(result.errs, "AE create errors").toEqual([]);
+    expect(result.count).toBe(1);
+    expect(result.firstName).toBeTruthy();
+});
+
+test("actor effect can be toggled and deleted from the sheet (#165)", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        // fresh actor
+        const stale = window.game.actors.filter((a: any) => a.name === "smoke-effect-actor")
+            .map((a: any) => a.id);
+        if (stale.length) await window.Actor.deleteDocuments(stale);
+        const actor = await window.Actor.create(
+            {name: "smoke-effect-actor", type: "character"},
+            {render: false},
+        );
+
+        // seed an actor-embedded effect (the same shape a legacy world would
+        // have produced by copying a transferred item effect onto the actor)
+        const [effect] = await actor.createEmbeddedDocuments("ActiveEffect", [{
+            name: "smoke-effect",
+            disabled: false,
+        }]);
+        const initialDisabled = effect.disabled;
+
+        // exercise the toggle handler the way the .effect-toggle click would
+        await effect.update({disabled: !effect.disabled});
+        const afterToggle = actor.effects.get(effect.id).disabled;
+
+        // exercise the delete handler the way the .effect-delete click would
+        await actor.deleteEmbeddedDocuments("ActiveEffect", [effect.id]);
+        const afterDelete = actor.effects.get(effect.id);
+
+        await actor.delete();
+
+        return {initialDisabled, afterToggle, afterDelete: afterDelete ?? null};
+    });
+
+    expect(result.initialDisabled).toBe(false);
+    expect(result.afterToggle).toBe(true);
+    expect(result.afterDelete).toBeNull();
+});
+
+test("deleting an item also removes orphan actor effects whose origin is the item (#165)", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const stale = window.game.actors.filter((a: any) => a.name === "smoke-orphan-actor")
+            .map((a: any) => a.id);
+        if (stale.length) await window.Actor.deleteDocuments(stale);
+        const actor = await window.Actor.create(
+            {name: "smoke-orphan-actor", type: "character"},
+            {render: false},
+        );
+
+        // create an item embedded on the actor
+        const [item] = await actor.createEmbeddedDocuments("Item", [
+            {name: "smoke-orphan-weapon", type: "weapon"},
+        ]);
+
+        // simulate the legacy / drops.ts code-path that copies an effect onto
+        // the actor with origin pointing at the source item
+        await actor.createEmbeddedDocuments("ActiveEffect", [{
+            name: "smoke-orphan-effect",
+            origin: item.uuid,
+        }]);
+        const beforeDelete = actor.effects.size;
+
+        // deleting the item must trigger preDeleteItem orphan cleanup
+        await item.delete();
+
+        // hook fires async; give it a tick
+        await new Promise((r) => setTimeout(r, 100));
+        const afterDelete = actor.effects.size;
+
+        await actor.delete();
+
+        return {beforeDelete, afterDelete};
+    });
+
+    expect(result.beforeDelete).toBe(1);
+    expect(result.afterDelete).toBe(0);
+});

--- a/tests/smoke/tier-3-active-effects.spec.ts
+++ b/tests/smoke/tier-3-active-effects.spec.ts
@@ -17,7 +17,7 @@
 import {test, expect} from "@playwright/test";
 import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
 
-test("addEffect helper creates an ActiveEffect with name field (#164)", async ({page}) => {
+test("item-sheet `+` button creates an ActiveEffect via addEffect helper (#164)", async ({page}) => {
     await loginAndWaitReady(page);
 
     const result = await evalInWorld(page, async () => {
@@ -31,34 +31,49 @@ test("addEffect helper creates an ActiveEffect with name field (#164)", async ({
         );
 
         const errs: string[] = [];
-        try {
-            await weapon.createEmbeddedDocuments("ActiveEffect", [{
-                name: window.game.i18n.localize("OD6S.NEW_ACTIVE_EFFECT"),
-            }]);
-        } catch (e) {
-            errs.push((e as Error).message);
-        }
+        const onRej = (e: PromiseRejectionEvent) =>
+            errs.push("rej: " + (e.reason?.message ?? String(e.reason)));
+        window.addEventListener("unhandledrejection", onRej);
+
+        await weapon.sheet.render(true);
+        await new Promise((r) => setTimeout(r, 250));
+
+        // Switch to effects tab if necessary, then click `.effect-add` —
+        // this is the click path exercising item-sheet-helpers/effects.ts
+        const root = weapon.sheet.element as HTMLElement;
+        const effectsTab = root.querySelector('a[data-tab="effects"]') as HTMLElement | null;
+        effectsTab?.click();
+        await new Promise((r) => setTimeout(r, 100));
+
+        const addBtn = root.querySelector('.effect-add') as HTMLElement | null;
+        const hadButton = !!addBtn;
+        addBtn?.click();
+        await new Promise((r) => setTimeout(r, 400));
+
+        window.removeEventListener("unhandledrejection", onRej);
 
         const effects = [...weapon.effects.contents];
         const out = {
             errs,
+            hadButton,
             count: effects.length,
             firstName: effects[0]?.name ?? null,
         };
+        await weapon.sheet.close();
         await weapon.delete();
         return out;
     });
 
-    expect(result.errs, "AE create errors").toEqual([]);
+    expect(result.hadButton, ".effect-add button rendered").toBe(true);
+    expect(result.errs, "no validation rejections").toEqual([]);
     expect(result.count).toBe(1);
     expect(result.firstName).toBeTruthy();
 });
 
-test("actor effect can be toggled and deleted from the sheet (#165)", async ({page}) => {
+test("actor sheet `.effect-toggle` and `.effect-delete` controls round-trip via the DOM (#165)", async ({page}) => {
     await loginAndWaitReady(page);
 
     const result = await evalInWorld(page, async () => {
-        // fresh actor
         const stale = window.game.actors.filter((a: any) => a.name === "smoke-effect-actor")
             .map((a: any) => a.id);
         if (stale.length) await window.Actor.deleteDocuments(stale);
@@ -67,30 +82,53 @@ test("actor effect can be toggled and deleted from the sheet (#165)", async ({pa
             {render: false},
         );
 
-        // seed an actor-embedded effect (the same shape a legacy world would
-        // have produced by copying a transferred item effect onto the actor)
         const [effect] = await actor.createEmbeddedDocuments("ActiveEffect", [{
             name: "smoke-effect",
             disabled: false,
         }]);
-        const initialDisabled = effect.disabled;
+        const effectId = effect.id;
 
-        // exercise the toggle handler the way the .effect-toggle click would
-        await effect.update({disabled: !effect.disabled});
-        const afterToggle = actor.effects.get(effect.id).disabled;
+        // Render the sheet and exercise the toggle/delete via DOM clicks
+        // — the regression was these controls being missing on the
+        // special-abilities tab and silently no-op on the data tab.
+        await actor.sheet.render(true);
+        await new Promise((r) => setTimeout(r, 300));
+        const root = actor.sheet.element as HTMLElement;
 
-        // exercise the delete handler the way the .effect-delete click would
-        await actor.deleteEmbeddedDocuments("ActiveEffect", [effect.id]);
-        const afterDelete = actor.effects.get(effect.id);
+        const toggleBtn = root.querySelector(
+            `.effect-toggle[data-effect-id="${effectId}"]`,
+        ) as HTMLElement | null;
+        const hadToggle = !!toggleBtn;
+        toggleBtn?.click();
+        // Poll until disabled flips (or timeout) to avoid CI flake.
+        const start = Date.now();
+        while (actor.effects.get(effectId)?.disabled !== true && Date.now() - start < 2000) {
+            await new Promise((r) => setTimeout(r, 50));
+        }
+        const afterToggle = actor.effects.get(effectId)?.disabled;
 
+        // Re-find the delete button after the toggle re-render
+        const deleteBtn = (actor.sheet.element as HTMLElement).querySelector(
+            `.effect-delete[data-effect-id="${effectId}"]`,
+        ) as HTMLElement | null;
+        const hadDelete = !!deleteBtn;
+        deleteBtn?.click();
+        const start2 = Date.now();
+        while (actor.effects.get(effectId) && Date.now() - start2 < 2000) {
+            await new Promise((r) => setTimeout(r, 50));
+        }
+        const afterDelete = actor.effects.get(effectId) ?? null;
+
+        await actor.sheet.close();
         await actor.delete();
 
-        return {initialDisabled, afterToggle, afterDelete: afterDelete ?? null};
+        return {hadToggle, hadDelete, afterToggle, afterDelete};
     });
 
-    expect(result.initialDisabled).toBe(false);
-    expect(result.afterToggle).toBe(true);
-    expect(result.afterDelete).toBeNull();
+    expect(result.hadToggle, ".effect-toggle rendered").toBe(true);
+    expect(result.hadDelete, ".effect-delete rendered").toBe(true);
+    expect(result.afterToggle, "toggle flipped disabled").toBe(true);
+    expect(result.afterDelete, "delete removed the effect").toBeNull();
 });
 
 test("deleting an item also removes orphan actor effects whose origin is the item (#165)", async ({page}) => {
@@ -105,24 +143,26 @@ test("deleting an item also removes orphan actor effects whose origin is the ite
             {render: false},
         );
 
-        // create an item embedded on the actor
         const [item] = await actor.createEmbeddedDocuments("Item", [
             {name: "smoke-orphan-weapon", type: "weapon"},
         ]);
 
-        // simulate the legacy / drops.ts code-path that copies an effect onto
-        // the actor with origin pointing at the source item
+        // Simulate the legacy / drops.ts code-path that copies an effect onto
+        // the actor with origin pointing at the source item.
         await actor.createEmbeddedDocuments("ActiveEffect", [{
             name: "smoke-orphan-effect",
             origin: item.uuid,
         }]);
         const beforeDelete = actor.effects.size;
 
-        // deleting the item must trigger preDeleteItem orphan cleanup
         await item.delete();
 
-        // hook fires async; give it a tick
-        await new Promise((r) => setTimeout(r, 100));
+        // Poll for the orphan-cleanup hook to settle instead of a fixed sleep
+        // so the test stays deterministic under CI load.
+        const start = Date.now();
+        while (actor.effects.size > 0 && Date.now() - start < 2000) {
+            await new Promise((r) => setTimeout(r, 50));
+        }
         const afterDelete = actor.effects.size;
 
         await actor.delete();


### PR DESCRIPTION
## Summary

Resolves three bugs reported in #165 on the actor sheet's Special Abilities tab.

1. **No way to delete an existing ActiveEffect.** `special-abilities.html` rendered each effect with only an edit hover div — no trash button.
2. **No way to enable / disable an effect.** No toggle control existed on either tab; nothing in the system flipped `effect.disabled` from the UI.
3. **Deleting the source item left its actor-side effect orphaned.** `drops.ts` and legacy worlds create actor-embedded effects whose `origin` points at the source item, but no cleanup runs on item deletion.

While here, two adjacent latent bugs fixed inline:

- The data-tab trash button had its listener attached only when the sheet was in EDIT mode. V2 sheets default to PLAY mode, so the icon appeared but did nothing. `registerEffectListeners` is now wired alongside roll listeners (above the `isEditable` gate) — effect management is a play-mode action.
- `data.html` had `data-effect-id="effect.id"` (missing Handlebars braces) on the `<li>`, so every list item shared the literal string `"effect.id"`.
- `special-abilities.html` still rendered a `{{effect.label}}` fallback (Foundry v11 renamed `label` → `name`). Dropped.

## Changes

- `sheet-listeners/effects.ts` — new `.effect-toggle` handler.
- `actor-sheet.ts` — `registerEffectListeners` moved above the editable gate.
- `special-abilities.html` — edit/toggle/delete control bar; drop `effect.label`.
- `data.html` — add toggle; fix the `effect.id` typo.
- `actor-hooks.ts` — `preDeleteItem` hook deletes actor effects whose `origin` is the item being deleted.
- `en.json` — add `OD6S.TOGGLE_EFFECT`.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 209 warnings, well under the 720 CI threshold
- [x] `pnpm run test` — 414/414 pass
- [x] `tests/smoke/tier-3-active-effects.spec.ts` (new) — 3 specs cover add (also locks in #164), toggle + delete, and orphan cleanup
- [x] Full smoke suite — **53/53** pass
- [ ] Manual: open a character's Special Abilities tab, add an effect to an item, verify edit/toggle/delete all work
- [ ] Manual: delete the source item, verify the actor-side effect is gone

Closes #165