### PR TITLE
chore(release): 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-07-03
+
 ### Changed
 
 - `compatibility.verified` bumped from `14.363` to `14.364` to match the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opend6-space",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "description": "OpenD6 Space system for Foundry VTT v14. Uses the rules from the OpenD6 Project SRD.",
   "scripts": {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "nonex-ist-od6s",
   "title": "OpenD6 Space",
   "description": "OpenD6 Space System for FoundryVTT",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "compatibility": {
     "minimum": "14",
     "verified": "14.364",


### PR DESCRIPTION
Release prep for **3.0.1**.

## Version bumps
- `src/system.json` and `package.json` → `3.0.1`.
- CHANGELOG `[Unreleased]` → `[3.0.1] - 2026-07-03`.

## What ships in 3.0.1
- **Added** — automatic migration of legacy `od6s.*` world settings onto `nonex-ist-od6s.*` on first load (#183), so GMs no longer re-enter System Settings by hand after the 3.0.0 rename. Verified live (56/56 smoke incl. the new Tier 5 spec, #186).
- **Changed** — `compatibility.verified` → `14.364` (#185).

## After merge
Once this lands on `main`, tag from a clean synced `main`:

```
task release:patch      # v3.0.0 → v3.0.1; CI builds the signed od6s.zip
```

The task's preconditions (on main, clean, synced, both manifests at `3.0.1`) are satisfied by this PR.