### PR TITLE
fix(settings): stop image path settings accumulating on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 - Global JS namespace renamed from `game.od6s` to `game["nonex-ist-od6s"]`
   (the new id contains hyphens, so bracket access is required).
 
+### Fixed
+
+- Image path settings in the config menus (Wild Die faces, active-attribute
+  icons, initiative/custom-field images) accumulated a growing bracketed list
+  of paths on every submit. The templates rendered a plain `<input>` alongside
+  the form-associated `<file-picker>` element under the same `name`, so the
+  form serialized two entries per field into an array. The redundant `<input>`
+  is removed; the `<file-picker>` already provides the text field and browse
+  button. Existing corrupted values are overwritten the next time a valid
+  image is selected. (#181)
+
 ## [2.7.4] - 2026-06-02
 
 Second hotfix for the 2.7.2 manifest art: the package tile and thumbnail

--- a/src/templates/settings/active-attributes.html
+++ b/src/templates/settings/active-attributes.html
@@ -9,8 +9,6 @@
                     </select>
                 {{else}}
                     {{#if (eq setting.filePicker "image")}}
-                        <input type="{{setting.inputType}}" name="{{setting.key}}" data-dtype="{{setting.type.name}}"
-                               value="{{setting.value}}">
                         <file-picker name="{{setting.key}}" value="{{setting.value}}" type="image"></file-picker>
                     {{else}}
                         {{#if (eq setting.inputType "checkbox")}}

--- a/src/templates/settings/custom-fields.html
+++ b/src/templates/settings/custom-fields.html
@@ -27,9 +27,6 @@
                                value="starship" title="{{localize 'ACTOR.TypeStarship'}}">
                     {{else}}
                         {{#if (eq setting.filePicker "image")}}
-                            <input type="{{setting.inputType}}" name="{{setting.key}}"
-                                   data-dtype="{{setting.type.name}}"
-                                   value="{{setting.value}}">
                             <file-picker name="{{setting.key}}" value="{{setting.value}}" type="image"></file-picker>
                         {{else}}
                             {{#if (eq setting.inputType "checkbox")}}

--- a/src/templates/settings/initiative-settings.html
+++ b/src/templates/settings/initiative-settings.html
@@ -9,8 +9,6 @@
                     </select>
                 {{else}}
                     {{#if (eq setting.filePicker "image")}}
-                        <input type="{{setting.inputType}}" name="{{setting.key}}" data-dtype="{{setting.type.name}}"
-                               value="{{setting.value}}">
                         <file-picker name="{{setting.key}}" value="{{setting.value}}" type="image"></file-picker>
                     {{else}}
                         {{#if (eq setting.inputType "checkbox")}}

--- a/src/templates/settings/settings-v2.html
+++ b/src/templates/settings/settings-v2.html
@@ -9,8 +9,6 @@
                     </select>
                 {{else}}
                     {{#if (eq setting.filePicker "image")}}
-                        <input type="{{setting.inputType}}" name="{{setting.key}}" data-dtype="{{setting.type.name}}"
-                               value="{{setting.value}}">
                         <file-picker name="{{setting.key}}" value="{{setting.value}}" type="image"></file-picker>
                     {{else}}
                         {{#if (eq setting.inputType "checkbox")}}

--- a/src/templates/settings/wild-die.html
+++ b/src/templates/settings/wild-die.html
@@ -20,9 +20,6 @@
                             </select>
                         {{else}}
                             {{#if (eq setting.filePicker "image")}}
-                                <input type="{{setting.inputType}}" name="{{setting.key}}"
-                                       data-dtype="{{setting.type.name}}"
-                                       value="{{setting.value}}">
                                 <file-picker name="{{setting.key}}" value="{{setting.value}}" type="image"></file-picker>
                             {{else}}
                                 {{#if (eq setting.inputType "checkbox")}}


### PR DESCRIPTION
## Summary

Fixes #181 — updating Wild Die configuration (and other image path settings) appends the current value to the previously stored one, producing an ever-growing bracketed list of paths on every submit.

## Root cause

The affected settings templates rendered a plain `<input>` **alongside** the form-associated `<file-picker>` custom element under the **same `name`**. In Foundry v13+/v14, `<file-picker>` (`HTMLFilePickerElement`) is itself a form control that contributes its own value, so `FormDataExtended` collected two entries per field into an **array**. That array was stored into a `type: String` setting and re-rendered into both fields on the next open, growing each submit.

## Fix

Remove the redundant `<input>` from the `filePicker === "image"` branch — `<file-picker>` already provides the text field and browse button, leaving a single named form control.

Applied to all five affected settings templates:

- `wild-die.html` (the reported case)
- `active-attributes.html`
- `settings-v2.html`
- `initiative-settings.html`
- `custom-fields.html`

No TS/handler changes were needed; `config-wild-die.ts`'s submit handler is correct once the form stops emitting arrays.

## Scope check

Swept the whole codebase for the same fault class (a form-associated custom element sharing a `name` with a plain input in the same render path):

- **`<file-picker>`** — 5 instances, all fixed.
- **`<prose-mirror>`** — 26 instances, none have a duplicate-named sibling. Clean.
- No other form-associated custom elements are used.
- Remaining duplicate-`name` hits (roll dialog, sheets) are legitimate: mutually-exclusive `{{#if}}/{{else}}` branches, per-iteration `{{#each}}` names, radio groups, and disabled display fields.

## Notes

- Existing worlds with a corrupted stored value self-heal the next time a valid image is selected.
- The reporter was on 2.7.4 (old `od6s` id); this branch is the renamed 3.0.0 system, but the template pattern was identical.

## Testing

`pnpm run build` passes; templates render as single-control form fields.