### PR TITLE
fix(sheet): set type=button on header buttons to stop Enter-key submit

### DIFF
--- a/src/templates/actor/character/header-sheet.html
+++ b/src/templates/actor/character/header-sheet.html
@@ -14,7 +14,7 @@
                        data-dtype="{{actor.system.chartype.type}}"/>
                 {{#if (eq actor.system.created.value false)}}
                     {{#if (displayCharacterTemplateClear actor)}}
-                        <button class="reset-template">{{localize 'OD6S.CLEAR'}}</button>
+                        <button type="button" class="reset-template">{{localize 'OD6S.CLEAR'}}</button>
                     {{/if}}
                 {{/if}}
                 </div>
@@ -34,7 +34,7 @@
                        data-dtype="{{actor.system.species.type}}"/>
                 {{#if (eq actor.system.sheetmode.value "freeedit")}}
                     {{#if (displaySpeciesTemplateClear actor)}}
-                        <button class="reset-species-template">{{localize 'OD6S.CLEAR'}}</button>
+                        <button type="button" class="reset-species-template">{{localize 'OD6S.CLEAR'}}</button>
                     {{/if}}
                 {{/if}}
                 </div>
@@ -179,7 +179,7 @@
         {{/if}}
         {{#if (eq actor.system.created.value false)}}
             <div class="flexrow flex-group-center creation">
-                <button class="create-character">{{localize 'OD6S.CREATE'}}</button>
+                <button type="button" class="create-character">{{localize 'OD6S.CREATE'}}</button>
             </div>
         {{/if}}
     </div>

--- a/src/templates/actor/common/tabs/data.html
+++ b/src/templates/actor/common/tabs/data.html
@@ -122,7 +122,7 @@
                 {{/each}}
             </ul>
 
-            <button class="vehicle-exit">{{localize 'OD6S.REMOVE_FROM_VEHICLE'}}</button>
+            <button type="button" class="vehicle-exit">{{localize 'OD6S.REMOVE_FROM_VEHICLE'}}</button>
 
             <h2>{{localize 'OD6S.ACTOR_EFFECTS'}}</h2>
             <ul class="effects-list">

--- a/src/templates/actor/npc/header-sheet.html
+++ b/src/templates/actor/npc/header-sheet.html
@@ -29,7 +29,7 @@
                        data-dtype="{{actor.system.species.type}}"/>
                 {{#if (eq actor.system.sheetmode.value "freeedit")}}
                     {{#if (displaySpeciesTemplateClear actor)}}
-                        <button class="reset-species-template">{{localize 'OD6S.CLEAR'}}</button>
+                        <button type="button" class="reset-species-template">{{localize 'OD6S.CLEAR'}}</button>
                     {{/if}}
                 {{/if}}
                 </div>


### PR DESCRIPTION
## Summary

- Five `<button>` elements inside the actor-sheet `<form>` lacked an explicit `type` attribute. HTML defaults type-less buttons to `type=\"submit\"`, so pressing **Enter** in any text input on the sheet implicit-submits the form and clicks the first one.
- On a not-yet-created character that first button is `.create-character` → opens the creation dialog → its `close()` path (`src/module/apps/character-creation.ts:471-481`) calls `_onClearCharacterTemplate()` and `deleteEmbeddedDocuments(\"Item\", actor.items.map(...))` if the dialog isn't taken through Finish. Skills disappear.
- Adds `type=\"button\"` to all five offenders. No behavior change for click handlers.

Closes #174. Related: #159 (the original \"sheet reset\" symptom report from owlsten).

## Affected buttons

- `src/templates/actor/character/header-sheet.html:182` — `.create-character` (fires immediately, wipes items if dialog closed)
- `src/templates/actor/common/tabs/data.html:125` — `.vehicle-exit` (fires immediately, clears `crew` flag)
- `src/templates/actor/character/header-sheet.html:17` — `.reset-template` (confirm-gated)
- `src/templates/actor/character/header-sheet.html:37` — `.reset-species-template` (confirm-gated)
- `src/templates/actor/npc/header-sheet.html:32` — `.reset-species-template` (confirm-gated)

Chat templates also have type-less `<button>`s but are not inside `<form>`s, so they're unaffected.

## Test plan

- [ ] Open a character sheet for an actor whose `system.created.value` is `false` so the Create button renders.
- [ ] Click the name input, type a few characters, press **Enter**. Verify the Create dialog does *not* open and items are intact.
- [ ] Repeat with focus in the chartype field (next to `.reset-template`) and species field (next to `.reset-species-template`).
- [ ] On a vehicle-crewed actor, press **Enter** in any data-tab input and confirm the actor isn't booted from the vehicle.
- [ ] Sanity: clicking each of the 5 buttons still works as before.