### PR TITLE
fix(roll): correctness bugs from code review (#178)

### DIFF
--- a/src/module/apps/character-creation.ts
+++ b/src/module/apps/character-creation.ts
@@ -193,7 +193,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 if (!skill) return;
                 this.skillScore = applySkillDelete(skill.system.base, this.skillScore);
                 await this.actor.sheet.deleteItem(ev);
-                await this.actor.sheet.getData();
                 await this.render();
             });
         });
@@ -218,7 +217,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 this.skillScore = updated.skillScore;
                 this.specScore = updated.specScore;
                 await this.actor.sheet.deleteItem(ev);
-                await this.actor.sheet.getData();
                 await this.render();
             });
         });
@@ -245,7 +243,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                         updates.push({_id: spec.id, "system.base": spec.system.base + 1});
                     }
                     await this.actor.updateEmbeddedDocuments("Item", updates);
-                    await this.actor.sheet.getData();
                     this.skillScore = this.skillScore - 1;
                 }
                 await this.render();
@@ -260,7 +257,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 const spec = this.actor.items.find((i: Item) => i._id === target.dataset.itemId);
                 if (spec) {
                     await spec.update({"system.base": (+target.dataset.base!) + 1});
-                    await this.actor.sheet.getData();
                     this.specScore = this.specScore - 1;
                 }
                 await this.render();
@@ -287,7 +283,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                         updates.push({_id: spec.id, "system.base": spec.system.base - 1});
                     }
                     await this.actor.updateEmbeddedDocuments("Item", updates);
-                    await this.actor.sheet.getData();
                     this.skillScore = this.skillScore + 1;
                 }
                 await this.render();
@@ -302,7 +297,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
                 const spec = this.actor.items.find((i: Item) => i._id === target.dataset.itemId);
                 if (spec) {
                     await spec.update({"system.base": (+target.dataset.base!) - 1});
-                    await this.actor.sheet.getData();
                     this.specScore = this.specScore + 1;
                 }
                 await this.render();
@@ -390,7 +384,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             const template = await od6sutilities.getItemByName(
                 this.characterTemplates.find((i) => i._id === this.selectedTemplate)!.name);
             await this.actor.sheet._addCharacterTemplate(template);
-            await this.actor.sheet.getData();
         }
         this.step = this.step + 1;
         await this.render();
@@ -456,7 +449,6 @@ export default class OD6SCreateCharacter extends HandlebarsApplicationMixin(Appl
             },
         };
         await this.actor.createEmbeddedDocuments("Item", [newItemData]);
-        await this.actor.sheet.getData();
 
         if (this.specScore === 0) {
             this.specScore = (OD6S.pipsPerDice * OD6S.specStartingPipsPerDie) - add;

--- a/src/module/apps/roll-helpers/roll-difficulty.ts
+++ b/src/module/apps/roll-helpers/roll-difficulty.ts
@@ -180,7 +180,7 @@ export function applyDifficultyEffects(rollData: RollData): Modifier[] {
 
     if (rollData.subtype === 'rangedattack' ||
         rollData.subtype === 'vehiclerangedattack' ||
-        rollData.subtype === 'vehcilerangedweaponattack') {
+        rollData.subtype === 'vehiclerangedweaponattack') {
         if (!OD6S.mapRange && OD6S.ranges[mods.range].difficulty) {
             modifiers.push({
                 "name": game.i18n.localize(OD6S.ranges[mods.range].name),
@@ -321,7 +321,7 @@ export function applyDamageEffects(rollData: RollData): Modifier[] {
 
     if (rollData.subtype === 'rangedattack' ||
         rollData.subtype === 'vehiclerangedattack' ||
-        rollData.subtype === 'vehcilerangedweaponattack') {
+        rollData.subtype === 'vehiclerangedweaponattack') {
         if (OD6S.rangedAttackOptions[mods.attackoption].damage) {
             let value;
             if (OD6S.rangedAttackOptions[mods.attackoption].multi) {

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -317,7 +317,9 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     if (typeof (rollData.vehicle) !== 'undefined' && rollData.vehicle !== ''
         && (rollData.actor.type !== 'vehicle' && rollData.actor.type !== 'starship')) {
         const vehicle = await od6sutilities.getActorFromUuid(rollData.vehicle);
-        label = label + " " + game.i18n.localize('NONEX_IST_OD6S.FOR') + " " + vehicle!.name;
+        if (vehicle) {
+            label = label + " " + game.i18n.localize('NONEX_IST_OD6S.FOR') + " " + vehicle.name;
+        }
     }
 
     let useWildDie;
@@ -325,11 +327,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     if(!game.settings.get('nonex-ist-od6s', 'use_wild_die')) {
         useWildDie = false;
     } else {
-        if(!rollData.wilddie) {
-            useWildDie = rollData.wilddie;
-        } else {
-            useWildDie = rollData.actor.system.use_wild_die;
-        }
+        useWildDie = rollData.wilddie;
     }
 
     if (useWildDie && rollMin < 1) {


### PR DESCRIPTION
Closes #178 (correctness section).

## Summary
- **roll-difficulty**: fix `vehcilerangedweaponattack` typo (lines 183, 324) that silently disabled range-to-difficulty mapping and ranged-attack damage modifiers for vehicle-borne weapon rolls. Canonical spelling `vehiclerangedweaponattack` is used everywhere else (item dispatch, roll-handlers, tests).
- **roll-execute** (l.323-333): drop the inverted inner branch. The dialog's wild-die checkbox now controls the wild die directly. Previously, unticking resolved to `false` (via `useWildDie = rollData.wilddie` inside `if (!rollData.wilddie)`) and ticking deferred to `actor.system.use_wild_die` — so the dialog toggle did the opposite of what it appeared to do.
- **roll-execute** (l.319): guard the `getActorFromUuid()` result before reading `.name`. A stale/deleted vehicle UUID no longer aborts chat-card rendering with `Cannot read properties of undefined`.
- **character-creation**: remove 8 dead `await this.actor.sheet.getData()` calls. `getData()` does not exist on ApplicationV2 sheets, and the following `this.render()` already refreshes state.

Cleanup items #5–#8 from #178 (deadliness dedup, dead wrapper, inline type checks, damage rules in chat listener) intentionally left for separate PRs.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 414/414 pass
- [x] `pnpm run test:domain` — 327/327 pass
- [x] `pnpm run lint` — 0 errors (210 pre-existing warnings, under 720 CI threshold)
- [ ] Manual smoke: roll a vehicle-borne ranged weapon at long range with an attack option that has a damage modifier; verify range difficulty and damage modifier apply.
- [ ] Manual smoke: open the roll dialog, untick wild die → wild die does not roll; tick → it does.
- [ ] Manual smoke: link a weapon to a vehicle, delete the vehicle, roll the weapon — chat card renders without the "for <vehicle>" suffix instead of throwing.
- [ ] Manual smoke: in character creation, add/remove/increase/decrease a skill and confirm the dialog UI updates as before.