### PR TITLE
fix(settings): opt-in workaround for sheet click → canvas ping bleed

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -534,6 +534,8 @@
   "OD6S.CONFIG_HIDE_SKILL_ROLLS": "Hide skill rolls until resolved",
   "OD6S.CONFIG_HIGHLIGHT_EFFECTS_DESCRIPTION": "Provide a green or red highlight to Attribute, Skill or Specialization scores that have been modified by an active effect.",
   "OD6S.CONFIG_HIGHLIGHT_EFFECTS": "Highlight Active Effects",
+  "OD6S.CONFIG_BLOCK_SHEET_POINTER_BLEED": "Block sheet clicks from reaching the canvas",
+  "OD6S.CONFIG_BLOCK_SHEET_POINTER_BLEED_DESCRIPTION": "Stops mousedown events that originate on a sheet or dialog from bubbling up to window-level listeners. Workaround for the `Pings` module (and similar) firing a canvas ping when you long-click on a character sheet under Foundry v14, where sheets mount to document.body and aren't seen as 'over the UI' by those modules. Enable only if you have a misbehaving module of this shape.",
   "OD6S.CONFIG_INITIAL_ATTRIBUTES_DESCRIPTION": "The total number of attribute pips available on character creation",
   "OD6S.CONFIG_INITIAL_ATTRIBUTES": "Initial Attribute Score",
   "OD6S.CONFIG_INITIAL_CHARACTER_POINTS_DESCRIPTION": "Starting Character Points for new characters",

--- a/src/module/config/settings/display.ts
+++ b/src/module/config/settings/display.ts
@@ -1,4 +1,5 @@
 import OD6S from "../config-od6s";
+import {applySheetPointerBleedSetting} from "../../system/sheet-pointer-bleed";
 
 export function applySheetBackgroundOpacity(value: number): void {
     const clamped = Number.isFinite(value) ? Math.max(0, Math.min(2, value)) : 1;
@@ -107,6 +108,18 @@ export function registerDisplaySettings() {
     });
 
     applySheetBackgroundOpacity(game.settings.get('od6s', 'sheet_background_opacity') as number);
