### PR TITLE
test(smoke): cover legacy od6s.* settings migration

### DIFF
--- a/docs/test-runbook.md
+++ b/docs/test-runbook.md
@@ -121,6 +121,10 @@ actors/items. Any failure prints a screenshot path and trace zip for
   `testCollision` wall is clipped back to ~origin);
   `explosive_end_of_round=false` reveals the region (`visibility=2`);
   `explosive_end_of_round=true` defers the reveal (`visibility=1`).
+- **Tier 5** (`tier-5-settings-migration`): seeds legacy `od6s.*` world
+  settings, rewinds `migrationVersion`, reloads to re-fire `migrateWorld()`,
+  and asserts they are copied to `nonex-ist-od6s.*` with `systems/od6s/` paths
+  rewritten — while a value already set under the new id is left untouched.
 
 ---
 
@@ -314,6 +318,10 @@ Requires two browser clients connected to the same world.
 ---
 
 ## Tier 5 — Migration (manual)
+
+The `od6s` → `nonex-ist-od6s` settings migration is covered automatically by
+`tier-5-settings-migration` (see the suite list above). The checks below need
+a real pre-v2 world backup and stay manual.
 
 If a backup of a pre-v2 world exists:
 

--- a/tests/smoke/tier-5-settings-migration.spec.ts
+++ b/tests/smoke/tier-5-settings-migration.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Tier 5 — #181/3.0.1 legacy world-settings migration.
+ * Tier 5 — #183/3.0.1 legacy world-settings migration.
  *
  * The 3.0.0 system-id rename left world settings stranded under the old
  * `od6s.*` namespace. `migrateLegacySettings()` (migration.ts, gated at
@@ -104,8 +104,13 @@ test.describe.serial("legacy od6s.* world settings migration", () => {
 
     test.afterAll(async ({browser}) => {
         // Restore defaults so re-runs start clean and the smoke world isn't
-        // left with synthetic icon paths.
-        const page = await browser.newPage();
+        // left with synthetic icon paths. Use an explicit context with the
+        // config baseURL — browser.newPage() bypasses the fixtures' baseURL,
+        // and loginAndWaitReady() navigates to a relative "/".
+        const context = await browser.newContext({
+            baseURL: process.env.FOUNDRY_URL ?? "http://localhost:30000",
+        });
+        const page = await context.newPage();
         try {
             await loginAndWaitReady(page);
             await evalInWorld(
@@ -128,7 +133,7 @@ test.describe.serial("legacy od6s.* world settings migration", () => {
                 {oneKey: ONE_KEY, sixKey: SIX_KEY},
             );
         } finally {
-            await page.close();
+            await context.close();
         }
     });
 });

--- a/tests/smoke/tier-5-settings-migration.spec.ts
+++ b/tests/smoke/tier-5-settings-migration.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Tier 5 — #181/3.0.1 legacy world-settings migration.
+ *
+ * The 3.0.0 system-id rename left world settings stranded under the old
+ * `od6s.*` namespace. `migrateLegacySettings()` (migration.ts, gated at
+ * 3.0.1) copies them onto `nonex-ist-od6s.*` on the next world load. This
+ * can't be a unit test — it reads/writes `game.settings.storage` on a live
+ * world — so it lives here.
+ *
+ * The spec seeds a synthetic upgraded world, forces the migration to re-run
+ * by rewinding `migrationVersion`, reloads (re-firing the `ready` hook), and
+ * asserts:
+ *   - a legacy `od6s.*` value is copied to `nonex-ist-od6s.*`;
+ *   - `systems/od6s/` asset paths are rewritten to `systems/nonex-ist-od6s/`;
+ *   - a value already set under the new id is NOT clobbered.
+ *
+ * Seeds mirror the exact encoding of a real Setting document (copied from a
+ * value written via `game.settings.set`) so the test is agnostic to how the
+ * running Foundry serializes `Setting#value`.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+const ONE_KEY = "wild_die_one_face";
+const SIX_KEY = "wild_die_six_face";
+// Legacy values as a real upgraded world would hold them: pointing at the
+// old system folder, so they also exercise the `systems/od6s/` path rewrite.
+const LEGACY_ONE = "systems/od6s/icons/smoke-migrated-one.svg";
+const LEGACY_SIX = "systems/od6s/icons/smoke-migrated-six.svg";
+// Expected copy target after the od6s → nonex-ist-od6s path rewrite.
+const MIGRATED_ONE = "systems/nonex-ist-od6s/icons/smoke-migrated-one.svg";
+// A value the GM already customised under the new id — must survive untouched.
+const PRESET_SIX = "systems/nonex-ist-od6s/icons/smoke-preset-six.svg";
+
+test.describe.serial("legacy od6s.* world settings migration", () => {
+    test("copies stranded settings, rewrites paths, and preserves new-id values", async ({page}) => {
+        await loginAndWaitReady(page);
+
+        // ── Seed a synthetic upgraded world ────────────────────────────
+        await evalInWorld(
+            page,
+            async (p: {oneKey: string; sixKey: string; legacyOne: string; legacySix: string; presetSix: string}) => {
+                const settings = window.game.settings;
+                const world = settings.storage.get("world");
+                const SettingCls = world.documentClass ?? window.foundry.documents.Setting;
+                const findDoc = (key: string) => [...world].find((s: {key: string}) => s.key === key);
+                const delDoc = async (key: string) => {
+                    const d = findDoc(key);
+                    if (d) await d.delete();
+                };
+
+                // Clean slate for both new-id keys and their legacy twins.
+                await delDoc(`od6s.${p.oneKey}`);
+                await delDoc(`od6s.${p.sixKey}`);
+                await delDoc(`nonex-ist-od6s.${p.oneKey}`);
+                await delDoc(`nonex-ist-od6s.${p.sixKey}`);
+
+                // Write the legacy values through the real setter first so we
+                // learn this Foundry's exact Setting#value encoding, then mint
+                // `od6s.*` docs that mirror it byte-for-byte.
+                await settings.set("nonex-ist-od6s", p.oneKey, p.legacyOne);
+                await settings.set("nonex-ist-od6s", p.sixKey, p.legacySix);
+                const oneEnc = findDoc(`nonex-ist-od6s.${p.oneKey}`).value;
+                const sixEnc = findDoc(`nonex-ist-od6s.${p.sixKey}`).value;
+                await SettingCls.create({key: `od6s.${p.oneKey}`, value: oneEnc});
+                await SettingCls.create({key: `od6s.${p.sixKey}`, value: sixEnc});
+
+                // one_face: unset under the new id → migration should copy it.
+                await delDoc(`nonex-ist-od6s.${p.oneKey}`);
+                // six_face: already customised under the new id → must be kept.
+                await settings.set("nonex-ist-od6s", p.sixKey, p.presetSix);
+
+                // Rewind so `migrateWorld()` runs only the 3.0.1 settings step
+                // (the ≤2.6.0 steps stay gated out; flag copy is a harmless no-op).
+                await settings.set("nonex-ist-od6s", "migrationVersion", "3.0.0");
+            },
+            {oneKey: ONE_KEY, sixKey: SIX_KEY, legacyOne: LEGACY_ONE, legacySix: LEGACY_SIX, presetSix: PRESET_SIX},
+        );
+
+        // ── Reload: full navigation re-fires init/ready → migrateWorld ─
+        await loginAndWaitReady(page);
+
+        const result = await evalInWorld(
+            page,
+            (p: {oneKey: string; sixKey: string}) => {
+                const s = window.game.settings;
+                return {
+                    one: s.get("nonex-ist-od6s", p.oneKey),
+                    six: s.get("nonex-ist-od6s", p.sixKey),
+                    version: s.get("nonex-ist-od6s", "migrationVersion"),
+                };
+            },
+            {oneKey: ONE_KEY, sixKey: SIX_KEY},
+        );
+
+        // Copied from od6s.* and path-rewritten to the new system folder.
+        expect(result.one).toBe(MIGRATED_ONE);
+        // Pre-existing new-id value left untouched (no clobber).
+        expect(result.six).toBe(PRESET_SIX);
+        // Migration ran and stamped the current version.
+        expect(result.version).toBe("3.0.1");
+    });
+
+    test.afterAll(async ({browser}) => {
+        // Restore defaults so re-runs start clean and the smoke world isn't
+        // left with synthetic icon paths.
+        const page = await browser.newPage();
+        try {
+            await loginAndWaitReady(page);
+            await evalInWorld(
+                page,
+                async (p: {oneKey: string; sixKey: string}) => {
+                    const world = window.game.settings.storage.get("world");
+                    const delDoc = async (key: string) => {
+                        const d = [...world].find((s: {key: string}) => s.key === key);
+                        if (d) await d.delete();
+                    };
+                    for (const k of [
+                        `od6s.${p.oneKey}`,
+                        `od6s.${p.sixKey}`,
+                        `nonex-ist-od6s.${p.oneKey}`,
+                        `nonex-ist-od6s.${p.sixKey}`,
+                    ]) {
+                        await delDoc(k);
+                    }
+                },
+                {oneKey: ONE_KEY, sixKey: SIX_KEY},
+            );
+        } finally {
+            await page.close();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Adds a live smoke test for the 3.0.1 `migrateLegacySettings()` step (from #183). That migration reads/writes `game.settings.storage` on a running world, so it can't be unit-tested under the repo's no-Foundry-globals policy — this fills the gap I flagged.

## What the spec does (`tests/smoke/tier-5-settings-migration.spec.ts`)

1. **Seeds a synthetic upgraded world** — mints legacy `od6s.wild_die_one_face` / `od6s.wild_die_six_face` Setting documents, mirroring the exact `Setting#value` encoding of a value written via `game.settings.set` (so it's agnostic to how this Foundry serializes settings).
2. **Rewinds** `nonex-ist-od6s.migrationVersion` to `3.0.0` so a reload runs *only* the 3.0.1 settings step.
3. **Reloads** (full navigation re-fires `init`/`ready` → `migrateWorld()`).
4. **Asserts**:
   - the legacy `one_face` is copied to `nonex-ist-od6s.*` with `systems/od6s/` → `systems/nonex-ist-od6s/` path rewrite;
   - a `six_face` value already set under the new id is **not** clobbered;
   - `migrationVersion` advanced to `3.0.1`.
5. **Cleans up** seeded/synthetic settings in `afterAll` so re-runs start clean.

## Running it

No Taskfile changes needed — the existing harness covers it:

```
task foundry:start      # boots Foundry v14, mounts src/ as the system
task test:smoke         # runs all specs incl. tier-5-settings-migration
task foundry:stop
```

Runbook updated: added the probe to the suite list and noted Tier 5 settings migration is now automated.

## Verification done here

`tsc --noEmit` and `eslint` pass; `playwright test --list` discovers and parses the spec (56 tests total). The spec itself needs a live Foundry world (license/credentials), so I could not execute it in this environment — it's ready for you to run via `task test:smoke`.