### PR TITLE
fix(metaphysics): add manifestation `+` button on character sheet

### DIFF
--- a/src/templates/actor/character/tabs/metaphysics.html
+++ b/src/templates/actor/character/tabs/metaphysics.html
@@ -103,8 +103,14 @@
             </div>
         </div>
         <div class="column">
-            <div>
+            <div class="grid title-add-grid">
                 <div class="flexrow flex-group-center"><b>{{getManifestationsName}}</b></div>
+                <div class="flexrow flex-group-center item-controls"
+                     title="{{localize 'OD6S.ADD'}} {{localize 'OD6S.MANIFESTATION'}}">
+                    <a class="item-add"
+                       data-type="manifestation">
+                        <i class="fas fa-plus"></i></a>
+                </div>
             </div>
             <div class="manifestations">
                 <ul class="manifestations-list">

--- a/tests/smoke/tier-3-metaphysics.spec.ts
+++ b/tests/smoke/tier-3-metaphysics.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Tier 3 — Metaphysics tab manifestation management.
+ *
+ * Regression covered:
+ *
+ *   #163 — The Manifestations column on the character sheet's Metaphysics
+ *          tab had no `+` button, so users couldn't add new manifestations
+ *          via UI. The shipped compendia have no manifestations to drag in
+ *          either, leaving the feature inaccessible.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("metaphysics tab renders an add-manifestation button wired to .item-add (#163)", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const stale = window.game.actors.filter((a: any) => a.name === "smoke-metaphysics-actor")
+            .map((a: any) => a.id);
+        if (stale.length) await window.Actor.deleteDocuments(stale);
+
+        const actor = await window.Actor.create(
+            {name: "smoke-metaphysics-actor", type: "character"},
+            {render: false},
+        );
+
+        // metaphysics tab is only rendered when metaphysicsextranormal is on
+        await actor.update({"system.metaphysicsextranormal.value": true});
+
+        await actor.sheet.render(true);
+        await new Promise((r) => setTimeout(r, 300));
+
+        const root = actor.sheet.element as HTMLElement;
+        const metaTab = root.querySelector('a[data-tab="metaphysics"]') as HTMLElement | null;
+        const hadMetaTab = !!metaTab;
+        metaTab?.click();
+        await new Promise((r) => setTimeout(r, 100));
+
+        const addBtn = root.querySelector(
+            '.tab.meta .item-add[data-type="manifestation"]',
+        ) as HTMLElement | null;
+        const hadAddBtn = !!addBtn;
+
+        await actor.sheet.close();
+        await actor.delete();
+
+        return {hadMetaTab, hadAddBtn};
+    });
+
+    expect(result.hadMetaTab, "metaphysics tab rendered with extranormal enabled").toBe(true);
+    expect(result.hadAddBtn, ".item-add[data-type=manifestation] present").toBe(true);
+});


### PR DESCRIPTION
## Summary

- The Manifestations column on the character sheet's Metaphysics tab rendered only the heading — no add affordance. The shipped compendia have no manifestations to drag in either, so users had no UI path to create one.
- Add a `.item-add[data-type="manifestation"]` button matching the inventory-tab pattern.
- The existing `.item-add` click listener in `sheet-listeners/inventory.ts` routes to `addItem`, which opens `OD6SAddItem` filtered to the manifestation type. `manifestation` is already in `allowedItemTypes.character`, so no further wiring is needed.

Closes #163

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] New smoke spec `tests/smoke/tier-3-metaphysics.spec.ts` — passes locally
- [ ] Manual: open a character sheet, enable Metaphysics, switch to the tab, click `+` next to Manifestations, verify the add-item dialog opens filtered to manifestations