+
+    game.settings.register("od6s", "block_sheet_pointer_bleed", {
+        name: game.i18n.localize('OD6S.CONFIG_BLOCK_SHEET_POINTER_BLEED'),
+        hint: game.i18n.localize('OD6S.CONFIG_BLOCK_SHEET_POINTER_BLEED_DESCRIPTION'),
+        scope: "client",
+        config: true,
+        default: false,
+        type: Boolean,
+        onChange: (value: boolean) => applySheetPointerBleedSetting(value),
+    });
+
+    applySheetPointerBleedSetting(game.settings.get('od6s', 'block_sheet_pointer_bleed') as boolean);
 
     game.settings.register("od6s", "show_metaphysics_attributes", {
         name: game.i18n.localize('OD6S.CONFIG_SHOW_METAPHYSICS_ATTRIBUTES'),

--- a/src/module/system/sheet-pointer-bleed.ts
+++ b/src/module/system/sheet-pointer-bleed.ts
@@ -1,0 +1,38 @@
+/**
+ * Optional workaround for module conflicts where global `mousedown` listeners
+ * on `window` fire while the user is clicking on an OD6S sheet/dialog (#166).
+ *
+ * The known instance is the `Pings` module (foundry-azzurite/pings v1.4.3),
+ * which tracks "is the cursor over `#interface`?" via mouseenter / mouseleave
+ * on `#interface`. In Foundry v14, `ApplicationV2._insertElement` mounts
+ * windows to `document.body` directly (foundry.mjs ~30486), so sheets are
+ * siblings of `#interface`, not descendants. The Pings flag stays false over
+ * sheets and its window-level `mousedown` listener triggers a canvas ping.
+ *
+ * Behavior when enabled: a `mousedown` listener on `document.body` in the
+ * bubble phase intercepts events that originate inside any application
+ * element (any `.application` or `<dialog>`) and calls `stopPropagation`,
+ * preventing the window-level listener from firing. Listeners attached *on*
+ * the sheet itself (in capture or bubble) still fire as normal because they
+ * run before the body-level listener; only the path between body → document
+ * → window is blocked.
+ */
+
+let attached: ((ev: MouseEvent) => void) | null = null;
+
+function blockBleed(ev: MouseEvent): void {
+    const t = ev.target as HTMLElement | null;
+    if (t?.closest('.application, dialog')) {
+        ev.stopPropagation();
+    }
+}
+
+export function applySheetPointerBleedSetting(enabled: boolean): void {
+    if (enabled && !attached) {
+        attached = blockBleed;
+        document.body.addEventListener('mousedown', attached, false);
+    } else if (!enabled && attached) {
+        document.body.removeEventListener('mousedown', attached, false);
+        attached = null;
+    }
+}

--- a/tests/smoke/tier-3-sheet-pointer-bleed.spec.ts
+++ b/tests/smoke/tier-3-sheet-pointer-bleed.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Tier 3 — Optional sheet-pointer-bleed workaround.
+ *
+ * Regression covered:
+ *
+ *   #166 — Modules with window-level `mousedown` listeners (the `Pings`
+ *          module is the reported case) fire on clicks over OD6S sheets
+ *          under Foundry v14, because ApplicationV2 windows mount to
+ *          `document.body` rather than `#interface`. The
+ *          `block_sheet_pointer_bleed` client setting installs a
+ *          body-level bubble-phase listener that stops `mousedown`
+ *          propagation when the event originated inside a sheet/dialog.
+ *
+ * The test installs a stand-in window-level `mousedown` listener
+ * (representing the misbehaving module) and verifies it does NOT fire
+ * for a click on a rendered sheet while the setting is enabled, and
+ * DOES fire when the setting is disabled.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("block_sheet_pointer_bleed stops mousedown from reaching window listeners (#166)", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const stale = window.game.actors.filter((a: any) => a.name === "smoke-bleed-actor")
+            .map((a: any) => a.id);
+        if (stale.length) await window.Actor.deleteDocuments(stale);
+
+        const actor = await window.Actor.create(
+            {name: "smoke-bleed-actor", type: "character"},
+            {render: false},
+        );
+        await actor.sheet.render(true);
+        await new Promise((r) => setTimeout(r, 300));
+
+        const root = actor.sheet.element as HTMLElement;
+
+        let windowHits = 0;
+        const windowListener = () => { windowHits++; };
+        window.addEventListener("mousedown", windowListener, false);
+
+        const dispatch = () => root.dispatchEvent(
+            new MouseEvent("mousedown", {bubbles: true, cancelable: true}),
+        );
+
+        // 1) Setting OFF — bubble reaches window
+        await window.game.settings.set("od6s", "block_sheet_pointer_bleed", false);
+        windowHits = 0;
+        dispatch();
+        const offHits = windowHits;
+
+        // 2) Setting ON — body-level listener stops propagation
+        await window.game.settings.set("od6s", "block_sheet_pointer_bleed", true);
+        windowHits = 0;
+        dispatch();
+        const onHits = windowHits;
+
+        // 3) Click outside any sheet should NOT be blocked even when ON
+        windowHits = 0;
+        document.body.dispatchEvent(
+            new MouseEvent("mousedown", {bubbles: true, cancelable: true}),
+        );
+        const offSheetHits = windowHits;
+
+        // teardown
+        window.removeEventListener("mousedown", windowListener, false);
+        await window.game.settings.set("od6s", "block_sheet_pointer_bleed", false);
+        await actor.sheet.close();
+        await actor.delete();
+
+        return {offHits, onHits, offSheetHits};
+    });
+
+    expect(result.offHits, "setting off: window listener fires").toBe(1);
+    expect(result.onHits, "setting on: window listener blocked").toBe(0);
+    expect(result.offSheetHits, "setting on: clicks outside sheets still bubble").toBe(1);
+});


### PR DESCRIPTION
## Summary

Resolves #166. The `Pings` module ([foundry-azzurite/pings](https://gitlab.com/foundry-azzurite/pings) v1.4.3, last release June 2025) installs a window-level `mousedown` listener gated by tracking whether the cursor is over `#interface`. In Foundry v14, `ApplicationV2._insertElement` (foundry.mjs ~30486) mounts windows to `document.body` directly — siblings of `#interface`, not descendants — so the module's "over interface" check stays `false` while the cursor is over a sheet. A long-press on a character sheet then triggers a canvas ping.

Upstream module appears unmaintained for v14 and exposes no API to suppress its listener.

## Fix

Opt-in client setting `block_sheet_pointer_bleed` (default **off**). When enabled, a `document.body` bubble-phase `mousedown` listener calls `stopPropagation` for events that originated inside any `.application` or `<dialog>` element. The window-level listener (Pings, or any module of similar shape) never sees those events. Clicks on the canvas (target outside any application) are untouched.

## Why opt-in

Globally blocking sheet→window event propagation could break other modules that legitimately need to see those events. Users only enable this when they're actually affected.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 414/414 unit pass
- [x] `tests/smoke/tier-3-sheet-pointer-bleed.spec.ts` (new) — verifies a stand-in window-level mousedown listener fires when the setting is off, doesn't fire on sheet clicks when on, and still fires for clicks outside any sheet
- [x] Full Playwright smoke — **55/55** pass
- [ ] Manual: enable Pings module + the new setting, long-click on a character sheet, verify no ping. Disable the setting, verify ping returns.

Closes #166