### PR TITLE
chore: bump compatibility.verified to 14.364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+### Changed
+
+- `compatibility.verified` bumped from `14.363` to `14.364` to match the
+  current recommended Foundry V14 build.
+
 ### Added
 
 - World settings stranded under the old `od6s.*` namespace after the 3.0.0

--- a/src/system.json
+++ b/src/system.json
@@ -5,7 +5,7 @@
   "version": "3.0.0",
   "compatibility": {
     "minimum": "14",
-    "verified": "14.363",
+    "verified": "14.364",
     "maximum": "14"
   },
   "documentTypes": {


### PR DESCRIPTION
Bump `compatibility.verified` in `system.json` from `14.363` to `14.364`, the current recommended Foundry V14 build. Noted under `[Unreleased]` in the CHANGELOG.

No functional changes.