### PR TITLE
chore(release): 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-04
+
 ### Changed
 
 - System settings are now grouped into logical clusters (Customization, Points

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opend6-space",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "type": "module",
   "description": "OpenD6 Space system for Foundry VTT v14. Uses the rules from the OpenD6 Project SRD.",
   "scripts": {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "nonex-ist-od6s",
   "title": "OpenD6 Space",
   "description": "OpenD6 Space System for FoundryVTT",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "compatibility": {
     "minimum": "14",
     "verified": "14.364",


### PR DESCRIPTION
Release 3.1.0.

Bumps `system.json` + `package.json` to 3.1.0 and finalizes the CHANGELOG.

**Highlights:** settings UX overhaul (shared config-menu base class; new Appearance / Maintenance / Custom Attributes menus; grouped + reordered settings; Custom Fields card overhaul) and the #189 legacy label-key migration + repair tool.

After merge: `task release:minor` tags `v3.1.0` and CI builds the signed `nonex-ist-od6s.zip`.