### PR TITLE
refactor: extract helpers flagged by code review (#178)

### DIFF
--- a/src/module/actor/actor-helpers/wounds.ts
+++ b/src/module/actor/actor-helpers/wounds.ts
@@ -4,7 +4,6 @@ import {
     findWoundLevelByCore,
     computeNewDamageLevel,
     computeNewWoundLevel,
-    type DeadlinessRow,
 } from "./wounds-math";
 import {isArmorItem, isCharacterActor, isVehicleActor} from "../../system/type-guards";
 import {debug} from "../../system/logger";
@@ -148,10 +147,6 @@ export async function applyIncapacitatedFailure(actor: Actor): Promise<void> {
     if (game.modules.get("dice-so-nice")?.active) game.dice3d.messageHookDisabled = false;
 
     await actor.toggleStatusEffect('unconscious', {overlay: false, active: true});
-}
-
-export function findFirstWoundLevel(_actor: Actor, table: Record<string, DeadlinessRow>, wound: string): string | undefined {
-    return findWoundLevelByCore(table, wound);
 }
 
 export function getWoundLevelFromBodyPoints(actor: Actor, bp?: number): string | undefined {

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -7,7 +7,7 @@ import {warnIfSchemaVersionMismatch, SCHEMA_VERSION_KEY} from "../system/schema-
 import {resolveRollAction} from "./actor-helpers/roll-action";
 import {prepareBaseActorData, prepareDerivedActorData, applyMods as applyModsHelper, setStrengthDamageBonus as setStrengthDamageBonusHelper, setInitiative as setInitiativeHelper, setResistance as setResistanceHelper} from "./actor-helpers/prepare-actor";
 import type {ResistanceKey} from "./actor-helpers/prepare-actor";
-import {applyDamage as applyDamageHelper, calculateNewDamageLevel as calculateNewDamageLevelHelper, applyWounds as applyWoundsHelper, calculateNewWoundLevel as calculateNewWoundLevelHelper, triggerMortallyWoundedCheck as triggerMortallyWoundedCheckHelper, applyMortallyWoundedFailure as applyMortallyWoundedFailureHelper, applyIncapacitatedFailure as applyIncapacitatedFailureHelper, findFirstWoundLevel as findFirstWoundLevelHelper, getWoundLevelFromBodyPoints as getWoundLevelFromBodyPointsHelper, setWoundLevelFromBodyPoints as setWoundLevelFromBodyPointsHelper} from "./actor-helpers/wounds";
+import {applyDamage as applyDamageHelper, calculateNewDamageLevel as calculateNewDamageLevelHelper, applyWounds as applyWoundsHelper, calculateNewWoundLevel as calculateNewWoundLevelHelper, triggerMortallyWoundedCheck as triggerMortallyWoundedCheckHelper, applyMortallyWoundedFailure as applyMortallyWoundedFailureHelper, applyIncapacitatedFailure as applyIncapacitatedFailureHelper, getWoundLevelFromBodyPoints as getWoundLevelFromBodyPointsHelper, setWoundLevelFromBodyPoints as setWoundLevelFromBodyPointsHelper} from "./actor-helpers/wounds";
 import {addEmbeddedPilot as addEmbeddedPilotHelper, addToCrew as addToCrewHelper, _verifyAddToCrew as _verifyAddToCrewHelper, removeFromCrew as removeFromCrewHelper, forceRemoveCrewmember as forceRemoveCrewmemberHelper, isCrewMember as isCrewMemberHelper, sendVehicleData as sendVehicleDataHelper, modifyShields as modifyShieldsHelper, vehicleCollision as vehicleCollisionHelper, onCargoHoldItemCreate as onCargoHoldItemCreateHelper} from "./actor-helpers/crew-vehicle";
 import {useCharacterPointOnRoll as useCharacterPointOnRollHelper} from "./actor-helpers/resources";
 
@@ -231,10 +231,6 @@ export class OD6SActor extends Actor {
 
     async applyIncapacitatedFailure() {
         return applyIncapacitatedFailureHelper(this);
-    }
-
-    findFirstWoundLevel(table: Record<string, { core: string; description?: string; penalty?: number }>, wound: string) {
-        return findFirstWoundLevelHelper(this, table, wound);
     }
 
     calculateNewWoundLevel(wound: string) {

--- a/src/module/apps/roll-helpers/roll-handlers.ts
+++ b/src/module/apps/roll-helpers/roll-handlers.ts
@@ -239,13 +239,17 @@ const purchaseHandler: Handler<'purchase'> = (input) => ({
     seller: input.seller ?? '',
 });
 
+const isVehicleView = (actor: ActorView): actor is VehicleActorView | StarshipActorView =>
+    actor.type === 'vehicle' || actor.type === 'starship';
+
+const isCharacterView = (actor: ActorView): actor is CharacterActorView | NpcActorView =>
+    actor.type === 'character' || actor.type === 'npc';
+
 const vehicleUuidForActor = (actor: ActorView): string =>
-    actor.type === 'vehicle' || actor.type === 'starship'
-        ? actor.uuid
-        : actor.vehicle?.uuid ?? '';
+    isVehicleView(actor) ? actor.uuid : actor.vehicle?.uuid ?? '';
 
 const characterStrengthDamage = (actor: ActorView): number =>
-    (actor.type === 'character' || actor.type === 'npc') ? actor.strengthDamage ?? 0 : 0;
+    isCharacterView(actor) ? actor.strengthDamage ?? 0 : 0;
 
 type WeaponBucketCommon = Pick<RollData,
     'damagetype' | 'damagescore' | 'stundamagetype' | 'stundamagescore' |
@@ -344,7 +348,7 @@ const vehicleWeaponHandler: Handler<'vehicle-weapon'> = (input, ctx) => ({
 // ---- Action family helpers ----
 
 const characterAttributes = (actor: ActorView): Record<string, { score: number }> =>
-    (actor.type === 'character' || actor.type === 'npc') ? actor.attributes ?? {} : {};
+    isCharacterView(actor) ? actor.attributes ?? {} : {};
 
 const characterAttributeScore = (actor: ActorView, key: string): number =>
     characterAttributes(actor)[key]?.score ?? 0;
@@ -352,7 +356,7 @@ const characterAttributeScore = (actor: ActorView, key: string): number =>
 const actorScale = (actor: ActorView): number => actor.scale?.score ?? 0;
 
 const vehicleScaleForActor = (actor: ActorView, ctx: HandlerContext): number =>
-    (actor.type === 'vehicle' || actor.type === 'starship')
+    isVehicleView(actor)
         ? actor.scale?.score ?? 0
         : ctx.vehicleStats?.scale?.score ?? 0;
 
@@ -360,7 +364,7 @@ const vehicleRamForActor = (
     actor: ActorView,
     ctx: HandlerContext,
 ): { ram: number; ramDamage: number } =>
-    (actor.type === 'vehicle' || actor.type === 'starship')
+    isVehicleView(actor)
         ? { ram: actor.ram?.score ?? 0, ramDamage: actor.ram_damage?.score ?? 0 }
         : {
             ram: ctx.vehicleStats?.ram?.score ?? 0,

--- a/src/module/system/utilities/wounds.ts
+++ b/src/module/system/utilities/wounds.ts
@@ -53,34 +53,28 @@ export function lookupInjury(
 // ---- Foundry-dependent wrappers ----
 
 /**
+ * Resolve the deadliness-table index for an actor, honoring the `woundConfig`
+ * override. NOTE: `OD6S.deadlinessLevel[type]` is the cached raw setting and
+ * does NOT apply the `woundConfig === 1` override — prefer this helper.
+ */
+function getDeadlinessLevel(actorType: string): number {
+    if (OD6S.woundConfig === 1) return 3;
+    const settingKey = actorType === 'npc' ? 'npc-deadliness'
+        : actorType === 'creature' ? 'creature-deadliness'
+        : 'deadliness';
+    return game.settings.get('nonex-ist-od6s', settingKey) as number;
+}
+
+/**
  * Get the action penalty from the actor's wound level vs. the system wound levels
  */
 export function getWoundPenalty(actor: Actor): number {
     if (!isCharacterActor(actor)) return 0;
-
-    let deadlinessLevel: number;
-    if (OD6S.woundConfig === 1) {
-        deadlinessLevel = 3;
-    } else {
-        const settingKey = actor.type === 'npc' ? 'npc-deadliness'
-            : actor.type === 'creature' ? 'creature-deadliness'
-            : 'deadliness';
-        deadlinessLevel = game.settings.get('nonex-ist-od6s', settingKey) as number;
-    }
-    return lookupWoundPenalty(OD6S.deadliness[deadlinessLevel], actor.system.wounds.value);
+    return lookupWoundPenalty(OD6S.deadliness[getDeadlinessLevel(actor.type)], actor.system.wounds.value);
 }
 
 export function getWoundLevel(value: number, actor: Actor): string {
-    let deadlinessLevel: number;
-    if (OD6S.woundConfig === 1) {
-        deadlinessLevel = 3;
-    } else {
-        const settingKey = actor.type === 'npc' ? 'npc-deadliness'
-            : actor.type === 'creature' ? 'creature-deadliness'
-            : 'deadliness';
-        deadlinessLevel = game.settings.get('nonex-ist-od6s', settingKey) as number;
-    }
-    return lookupWoundLevel(OD6S.deadliness[deadlinessLevel], value);
+    return lookupWoundLevel(OD6S.deadliness[getDeadlinessLevel(actor.type)], value);
 }
 
 export function getInjury(damage: number, actorType: OD6SActorType | "system"): string {


### PR DESCRIPTION
Refs #178 — cleanup items #5–#7. Item #8 (damage rules in chat-log listener) is a larger architectural extraction left for a separate PR.

## Summary

- **`system/utilities/wounds.ts`** — dedupe the `woundConfig === 1 ? 3 : settings.get(...)` ladder duplicated between `getWoundPenalty` and `getWoundLevel` behind a private `getDeadlinessLevel(actorType)`. The helper documents the divergence with `OD6S.deadlinessLevel[type]` (the cached raw setting), which does **not** apply the `woundConfig === 1` override — `actor-helpers/wounds.ts` callers were intentionally left alone since switching them would change runtime behavior in body-points mode. That divergence may itself be a latent bug; flagged but not fixed here.
- **`actor-helpers/wounds.ts` + `actor.ts`** — delete the dead `findFirstWoundLevel` wrapper and its `OD6SActor.findFirstWoundLevel` method. Three-link chain (`actor method → helper → core`) that ignored its `actor` argument and had no callers.
- **`roll-handlers.ts`** — extract `isCharacterView` / `isVehicleView` type guards over `ActorView` and route the five inline `actor.type === 'x' || actor.type === 'y'` checks through them. Note: Foundry's `system/type-guards.ts` guards operate on the `Actor` document; this module is Foundry-free by design (header comment) and operates on narrowed views, so the existing guards don't substitute — the cleanup is the equivalent guards living next to the `ActorView` definition.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 414/414 pass
- [x] `pnpm run test:domain` — 327/327 pass
- [x] `pnpm run lint` — 0 errors, 210 warnings (pre-existing, under 720 CI threshold)
- No behavior change intended; verified by the existing wounds and roll-handler unit tests.