### PR TITLE
fix: V14 roll/chat compatibility — single-click penalty roll, messageMode migration, restore CP menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,4 @@ FOUNDRY_ADMIN_KEY=your-admin-password
 
 # Optional: pin the Foundry image tag (defaults to floating `14`). Match
 # this to system.json `compatibility.verified` for reproducible runs.
-# FOUNDRY_VERSION=14.361
+# FOUNDRY_VERSION=14.364

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+### Fixed
+
+- Rolling a skill or attribute with a penalty entered no longer requires two
+  clicks — a single click on **Roll** now submits. The penalty field's `change`
+  event (fired on blur when the Roll button is pressed) previously re-rendered
+  the dialog and swallowed the first click; the resulting-dice preview now
+  updates in place instead. (#193)
+- Restored the **Use a Character Point** right-click option on roll chat cards,
+  which was silently non-functional on Foundry V14 — it was bound to a hook
+  Foundry no longer emits and used jQuery on what is now a plain HTML element.
+
+### Changed
+
+- Migrated the roll and chat pipeline off Foundry V14-deprecated APIs
+  (`Roll#toMessage` / `Combat#rollInitiative` `rollMode` → `messageMode`,
+  `CONST.DICE_ROLL_MODES` → message-mode keys, and
+  `SortingHelpers.performIntegerSort` → `foundry.utils.performIntegerSort`),
+  eliminating the deprecation warnings these logged on every roll. Chat-message
+  visibility classification still reads legacy values on historical messages.
+
 ## [3.1.0] - 2026-07-04
 
 ### Changed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ dotenv: [".env"]
 
 vars:
   # Foundry image tag. Defaults to the floating `14` major; pin to a
-  # specific build (e.g. `14.361`) via .env when you want reproducible
+  # specific build (e.g. `14.364`) via .env when you want reproducible
   # runs against the system.json `compatibility.verified` value.
   FOUNDRY_VERSION: '{{.FOUNDRY_VERSION | default "14"}}'
   CONTAINER_NAME: nonex-ist-od6s-foundry
@@ -17,13 +17,20 @@ vars:
   # explicitly so commands aren't sensitive to ambient state. Override via
   # .env (NERDCTL_NAMESPACE=k8s.io) if your container lives elsewhere.
   NERDCTL_NAMESPACE: '{{.NERDCTL_NAMESPACE | default "default"}}'
-  # Resolve the container runtime once. Prefer docker; fall back to
-  # `nerdctl --namespace=<ns>` so every downstream invocation targets the
-  # same namespace without each task remembering to pass the flag.
+  # Resolve the container runtime once. Prefer whichever runtime actually
+  # holds the Foundry container — otherwise a running Docker daemon hijacks
+  # detection even when the container lives in containerd (nerdctl), and
+  # `docker ps` never finds it. Only when neither runtime has the container
+  # yet (initial `foundry:start`) do we fall back to whichever daemon is up.
+  # The trailing `--namespace=<ns>` is carried on the nerdctl value so every
+  # downstream invocation targets the same namespace.
   CONTAINER_RT:
     sh: |
-      if docker info >/dev/null 2>&1; then echo docker
-      elif nerdctl info >/dev/null 2>&1; then echo "nerdctl --namespace={{.NERDCTL_NAMESPACE}}"
+      ns="{{.NERDCTL_NAMESPACE}}"; name="{{.CONTAINER_NAME}}"
+      if docker ps -a --format '{{"{{.Names}}"}}' 2>/dev/null | grep -qx "$name"; then echo docker
+      elif nerdctl --namespace="$ns" ps -a --format '{{"{{.Names}}"}}' 2>/dev/null | grep -qx "$name"; then echo "nerdctl --namespace=$ns"
+      elif docker info >/dev/null 2>&1; then echo docker
+      elif nerdctl info >/dev/null 2>&1; then echo "nerdctl --namespace=$ns"
       else echo none
       fi
 

--- a/docs/test-runbook.md
+++ b/docs/test-runbook.md
@@ -96,6 +96,16 @@ actors/items. Any failure prints a screenshot path and trace zip for
   chat message created, zero v14 deprecation warnings.
 - **Tier 3b** (`tier-3-skill-roll`): skill item roll → dialog opens → submit
   → chat message created.
+- **Tier 3b** (`tier-3-roll-penalty`, regression #193): enter a penalty then
+  click Roll **once** (real pointer events) → dialog closes and exactly one
+  chat message is created — the penalty `change` (fired on blur by the click)
+  must not re-render and swallow the click. Also: penalty change updates the
+  `.roll-dice-preview` in place.
+- **Tier 3b** (`tier-3-chat-cp-menu`, v14 regression): the "Use a Character
+  Point" entry registers on the `getChatMessageContextOptions` hook, is
+  `visible` for an owned character's roll message (HTMLElement row) while CP
+  remain, and `onClick` spends one point. Message is created via
+  `roll.toMessage(..., {messageMode})`, covering the message-mode migration.
 - **Tier 3c** (`tier-3-wounds`): wound transitions Healthy → Wounded →
   Severely Wounded; `toggleStatusEffect` fires without schema errors.
 - **Tier 3d** (`tier-3-combat`): scene + combat creation, combatant added,

--- a/src/module/actor/actor-helpers/crew-vehicle.ts
+++ b/src/module/actor/actor-helpers/crew-vehicle.ts
@@ -1,6 +1,7 @@
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import {isVehicleActor} from "../../system/type-guards";
+import {MESSAGE_MODES} from "../../hooks/chat-mode";
 import {
     isCrewMemberByFlag,
     canRemoveFromCrew,
@@ -224,16 +225,16 @@ async function rollVehicleCollision(
         }
     }
 
-    let rollMode: string = CONST.DICE_ROLL_MODES.PUBLIC;
+    let messageMode: string = MESSAGE_MODES.PUBLIC;
     if (game.user.isGM && game.settings.get("nonex-ist-od6s", "hide-gm-rolls")) {
-        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+        messageMode = MESSAGE_MODES.GM;
     }
 
     const rollMessage = await roll.toMessage({
         speaker: ChatMessage.getSpeaker({actor: game.actors.find((a: Actor) => a.id === actor.id)}),
         flavor: label,
         flags: {"nonex-ist-od6s": flags},
-    }, {rollMode, create: true});
+    }, {messageMode, create: true});
 
     if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
         type DieResult = { result: number; discarded?: boolean; active?: boolean };

--- a/src/module/actor/sheet-helpers/rolls.ts
+++ b/src/module/actor/sheet-helpers/rolls.ts
@@ -18,6 +18,7 @@ import {od6sroll} from "../../apps/roll";
 import {od6sutilities} from "../../system/utilities";
 import OD6S from "../../config/config-od6s";
 import type {IncomingRollData} from "../../apps/roll-helpers/roll-data";
+import {MESSAGE_MODES} from "../../hooks/chat-mode";
 
 /**
  * Minimal sheet shape consumed by these helpers. Matches the pattern in
@@ -164,15 +165,15 @@ export async function rollBodyPoints(sheet: RollSheetLike): Promise<void> {
 
     const label = game.i18n.localize("NONEX_IST_OD6S.ROLLING") + " " + game.i18n.localize(OD6S.bodyPointsName);
 
-    let rollMode: string = CONST.DICE_ROLL_MODES.PUBLIC;
+    let messageMode: string = MESSAGE_MODES.PUBLIC;
     if (game.user.isGM && game.settings.get("nonex-ist-od6s", "hide-gm-rolls")) {
-        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+        messageMode = MESSAGE_MODES.GM;
     }
     const roll = await new Roll(rollString).evaluate();
     await roll.toMessage({
         speaker: ChatMessage.getSpeaker(),
         flavor: label,
-    }, {rollMode, create: true});
+    }, {messageMode, create: true});
 
     await sheet.document.update({"system.wounds.body_points.max": roll.total});
 }

--- a/src/module/actor/sheet-helpers/sorting.ts
+++ b/src/module/actor/sheet-helpers/sorting.ts
@@ -37,7 +37,7 @@ export function onSortItem(sheet: ActorSheetLike, event: DragEvent, itemData: So
     }
 
     // Perform the sort
-    const sortUpdates = SortingHelpers.performIntegerSort(source, {target, siblings});
+    const sortUpdates = foundry.utils.performIntegerSort(source, {target, siblings});
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
         update._id = u.target!._id;
@@ -69,7 +69,7 @@ export async function onSortCrew(sheet: ActorSheetLike, event: DragEvent, data: 
         }
     }
 
-    const sortUpdates = SortingHelpers.performIntegerSort(source, {target, siblings});
+    const sortUpdates = foundry.utils.performIntegerSort(source, {target, siblings});
 
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
@@ -113,7 +113,7 @@ export async function onSortCargoItem(sheet: ActorSheetLike, event: DragEvent, i
     const target = siblings.find((s: Item) => s._id === targetId);
 
     // Perform the sort
-    const sortUpdates = SortingHelpers.performIntegerSort(source, {target: target, siblings});
+    const sortUpdates = foundry.utils.performIntegerSort(source, {target: target, siblings});
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
         update._id = u.target!._id;
@@ -144,7 +144,7 @@ export async function onSortContainerItem(sheet: ActorSheetLike, event: DragEven
     if (target && (source!.type !== target.type)) return;
 
     // Perform the sort
-    const sortUpdates = SortingHelpers.performIntegerSort(source, {target: target, siblings});
+    const sortUpdates = foundry.utils.performIntegerSort(source, {target: target, siblings});
     const updateData = sortUpdates.map((u) => {
         const update = u.update;
         update._id = u.target!._id;

--- a/src/module/apps/chat-menu.ts
+++ b/src/module/apps/chat-menu.ts
@@ -1,50 +1,57 @@
 import {isCharacterActor} from "../system/type-guards";
 
+/**
+ * A chat-message context-menu entry in the v14 shape: `label`/`visible`/
+ * `onClick` (the v13 `name`/`condition`/`callback` fields are deprecated), with
+ * callbacks receiving the message row as an `HTMLElement` (no longer jQuery).
+ */
+interface ChatContextEntry {
+    label: string;
+    icon: string;
+    visible: (li: HTMLElement) => boolean;
+    onClick: (event: Event, li: HTMLElement) => unknown;
+}
+
 export class OD6SChat {
 
-    static chatContextMenu(html: any, options: any[]) {
-        const canApplyCharacterPoint = function (li: any) {
-            const result = false;
-            let actor;
-            if (li.find(".dice-roll").length) {
-                const message = game.messages.get(li.attr("data-message-id"));
-                if (message!.speaker.actor) {
-                    if (message!.speaker.token) {
-                        actor = game.scenes.viewed.tokens.filter(t => t.id === message!.speaker.token)[0].actor;
-                    } else {
-                        actor = game.actors.get(message!.speaker.actor);
-                    }
+    /** Resolve the acting Actor for a chat message row (token actor if any). */
+    private static resolveActor(li: HTMLElement): Actor | undefined {
+        const message = game.messages.get(li.dataset.messageId ?? "");
+        if (!message?.speaker.actor) return undefined;
+        if (message.speaker.token) {
+            return game.scenes.viewed?.tokens.find(t => t.id === message.speaker.token)?.actor ?? undefined;
+        }
+        return game.actors.get(message.speaker.actor) ?? undefined;
+    }
 
-                    if (message!.getFlag('nonex-ist-od6s', 'canUseCp') &&
-                        actor && (game.user.isGM || actor.isOwner) &&
-                        isCharacterActor(actor) &&
-                        (actor.type === "character" || actor.type === "npc") &&
-                        actor.system.characterpoints.value > 0) {
-                        return true;
-                    }
-                }
-            }
-            return result;
-        };
-
-        options.push(
-            {
-                name: game.i18n.localize("NONEX_IST_OD6S.USE_A_CHARACTER_POINT"),
-                icon: '<i class="fas fa-user-plus"></i>',
-                condition: canApplyCharacterPoint,
-                callback: (li: any) => {
-                    const message = game.messages.get(li.attr("data-message-id"));
-                    if (!message) return;
-                    let actor;
-                    if (message.speaker.token) {
-                        actor = game.scenes.viewed?.tokens.filter(t => t.id === message.speaker.token)[0]?.actor;
-                    } else {
-                        actor = game.actors.get(message.speaker.actor);
-                    }
-                    if (!actor) return;
-                    return actor.useCharacterPointOnRoll(message);
-                }
-            }
-        )
+    /**
+     * Append the "Use a Character Point" entry to the chat message context menu.
+     * Registered via the `getChatMessageContextOptions` hook (v14).
+     */
+    static chatContextMenu(options: ChatContextEntry[]) {
+        options.push({
+            label: game.i18n.localize("NONEX_IST_OD6S.USE_A_CHARACTER_POINT"),
+            icon: '<i class="fas fa-user-plus"></i>',
+            visible: (li: HTMLElement) => {
+                if (!li.querySelector(".dice-roll")) return false;
+                const message = game.messages.get(li.dataset.messageId ?? "");
+                if (!message) return false;
+                const actor = OD6SChat.resolveActor(li);
+                return !!(
+                    message.getFlag('nonex-ist-od6s', 'canUseCp') &&
+                    actor && (game.user.isGM || actor.isOwner) &&
+                    isCharacterActor(actor) &&
+                    (actor.type === "character" || actor.type === "npc") &&
+                    actor.system.characterpoints.value > 0
+                );
+            },
+            onClick: (_event: Event, li: HTMLElement) => {
+                const message = game.messages.get(li.dataset.messageId ?? "");
+                if (!message) return;
+                const actor = OD6SChat.resolveActor(li);
+                if (!actor) return;
+                return actor.useCharacterPointOnRoll(message);
+            },
+        });
     }
 }

--- a/src/module/apps/init-roll.ts
+++ b/src/module/apps/init-roll.ts
@@ -1,5 +1,6 @@
 import {od6sutilities} from "../system/utilities";
 import {InitRollDialog} from "./init-roll-dialog";
+import {MESSAGE_MODES} from "../hooks/chat-mode";
 
 export class od6sInitRoll {
 
@@ -96,10 +97,11 @@ export class od6sInitRoll {
         const messageOptions: any = {
             'flags.nonex-ist-od6s.canUseCp': true
         };
-        if (game.user.isGM && game.settings.get('nonex-ist-od6s', 'hide-gm-rolls')) messageOptions.rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
-        await game.combats.active.rollInitiative(rollData.combatantId, {
-            "formula": rollString,
-            "messageOptions": messageOptions
-        });
+        const initOptions: {formula: string; messageOptions: any; messageMode?: string} = {
+            formula: rollString,
+            messageOptions,
+        };
+        if (game.user.isGM && game.settings.get('nonex-ist-od6s', 'hide-gm-rolls')) initOptions.messageMode = MESSAGE_MODES.GM;
+        await game.combats.active.rollInitiative(rollData.combatantId, initOptions);
     }
 }

--- a/src/module/apps/roll-dialog.ts
+++ b/src/module/apps/roll-dialog.ts
@@ -3,6 +3,7 @@ import {od6sutilities} from "../system/utilities";
 import OD6S, {type CharacterPointLimits} from "../config/config-od6s";
 import {od6sroll} from "./roll";
 import {isCharacterActor} from "../system/type-guards";
+import {MESSAGE_MODES} from "../hooks/chat-mode";
 import type {RollData} from "./roll-helpers/roll-data";
 
 
@@ -74,8 +75,8 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         }
         if (typeof this.rollData.rollmode !== "string") {
             this.rollData.rollmode = (game.user.isGM && game.settings.get("nonex-ist-od6s", "hide-gm-rolls"))
-                ? "gmroll"
-                : "publicroll";
+                ? MESSAGE_MODES.GM
+                : MESSAGE_MODES.PUBLIC;
         }
         return this.rollData;
     }
@@ -87,6 +88,30 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     #submitted = false;
+
+    /**
+     * Refresh the "resulting dice" preview (`{{setDice ...}}`) in place, without
+     * re-rendering the whole dialog.
+     *
+     * A full `render()` on every numeric-modifier `change` re-rendered the form —
+     * and because `change` fires on blur, clicking the Roll button blurred the
+     * focused penalty input, tore down the DOM (including the submit button)
+     * mid-click, and swallowed the first click. Patching just the preview text
+     * keeps the submit button alive so a single click rolls (issue #193). Mirrors
+     * the `setDice` Handlebars helper: dice minus the four penalties, clamped ≥ 0.
+     */
+    #updateDicePreview(): void {
+        const root = this.element as HTMLElement | null;
+        const preview = root?.querySelector<HTMLElement>(".roll-dice-preview");
+        if (!preview) return;
+        const rd = this.rollData;
+        const dice = (+rd.dice || 0)
+            - (+rd.actionpenalty || 0)
+            - (+rd.woundpenalty || 0)
+            - (+rd.stunnedpenalty || 0)
+            - (+rd.otherpenalty || 0);
+        preview.textContent = String(dice > 0 ? dice : 0);
+    }
 
     _onRender(_context: object, _options: object): void {
         const root = this.element as HTMLElement;
@@ -216,34 +241,32 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             this.rollData.stun = !this.rollData.stun;
         });
 
-        find("#difficulty")?.addEventListener("change", async (ev) => {
+        find("#difficulty")?.addEventListener("change", (ev) => {
             this.rollData.difficulty = +(ev.target as HTMLInputElement).valueAsNumber;
-            await this.render();
         });
 
-        find("#actionpenalty")?.addEventListener("change", async (ev) => {
+        find("#actionpenalty")?.addEventListener("change", (ev) => {
             this.rollData.actionpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
-            await this.render();
+            this.#updateDicePreview();
         });
 
-        find("#woundpenalty")?.addEventListener("change", async (ev) => {
+        find("#woundpenalty")?.addEventListener("change", (ev) => {
             this.rollData.woundpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
-            await this.render();
+            this.#updateDicePreview();
         });
 
-        find("#stunnedpenalty")?.addEventListener("change", async (ev) => {
+        find("#stunnedpenalty")?.addEventListener("change", (ev) => {
             this.rollData.stunnedpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
-            await this.render();
+            this.#updateDicePreview();
         });
 
-        find("#otherpenalty")?.addEventListener("change", async (ev) => {
+        find("#otherpenalty")?.addEventListener("change", (ev) => {
             this.rollData.otherpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
-            await this.render();
+            this.#updateDicePreview();
         });
 
-        find("#shots")?.addEventListener("change", async (ev) => {
+        find("#shots")?.addEventListener("change", (ev) => {
             this.rollData.shots = +(ev.target as HTMLInputElement).valueAsNumber;
-            await this.render();
         });
 
         find("#target")?.addEventListener("change", async (ev) => {
@@ -298,10 +321,9 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             await this.render();
         });
 
-        find("#miscmod")?.addEventListener("change", async (ev) => {
+        find("#miscmod")?.addEventListener("change", (ev) => {
             const raw = (ev.target as HTMLInputElement).valueAsNumber;
             this.rollData.modifiers.miscmod = Number.isFinite(raw) ? raw : 0;
-            await this.render();
         });
 
         find("#vehiclespeed")?.addEventListener("change", (ev) => {

--- a/src/module/apps/roll-dialog.ts
+++ b/src/module/apps/roll-dialog.ts
@@ -118,6 +118,14 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         const find = (sel: string): HTMLElement | null => root.querySelector(sel);
         const findAll = (sel: string): NodeListOf<HTMLElement> => root.querySelectorAll(sel);
 
+        // Clearing a number input yields `valueAsNumber === NaN`; coerce to a
+        // safe default so it doesn't propagate into dice/difficulty math on
+        // submit.
+        const numField = (ev: Event, fallback = 0): number => {
+            const raw = (ev.target as HTMLInputElement).valueAsNumber;
+            return Number.isFinite(raw) ? raw : fallback;
+        };
+
         find(".cpup")?.addEventListener("click", async () => {
             let rollType = this.rollData.type;
             const actor = this.rollData.actor;
@@ -174,15 +182,15 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         });
 
         find("#scaledice")?.addEventListener("change", (ev) => {
-            this.rollData.scaledice = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.scaledice = numField(ev);
         });
 
         find("#bonusdice")?.addEventListener("change", (ev) => {
-            this.rollData.bonusdice = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.bonusdice = numField(ev);
         });
 
         find("#bonuspips")?.addEventListener("change", (ev) => {
-            this.rollData.bonuspips = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.bonuspips = numField(ev);
         });
 
         find(".timer input")?.addEventListener("change", async (ev) => {
@@ -240,14 +248,6 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         find("#stun")?.addEventListener("click", async () => {
             this.rollData.stun = !this.rollData.stun;
         });
-
-        // Clearing a number input yields `valueAsNumber === NaN`; coerce to a
-        // safe default so it doesn't propagate into dice/difficulty math on
-        // submit (matches the `#miscmod` handling below).
-        const numField = (ev: Event, fallback = 0): number => {
-            const raw = (ev.target as HTMLInputElement).valueAsNumber;
-            return Number.isFinite(raw) ? raw : fallback;
-        };
 
         find("#difficulty")?.addEventListener("change", (ev) => {
             this.rollData.difficulty = numField(ev);

--- a/src/module/apps/roll-dialog.ts
+++ b/src/module/apps/roll-dialog.ts
@@ -241,32 +241,42 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
             this.rollData.stun = !this.rollData.stun;
         });
 
+        // Clearing a number input yields `valueAsNumber === NaN`; coerce to a
+        // safe default so it doesn't propagate into dice/difficulty math on
+        // submit (matches the `#miscmod` handling below).
+        const numField = (ev: Event, fallback = 0): number => {
+            const raw = (ev.target as HTMLInputElement).valueAsNumber;
+            return Number.isFinite(raw) ? raw : fallback;
+        };
+
         find("#difficulty")?.addEventListener("change", (ev) => {
-            this.rollData.difficulty = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.difficulty = numField(ev);
         });
 
         find("#actionpenalty")?.addEventListener("change", (ev) => {
-            this.rollData.actionpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.actionpenalty = numField(ev);
             this.#updateDicePreview();
         });
 
         find("#woundpenalty")?.addEventListener("change", (ev) => {
-            this.rollData.woundpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.woundpenalty = numField(ev);
             this.#updateDicePreview();
         });
 
         find("#stunnedpenalty")?.addEventListener("change", (ev) => {
-            this.rollData.stunnedpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.stunnedpenalty = numField(ev);
             this.#updateDicePreview();
         });
 
         find("#otherpenalty")?.addEventListener("change", (ev) => {
-            this.rollData.otherpenalty = +(ev.target as HTMLInputElement).valueAsNumber;
+            this.rollData.otherpenalty = numField(ev);
             this.#updateDicePreview();
         });
 
         find("#shots")?.addEventListener("change", (ev) => {
-            this.rollData.shots = +(ev.target as HTMLInputElement).valueAsNumber;
+            // Shots feeds `(shots - 1)` multishot math; an empty field means a
+            // single shot, so fall back to 1 (0 would flip the penalty into a bonus).
+            this.rollData.shots = numField(ev, 1);
         });
 
         find("#target")?.addEventListener("change", async (ev) => {
@@ -322,8 +332,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         });
 
         find("#miscmod")?.addEventListener("change", (ev) => {
-            const raw = (ev.target as HTMLInputElement).valueAsNumber;
-            this.rollData.modifiers.miscmod = Number.isFinite(raw) ? raw : 0;
+            this.rollData.modifiers.miscmod = numField(ev);
         });
 
         find("#vehiclespeed")?.addEventListener("change", (ev) => {

--- a/src/module/apps/roll-helpers/roll-data.ts
+++ b/src/module/apps/roll-helpers/roll-data.ts
@@ -105,6 +105,7 @@ export interface RollData {
     stun: boolean;
     attackerScale: number;
     modifiers: RollModifiers;
+    /** messageMode chosen in the roll dialog (`public`/`gm`/`blind`/`self`). */
     rollmode?: string;
     /**
      * Region id of the explosive blast template tied to this roll. Set by
@@ -194,9 +195,11 @@ export interface RollMessageFlags {
     targets?: unknown;
     originalroll?: unknown;
     /**
-     * Persisted roll mode chosen at message creation. Read by chat-mode.ts so
+     * Persisted message-visibility mode chosen at message creation — a
+     * `messageMode` key (`public`/`gm`/`blind`/`self`). Read by chat-mode.ts so
      * the renderer can distinguish self vs gm in single-GM worlds, where
-     * `whisper === [author.id]` is ambiguous.
+     * `whisper === [author.id]` is ambiguous. (Historical messages may still
+     * carry the legacy `publicroll`/… values; chat-mode.ts maps both.)
      */
     rollMode?: string;
     /**

--- a/src/module/apps/roll-helpers/roll-execute-math.test.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
     computeHighHitDamage,
     computeWildDieReduction,
-    resolveRollMode,
+    resolveMessageMode,
     applyDicePenalties,
     buildRollString,
     detectWildDieResult,
@@ -94,33 +94,33 @@ describe('computeWildDieReduction', () => {
     });
 });
 
-describe('resolveRollMode', () => {
-    it('defaults to publicroll for non-GM with no explicit choice', () => {
-        expect(resolveRollMode({ isGM: false, hideGmRolls: false })).toBe('publicroll');
-        expect(resolveRollMode({ isGM: false, hideGmRolls: true })).toBe('publicroll');
+describe('resolveMessageMode', () => {
+    it('defaults to public for non-GM with no explicit choice', () => {
+        expect(resolveMessageMode({ isGM: false, hideGmRolls: false })).toBe('public');
+        expect(resolveMessageMode({ isGM: false, hideGmRolls: true })).toBe('public');
     });
 
-    it('switches to gmroll for a GM with hide-gm-rolls enabled', () => {
-        expect(resolveRollMode({ isGM: true, hideGmRolls: true })).toBe('gmroll');
+    it('switches to gm for a GM with hide-gm-rolls enabled', () => {
+        expect(resolveMessageMode({ isGM: true, hideGmRolls: true })).toBe('gm');
     });
 
-    it('stays publicroll for a GM without hide-gm-rolls', () => {
-        expect(resolveRollMode({ isGM: true, hideGmRolls: false })).toBe('publicroll');
+    it('stays public for a GM without hide-gm-rolls', () => {
+        expect(resolveMessageMode({ isGM: true, hideGmRolls: false })).toBe('public');
     });
 
     it('explicit dialog choice always wins over hide-gm-rolls', () => {
         // Pin the contract for issue #77's footer mode selector: even a GM
-        // who has hide-gm-rolls on can still pick publicroll/blindroll/selfroll
+        // who has hide-gm-rolls on can still pick public/blind/self
         // and have it stick.
-        expect(resolveRollMode({ explicit: 'publicroll', isGM: true, hideGmRolls: true })).toBe('publicroll');
-        expect(resolveRollMode({ explicit: 'blindroll',  isGM: true, hideGmRolls: true })).toBe('blindroll');
-        expect(resolveRollMode({ explicit: 'selfroll',   isGM: true, hideGmRolls: true })).toBe('selfroll');
-        expect(resolveRollMode({ explicit: 'gmroll',     isGM: false, hideGmRolls: false })).toBe('gmroll');
+        expect(resolveMessageMode({ explicit: 'public', isGM: true, hideGmRolls: true })).toBe('public');
+        expect(resolveMessageMode({ explicit: 'blind',  isGM: true, hideGmRolls: true })).toBe('blind');
+        expect(resolveMessageMode({ explicit: 'self',   isGM: true, hideGmRolls: true })).toBe('self');
+        expect(resolveMessageMode({ explicit: 'gm',     isGM: false, hideGmRolls: false })).toBe('gm');
     });
 
     it('treats empty/null explicit as no choice', () => {
-        expect(resolveRollMode({ explicit: '', isGM: true, hideGmRolls: true })).toBe('gmroll');
-        expect(resolveRollMode({ explicit: null, isGM: false, hideGmRolls: false })).toBe('publicroll');
+        expect(resolveMessageMode({ explicit: '', isGM: true, hideGmRolls: true })).toBe('gm');
+        expect(resolveMessageMode({ explicit: null, isGM: false, hideGmRolls: false })).toBe('public');
     });
 });
 

--- a/src/module/apps/roll-helpers/roll-execute-math.ts
+++ b/src/module/apps/roll-helpers/roll-execute-math.ts
@@ -74,7 +74,7 @@ export function computeWildDieReduction(
     return { discardedIndex: highest, newTotal };
 }
 
-export interface ResolveRollModeInput {
+export interface ResolveMessageModeInput {
     /** Per-roll mode chosen in the dialog, if any. Wins over hide-gm-rolls. */
     explicit?: string | null;
     isGM: boolean;
@@ -82,13 +82,14 @@ export interface ResolveRollModeInput {
 }
 
 /**
- * Resolve the rollMode passed to ChatMessage. An explicit dialog choice always
- * wins; otherwise GMs with `hide-gm-rolls` get gmroll, everyone else publicroll.
+ * Resolve the `messageMode` passed to ChatMessage (a key of
+ * `CONFIG.ChatMessage.modes`). An explicit dialog choice always wins; otherwise
+ * GMs with `hide-gm-rolls` get `gm`, everyone else `public`.
  */
-export function resolveRollMode(input: ResolveRollModeInput): string {
+export function resolveMessageMode(input: ResolveMessageModeInput): string {
     if (typeof input.explicit === "string" && input.explicit.length > 0) return input.explicit;
-    if (input.isGM && input.hideGmRolls) return "gmroll";
-    return "publicroll";
+    if (input.isGM && input.hideGmRolls) return "gm";
+    return "public";
 }
 
 export interface DicePenalties {

--- a/src/module/apps/roll-helpers/roll-execute.ts
+++ b/src/module/apps/roll-helpers/roll-execute.ts
@@ -11,7 +11,7 @@ import type {RollData, RollMessageFlags} from "./roll-data";
 import {
     computeHighHitDamage,
     computeWildDieReduction,
-    resolveRollMode,
+    resolveMessageMode,
     applyDicePenalties,
     buildRollString,
     detectWildDieResult,
@@ -53,7 +53,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     }
 
     rollData.isknown = true;
-    const rollMode: string = resolveRollMode({
+    const messageMode: string = resolveMessageMode({
         explicit: typeof rollData.rollmode === "string" ? rollData.rollmode : null,
         isGM: !!game.user.isGM,
         hideGmRolls: !!game.settings.get('nonex-ist-od6s', 'hide-gm-rolls'),
@@ -175,7 +175,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
     const scaleDice = damageAssembly.scaleDice;
 
     const flags: RollMessageFlags = {
-        "rollMode": rollMode,
+        "rollMode": messageMode,
         "actorId": rollData.actor.id,
         "targetName": targetName,
         "targetId": targetId,
@@ -388,7 +388,7 @@ export async function executeRollAction(rollData: RollData): Promise<unknown> {
             flavor: label,
             flags: {"nonex-ist-od6s": flags}
         },
-        {rollMode, create: true}
+        {messageMode, create: true}
     );
 
     if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {

--- a/src/module/hooks/chat-log-listeners.ts
+++ b/src/module/hooks/chat-log-listeners.ts
@@ -7,6 +7,7 @@ import {OD6SEditDamage} from "../apps/edit-damage";
 import {OD6SChooseTarget} from "../apps/choose-target";
 import {OD6SHandleWildDieForm} from "../apps/handle-wild-die";
 import {error as logError} from "../system/logger";
+import {MESSAGE_MODES} from "./chat-mode";
 
 // Delegated event helper: attaches a listener on a parent that fires when a child matching selector is the target.
 // Wraps the handler so async failures leave a `[nonex-ist-od6s:chat-log]` breadcrumb instead of unhandled rejections.
@@ -257,8 +258,8 @@ export function registerChatLogListeners() {
                 }
             }
 
-            let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
-            if (game.user.isGM && game.settings.get('nonex-ist-od6s', 'hide-gm-rolls')) rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+            let messageMode: string = MESSAGE_MODES.PUBLIC;
+            if (game.user.isGM && game.settings.get('nonex-ist-od6s', 'hide-gm-rolls')) messageMode = MESSAGE_MODES.GM;
 
             const rollMessage = await roll.toMessage({
                 speaker: ChatMessage.getSpeaker({actor: game.actors.find(a => a.id === data.actor)}),
@@ -266,7 +267,7 @@ export function registerChatLogListeners() {
                 flags: {
                     "nonex-ist-od6s": flags
                 },
-            }, {rollMode, create: true});
+            }, {messageMode, create: true});
 
             if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
                 const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));

--- a/src/module/hooks/chat-mode.test.ts
+++ b/src/module/hooks/chat-mode.test.ts
@@ -72,5 +72,19 @@ describe('deriveRollMode', () => {
                 flags: { "nonex-ist-od6s": { rollMode: 'garbage' } },
             })).toBe('public');
         });
+
+        // New messages persist the v14 messageMode value (gm/self/blind/public);
+        // classification must honour it exactly like the legacy strings above.
+        it('classifies new messageMode flag values (gm/self/blind/public)', () => {
+            const base = { whisper: ['gm1'], author: { id: 'gm1' } };
+            expect(deriveRollMode({ ...base, flags: { "nonex-ist-od6s": { rollMode: 'gm' } } })).toBe('gm');
+            expect(deriveRollMode({ ...base, flags: { "nonex-ist-od6s": { rollMode: 'self' } } })).toBe('self');
+            expect(deriveRollMode({ ...base, flags: { "nonex-ist-od6s": { rollMode: 'blind' } } })).toBe('blind');
+            expect(deriveRollMode({
+                whisper: ['gm1'],
+                author: { id: 'u1' },
+                flags: { "nonex-ist-od6s": { rollMode: 'public' } },
+            })).toBe('public');
+        });
     });
 });

--- a/src/module/hooks/chat-mode.ts
+++ b/src/module/hooks/chat-mode.ts
@@ -18,7 +18,32 @@ export interface DeriveRollModeInput {
     flags?: { "nonex-ist-od6s"?: { rollMode?: string } } | null;
 }
 
+/**
+ * Canonical Foundry v14 message-visibility modes — keys of
+ * `CONFIG.ChatMessage.modes`, passed as the `messageMode` option to
+ * `Roll#toMessage` / `Combat#rollInitiative`. Replaces the deprecated
+ * `CONST.DICE_ROLL_MODES`, whose `PUBLIC`/`PRIVATE`/`BLIND`/`SELF` returned the
+ * old `publicroll`/`gmroll`/`blindroll`/`selfroll` strings.
+ */
+export const MESSAGE_MODES = {
+    PUBLIC: 'public',
+    GM:     'gm',
+    BLIND:  'blind',
+    SELF:   'self',
+} as const satisfies Record<string, RollMode>;
+
+/**
+ * Classify a persisted mode flag into one of the four modes. Accepts both the
+ * current `messageMode` values and the legacy pre-v14 `publicroll`/… strings
+ * that historical chat messages still carry in `flags.nonex-ist-od6s.rollMode`.
+ */
 const PERSISTED_TO_MODE: Record<string, RollMode> = {
+    // current messageMode keys
+    public: 'public',
+    gm:     'gm',
+    blind:  'blind',
+    self:   'self',
+    // legacy pre-v14 rollMode strings (still present on older messages)
     publicroll: 'public',
     gmroll:     'gm',
     blindroll:  'blind',

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -1,4 +1,5 @@
 import OD6S from "./config/config-od6s";
+import {MESSAGE_MODES} from "./hooks/chat-mode";
 
 /**
  * Create a Macro from an Item drop.
@@ -128,7 +129,7 @@ interface SimpleRollResult {
 async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
     let wild = false;
     let rollString = "";
-    let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
+    let messageMode: string = MESSAGE_MODES.PUBLIC;
     let dice = result.dice;
     const pips = result.pips;
     const damageRoll = !!result.damageroll;
@@ -183,13 +184,13 @@ async function runSimpleRoll(result: SimpleRollResult): Promise<void> {
     }
 
     if (game.user.isGM && game.settings.get("nonex-ist-od6s", "hide-gm-rolls")) {
-        rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+        messageMode = MESSAGE_MODES.GM;
     }
     const rollMessage = await roll.toMessage({
         speaker: ChatMessage.getSpeaker(),
         flavor: label,
         flags: {"nonex-ist-od6s": flags},
-    }, {rollMode, create: true});
+    }, {messageMode, create: true});
 
     if (flags.wild === true && OD6S.wildDieOneDefault === 2 && OD6S.wildDieOneAuto === 0) {
         const replacementRoll = JSON.parse(JSON.stringify(rollMessage.rolls[0].toJSON()));

--- a/src/module/nonex-ist-od6s.ts
+++ b/src/module/nonex-ist-od6s.ts
@@ -162,6 +162,9 @@ Hooks.on('i18nInit', () => {
     game.i18n.translations.ITEM.TypeManifestation = OD6S.manifestationName;
 })
 
-Hooks.on("getOD6SChatLogEntryContext", async (html, options) => {
-    await OD6SChat.chatContextMenu(html, options);
+// v14 fires `getChatMessageContextOptions` (the old `getChatLogEntryContext` /
+// our custom `getOD6SChatLogEntryContext` is never emitted). The menuItems
+// array is the second hook argument.
+Hooks.on("getChatMessageContextOptions", (_application, options) => {
+    OD6SChat.chatContextMenu(options);
 })

--- a/src/module/overrides/combat-tracker.ts
+++ b/src/module/overrides/combat-tracker.ts
@@ -1,4 +1,5 @@
 import {od6sInitRoll} from "../apps/init-roll";
+import {MESSAGE_MODES} from "../hooks/chat-mode";
 
 export class OD6SCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {
     /**
@@ -12,10 +13,10 @@ export class OD6SCombatTracker extends foundry.applications.sidebar.tabs.CombatT
             void od6sInitRoll._onInitRollDialog(this.viewed, combatant);
             return undefined;
         }
-        const messageOptions: Record<string, unknown> = {};
+        const options: {messageMode?: string} = {};
         if (game.user.isGM && game.settings.get("nonex-ist-od6s", "hide-gm-rolls")) {
-            messageOptions.rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+            options.messageMode = MESSAGE_MODES.GM;
         }
-        return this.viewed.rollInitiative([combatant.id], {messageOptions});
+        return this.viewed.rollInitiative([combatant.id], options);
     }
 }

--- a/src/module/system/utilities/explosives.ts
+++ b/src/module/system/utilities/explosives.ts
@@ -4,6 +4,7 @@ import { boolCheck } from "./converters";
 import { getDiceFromScore } from "./dice";
 import { getActorFromUuid } from "./actors";
 import { isCharacterActor, isVehicleActor, isWeaponItem } from "../type-guards";
+import { MESSAGE_MODES } from "../../hooks/chat-mode";
 
 /**
  * Resolve a target actor's dodge score for the auto-explosive evade check.
@@ -220,15 +221,15 @@ export async function detonateExplosives(combat: Combat): Promise<void> {
                 await origMessage.unsetFlag('nonex-ist-od6s', 'isExplosive');
                 // Blind rolls also populate `whisper`, so the blind check
                 // must come first or it would never be reached.
-                let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
+                let messageMode: string = MESSAGE_MODES.PUBLIC;
                 if (origMessage.blind) {
-                    rollMode = CONST.DICE_ROLL_MODES.BLIND;
+                    messageMode = MESSAGE_MODES.BLIND;
                 } else if (origMessage.whisper.length > 0) {
-                    rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+                    messageMode = MESSAGE_MODES.GM;
                 }
                 await ChatMessage.deleteDocuments([origMessage.id]);
                 cloneMessage.flags["nonex-ist-od6s"].canUseCp = false;
-                cloneMessage.rolls[0].toMessage(cloneMessage, {rollMode});
+                cloneMessage.rolls[0].toMessage(cloneMessage, {messageMode});
             }
         }
     }

--- a/src/module/system/utilities/weapons.test.ts
+++ b/src/module/system/utilities/weapons.test.ts
@@ -52,14 +52,6 @@ describe('getWeaponRange', () => {
             user: { isGM: false },
         });
         vi.stubGlobal('ChatMessage', { getSpeaker: () => ({}) });
-        vi.stubGlobal('CONST', {
-            DICE_ROLL_MODES: {
-                PUBLIC: 'publicroll',
-                PRIVATE: 'gmroll',
-                BLIND: 'blindroll',
-                SELF: 'selfroll',
-            },
-        });
         vi.stubGlobal('Roll', class {
             total = 0;
             constructor(public formula: string) {}
@@ -143,17 +135,17 @@ describe('getWeaponRange', () => {
         });
         expect(rollEvaluate).toHaveBeenCalledTimes(1);
         expect(rollToMessage).toHaveBeenCalledTimes(1);
-        // Pin the v13+ call shape: rollMode and create must be in the
+        // Pin the v14 call shape: messageMode and create must be in the
         // options arg (second), not inside messageData (first). If they
         // leak back into messageData, Foundry silently ignores them and
         // the GM hide-rolls setting becomes a no-op (issue #76).
         const [messageData, options] = rollToMessage.mock.calls[0];
-        expect(messageData).not.toHaveProperty('rollMode');
+        expect(messageData).not.toHaveProperty('messageMode');
         expect(messageData).not.toHaveProperty('create');
-        expect(options).toEqual({rollMode: 'publicroll', create: true});
+        expect(options).toEqual({messageMode: 'public', create: true});
     });
 
-    it('uses gmroll mode when GM has hide-gm-rolls enabled', async () => {
+    it('uses gm message mode when GM has hide-gm-rolls enabled', async () => {
         settings.set('static_str_range', false);
         settings.set('hide-gm-rolls', true);
         vi.stubGlobal('game', {
@@ -165,6 +157,6 @@ describe('getWeaponRange', () => {
         const item = { ...rangeItem('AGI', 'AGI+2', 'AGI-1'), name: 'Blaster' } as unknown as Item;
         await getWeaponRange(actor, item);
         const [, options] = rollToMessage.mock.calls[0];
-        expect(options).toEqual({rollMode: 'gmroll', create: true});
+        expect(options).toEqual({messageMode: 'gm', create: true});
     });
 });

--- a/src/module/system/utilities/weapons.ts
+++ b/src/module/system/utilities/weapons.ts
@@ -2,6 +2,7 @@ import OD6S from "../../config/config-od6s";
 import { getDiceFromScore } from "./dice";
 import { getScoreFromSkill } from "./skills";
 import { isCharacterActor, isWeaponItem } from "../type-guards";
+import { MESSAGE_MODES } from "../../hooks/chat-mode";
 
 /**
  * Calculate Strength Damage die code from a Strength die count.
@@ -104,15 +105,15 @@ export async function getWeaponRange(actor: Actor, item: Item): Promise<Record<s
             origRange: range,
         };
         const label = game.i18n.localize('NONEX_IST_OD6S.RANGE_ROLL') + ": " + item.name;
-        let rollMode = CONST.DICE_ROLL_MODES.PUBLIC;
-        if (game.user.isGM && game.settings.get('nonex-ist-od6s', 'hide-gm-rolls')) rollMode = CONST.DICE_ROLL_MODES.PRIVATE;
+        let messageMode: string = MESSAGE_MODES.PUBLIC;
+        if (game.user.isGM && game.settings.get('nonex-ist-od6s', 'hide-gm-rolls')) messageMode = MESSAGE_MODES.GM;
         await roll.toMessage({
             speaker: ChatMessage.getSpeaker(),
             flavor: label,
             flags: {
                 "nonex-ist-od6s": flags
             },
-        }, {rollMode, create: true})
+        }, {messageMode, create: true})
     }
     return newRanges;
 }

--- a/src/templates/metaphysicsRoll.html
+++ b/src/templates/metaphysicsRoll.html
@@ -106,10 +106,10 @@
             <div class="flexrow flex-group-left sheetmode">
                 <label for="rollmode">{{localize 'NONEX_IST_OD6S.ROLL_MODE'}}</label>
                 <select name="rollmode" id="rollmode">
-                    <option value="publicroll" {{#if (eq rollmode "publicroll")}}selected{{/if}}>{{localize "CHAT.MODES.public"}}</option>
-                    <option value="gmroll"     {{#if (eq rollmode "gmroll")}}selected{{/if}}>{{localize "CHAT.MODES.gm"}}</option>
-                    <option value="blindroll"  {{#if (eq rollmode "blindroll")}}selected{{/if}}>{{localize "CHAT.MODES.blind"}}</option>
-                    <option value="selfroll"   {{#if (eq rollmode "selfroll")}}selected{{/if}}>{{localize "CHAT.MODES.self"}}</option>
+                    <option value="public" {{#if (eq rollmode "public")}}selected{{/if}}>{{localize "CHAT.MODES.public"}}</option>
+                    <option value="gm"     {{#if (eq rollmode "gm")}}selected{{/if}}>{{localize "CHAT.MODES.gm"}}</option>
+                    <option value="blind"  {{#if (eq rollmode "blind")}}selected{{/if}}>{{localize "CHAT.MODES.blind"}}</option>
+                    <option value="self"   {{#if (eq rollmode "self")}}selected{{/if}}>{{localize "CHAT.MODES.self"}}</option>
                 </select>
             </div>
         </section>

--- a/src/templates/roll.html
+++ b/src/templates/roll.html
@@ -1,11 +1,13 @@
 <div class="nonex-ist-od6s roll-dialog">
     {{#if (getConfig 'showSkillSpecialization' '')}}
-        <p><b>{{ localize 'NONEX_IST_OD6S.ROLLING'}} {{specSkill}}: {{title}}: {{setDice dice actionpenalty woundpenalty
-                                                                               stunnedpenalty otherpenalty}}D
+        <p><b>{{ localize 'NONEX_IST_OD6S.ROLLING'}} {{specSkill}}: {{title}}: <span
+                    class="roll-dice-preview">{{setDice dice actionpenalty woundpenalty
+                    stunnedpenalty otherpenalty}}</span>D
             + {{pips}}</b></p>
     {{else}}
-        <p><b>{{ localize 'NONEX_IST_OD6S.ROLLING'}} {{title}}: {{setDice dice actionpenalty woundpenalty
-                                                                stunnedpenalty otherpenalty}}D
+        <p><b>{{ localize 'NONEX_IST_OD6S.ROLLING'}} {{title}}: <span
+                    class="roll-dice-preview">{{setDice dice actionpenalty woundpenalty
+                    stunnedpenalty otherpenalty}}</span>D
             + {{pips}}</b></p>
     {{/if}}
     {{#if (isDefense subtype)}}
@@ -443,10 +445,10 @@
             <div class="flexrow flex-group-left sheetmode">
                 <label for="rollmode">{{localize 'NONEX_IST_OD6S.ROLL_MODE'}}</label>
                 <select name="rollmode" id="rollmode">
-                    <option value="publicroll" {{#if (eq rollmode "publicroll")}}selected{{/if}}>{{localize "CHAT.MODES.public"}}</option>
-                    <option value="gmroll"     {{#if (eq rollmode "gmroll")}}selected{{/if}}>{{localize "CHAT.MODES.gm"}}</option>
-                    <option value="blindroll"  {{#if (eq rollmode "blindroll")}}selected{{/if}}>{{localize "CHAT.MODES.blind"}}</option>
-                    <option value="selfroll"   {{#if (eq rollmode "selfroll")}}selected{{/if}}>{{localize "CHAT.MODES.self"}}</option>
+                    <option value="public" {{#if (eq rollmode "public")}}selected{{/if}}>{{localize "CHAT.MODES.public"}}</option>
+                    <option value="gm"     {{#if (eq rollmode "gm")}}selected{{/if}}>{{localize "CHAT.MODES.gm"}}</option>
+                    <option value="blind"  {{#if (eq rollmode "blind")}}selected{{/if}}>{{localize "CHAT.MODES.blind"}}</option>
+                    <option value="self"   {{#if (eq rollmode "self")}}selected{{/if}}>{{localize "CHAT.MODES.self"}}</option>
                 </select>
             </div>
         </section>

--- a/tests/smoke/tier-3-chat-cp-menu.spec.ts
+++ b/tests/smoke/tier-3-chat-cp-menu.spec.ts
@@ -67,3 +67,75 @@ test("CP chat context menu entry appears, is visible, and spends a point", async
     expect(result.visibleBefore, "entry visible for owned character with CP").toBe(true);
     expect(result.cpAfter, "one character point spent").toBe(result.cpBefore - 1);
 });
+
+test("CP chat context menu entry is hidden when its gates are not met", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        const chatRoot = () => (window.ui.chat?.element ?? document);
+        const rowFor = async (id: string): Promise<HTMLElement | null> => {
+            for (let i = 0; i < 30; i++) {
+                const el = chatRoot().querySelector(`.message[data-message-id="${id}"]`);
+                if (el) return el as HTMLElement;
+                await new Promise((r) => setTimeout(r, 100));
+            }
+            return null;
+        };
+        const rollMessage = (speaker: any, flags: any) =>
+            new window.Roll("3d6").evaluate().then((r: any) =>
+                r.toMessage({speaker, flags}, {messageMode: "public", create: true}));
+
+        // A character out of character points (checked live by `visible`), and a
+        // separate character that still has points for the flag/non-roll cases.
+        let broke = window.game.actors.find((a: any) => a.name === "smoke-cp-broke");
+        if (!broke) broke = await window.Actor.create({name: "smoke-cp-broke", type: "character"}, {render: false});
+        await broke.update({"system.characterpoints.value": 0});
+
+        let rich = window.game.actors.find((a: any) => a.name === "smoke-cp-rich");
+        if (!rich) rich = await window.Actor.create({name: "smoke-cp-rich", type: "character"}, {render: false});
+        await rich.update({"system.characterpoints.value": 5});
+
+        let vehicle = window.game.actors.find((a: any) => a.name === "smoke-cp-vehicle");
+        if (!vehicle) vehicle = await window.Actor.create({name: "smoke-cp-vehicle", type: "vehicle"}, {render: false});
+
+        const cpFlags = (actor: any) => ({"nonex-ist-od6s": {canUseCp: true, actorId: actor.id}});
+        // (1) roll flagged canUseCp, but the acting character has 0 points.
+        const noCp = await rollMessage(window.ChatMessage.getSpeaker({actor: broke}), cpFlags(broke));
+        // (2) roll with points available, but no canUseCp flag.
+        const noFlag = await rollMessage(window.ChatMessage.getSpeaker({actor: rich}), {});
+        // (3) a non-roll chat card (no `.dice-roll`), flag and points present.
+        const plain = await window.ChatMessage.create({
+            speaker: window.ChatMessage.getSpeaker({actor: rich}),
+            content: "not a roll", flags: cpFlags(rich),
+        });
+        // (4) roll flagged canUseCp, but the actor is not a character/npc.
+        const nonChar = await rollMessage(window.ChatMessage.getSpeaker({actor: vehicle}), cpFlags(vehicle));
+
+        const [liNoCp, liNoFlag, liPlain, liNonChar] = await Promise.all(
+            [noCp, noFlag, plain, nonChar].map((m: any) => rowFor(m.id)));
+
+        const options: any[] = [];
+        window.Hooks.callAll("getChatMessageContextOptions", window.ui.chat, options);
+        const label = window.game.i18n.localize("NONEX_IST_OD6S.USE_A_CHARACTER_POINT");
+        const entry = options.find((o: any) => o.label === label);
+        const vis = (li: HTMLElement | null) => !!(entry && li && entry.visible(li));
+
+        const out = {
+            hasEntry: !!entry,
+            rows: [!!liNoCp, !!liNoFlag, !!liPlain, !!liNonChar],
+            visibleNoCp: vis(liNoCp),
+            visibleNoFlag: vis(liNoFlag),
+            visiblePlain: vis(liPlain),
+            visibleNonChar: vis(liNonChar),
+        };
+        await window.ChatMessage.deleteDocuments([noCp.id, noFlag.id, plain.id, nonChar.id]);
+        return out;
+    });
+
+    expect(result.hasEntry, "entry registered").toBe(true);
+    expect(result.rows, "all four message rows rendered").toEqual([true, true, true, true]);
+    expect(result.visibleNoCp, "hidden when the character has 0 CP").toBe(false);
+    expect(result.visibleNoFlag, "hidden when canUseCp flag is absent").toBe(false);
+    expect(result.visiblePlain, "hidden on a non-roll message").toBe(false);
+    expect(result.visibleNonChar, "hidden when the actor is not a character/npc").toBe(false);
+});

--- a/tests/smoke/tier-3-chat-cp-menu.spec.ts
+++ b/tests/smoke/tier-3-chat-cp-menu.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Tier 3 — "Use a Character Point" chat context menu (v14 regression).
+ *
+ * In v14 the entry must register on the `getChatMessageContextOptions` hook and
+ * operate on the message row as an HTMLElement. Previously it was bound to a
+ * custom hook Foundry never emits (so it never appeared) and its callbacks used
+ * jQuery APIs (`li.find`/`li.attr`) that throw on an HTMLElement.
+ *
+ * Verifies: the entry is registered on the live hook; it is visible for an
+ * owned character's roll message while character points remain; and invoking it
+ * spends one character point. Creating the message via `roll.toMessage(...,
+ * {messageMode})` also exercises the migrated message-mode API end to end.
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+test("CP chat context menu entry appears, is visible, and spends a point", async ({page}) => {
+    await loginAndWaitReady(page);
+
+    const result = await evalInWorld(page, async () => {
+        // A character with character points to spend.
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-cp-character");
+        if (!actor) {
+            actor = await window.Actor.create({name: "smoke-cp-character", type: "character"}, {render: false});
+        }
+        await actor.update({"system.characterpoints.value": 5});
+
+        // A roll message flagged canUseCp for this actor (the CP menu's gate),
+        // created through the migrated messageMode option.
+        const roll = await new window.Roll("3d6").evaluate();
+        const message = await roll.toMessage({
+            speaker: window.ChatMessage.getSpeaker({actor}),
+            flags: {"nonex-ist-od6s": {canUseCp: true, actorId: actor.id}},
+        }, {messageMode: "public", create: true});
+
+        // Wait for the message row to render in the chat log.
+        const chatRoot = () => (window.ui.chat?.element ?? document);
+        let li: HTMLElement | null = null;
+        for (let i = 0; i < 30 && !li; i++) {
+            li = chatRoot().querySelector(`.message[data-message-id="${message.id}"]`);
+            if (!li) await new Promise((r) => setTimeout(r, 100));
+        }
+
+        // Fire the v14 hook exactly as Foundry does and locate our entry.
+        const options: any[] = [];
+        window.Hooks.callAll("getChatMessageContextOptions", window.ui.chat, options);
+        const label = window.game.i18n.localize("NONEX_IST_OD6S.USE_A_CHARACTER_POINT");
+        const entry = options.find((o: any) => o.label === label);
+
+        const visibleBefore = !!(entry && li && entry.visible(li));
+        const cpBefore = actor.system.characterpoints.value;
+
+        // Spend a point. The CP deduction is applied before the (unrelated)
+        // message re-render, so guard the call and measure the actor after.
+        if (entry && li) {
+            try { await entry.onClick(new MouseEvent("click"), li); } catch { /* message rebuild edge */ }
+            await new Promise((r) => setTimeout(r, 400));
+        }
+        const cpAfter = window.game.actors.get(actor.id).system.characterpoints.value;
+
+        return {hasEntry: !!entry, hasRow: !!li, visibleBefore, cpBefore, cpAfter};
+    });
+
+    expect(result.hasEntry, "entry registered on getChatMessageContextOptions").toBe(true);
+    expect(result.hasRow, "rendered chat message row found").toBe(true);
+    expect(result.visibleBefore, "entry visible for owned character with CP").toBe(true);
+    expect(result.cpAfter, "one character point spent").toBe(result.cpBefore - 1);
+});

--- a/tests/smoke/tier-3-melee-range.spec.ts
+++ b/tests/smoke/tier-3-melee-range.spec.ts
@@ -26,6 +26,18 @@
 import {test, expect} from "@playwright/test";
 import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
 
+// These cases depend on the PIXI canvas: the gate calls
+// `canvas.grid.measurePath` on live token centers. In headless Chromium
+// (no hardware acceleration, sub-minimum resolution) that measurement
+// transiently returns 0 mid-render, and the gate short-circuits its
+// out-of-range warn on `distance === 0` — a re-render race the settle-wait
+// in runMeleeRoll narrows but can't fully close from the test side. Bounded
+// retries keep these green without masking real logic failures (a genuine
+// break fails all attempts). Scoped to this file; global retries stay 0.
+// Three retries keep the residual ~30% per-attempt canvas flake well under
+// 1% at the suite level.
+test.describe.configure({retries: 3});
+
 type GateResult = {
     warned: boolean;
     warnMessage: string | null;
@@ -151,6 +163,28 @@ async function runMeleeRoll(
             // Target the far/near token from the current user.
             window.game.user.targets.clear();
             targetToken.setTarget(true, {user: window.game.user, releaseOthers: true});
+
+            // Wait for the exact measurement the range gate depends on to
+            // settle. Headless Chromium has no hardware acceleration, so PIXI
+            // token centers lag placement and `measurePath` transiently returns
+            // 0 mid-render. The gate skips the warn when distance is 0
+            // (`if (distance !== 0 && …)`), so rolling before the measured
+            // separation is finite and non-zero flakes the out-of-range case.
+            let stable = 0;
+            for (let i = 0; i < 80; i++) {
+                const tgt = [...(window.game.user.targets ?? [])][0];
+                const atk = actor.getActiveTokens()[0];
+                let d = 0;
+                if (tgt?.center && atk?.center) {
+                    d = window.canvas.grid.measurePath([atk.center, tgt.center]).distance;
+                }
+                // Require several consecutive non-zero readings so we roll only
+                // once the canvas has stopped re-rendering, not on a single
+                // transient non-zero frame.
+                stable = Number.isFinite(d) && d > 0 ? stable + 1 : 0;
+                if (stable >= 4) break;
+                await new Promise((r) => setTimeout(r, 100));
+            }
 
             const apps0 = new Set([...window.foundry.applications.instances.keys()]);
             const msgsBefore = window.game.messages.size;

--- a/tests/smoke/tier-3-roll-penalty.spec.ts
+++ b/tests/smoke/tier-3-roll-penalty.spec.ts
@@ -94,3 +94,30 @@ test("penalty change updates the resulting-dice preview in place", async ({page}
         if (dlg) { try { await (dlg as any).close(); } catch { /* ignore */ } }
     });
 });
+
+test("clearing a penalty field still produces a valid roll", async ({page}) => {
+    await loginAndWaitReady(page);
+    await ensureSkillActor(page);
+    const before = await openRollDialog(page);
+
+    const dialog = page.locator("#nonex-ist-od6s-roll-dialog");
+    await expect(dialog).toBeVisible();
+
+    // Enter then clear the penalty. A cleared number input reports
+    // `valueAsNumber === NaN`; before normalization that NaN flowed into the
+    // dice math and broke roll-string generation (no valid message). The
+    // handler now coerces it to 0.
+    const penalty = dialog.locator("#actionpenalty");
+    await penalty.fill("3");
+    await penalty.fill("");
+    await dialog.locator(".dialog-submit").click();
+
+    await expect(dialog, "dialog closes on submit").toBeHidden();
+    const info = await evalInWorld(page, async () => {
+        const msgs = [...window.game.messages.values()];
+        const total = (msgs[msgs.length - 1] as any)?.rolls?.[0]?.total;
+        return {count: window.game.messages.size as number, isFinite: Number.isFinite(total)};
+    });
+    expect(info.count, "a roll message was created").toBe(before + 1);
+    expect(info.isFinite, "roll total is finite (cleared penalty coerced to 0)").toBe(true);
+});

--- a/tests/smoke/tier-3-roll-penalty.spec.ts
+++ b/tests/smoke/tier-3-roll-penalty.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Tier 3 — Roll dialog penalty behaviour (regression for #193).
+ *
+ * Entering a value in a penalty box and then clicking Roll *once* must submit
+ * and post a chat message. Previously the penalty `change` event (which fires
+ * on blur when the Roll button is pressed) triggered a full dialog re-render
+ * that destroyed the submit button mid-click, so the first click was swallowed
+ * and a second was required. This must use real pointer events — the
+ * programmatic `.click()` used elsewhere can't reproduce the blur→change→click
+ * ordering that caused the bug.
+ *
+ * Also asserts the "resulting dice" preview updates in place on penalty change
+ * (the mechanism that replaced the re-render).
+ */
+
+import {test, expect} from "@playwright/test";
+import {loginAndWaitReady, evalInWorld} from "./helpers/foundry-page.js";
+
+async function ensureSkillActor(page: import("@playwright/test").Page): Promise<void> {
+    await evalInWorld(page, async () => {
+        let actor = window.game.actors.find((a: any) => a.name === "smoke-penalty-character");
+        if (!actor) {
+            actor = await window.Actor.create({name: "smoke-penalty-character", type: "character"}, {render: false});
+        }
+        // A rollable linked attribute is required or setupRollData bails and no
+        // dialog opens.
+        await actor.update({"system.attributes.agi.base": 10});
+        // A high skill score guarantees the pool stays positive after a 1D
+        // penalty, so the roll always produces a message (an over-penalised
+        // roll to 0 dice is suppressed and would mask the regression).
+        const skill = actor.items.find((i: any) => i.type === "skill" && i.name === "smoke-penalty-skill");
+        if (!skill) {
+            await actor.createEmbeddedDocuments("Item", [{
+                name: "smoke-penalty-skill", type: "skill", system: {score: 12, attribute: "agi"},
+            }]);
+        } else {
+            await skill.update({"system.score": 12});
+        }
+    });
+}
+
+async function openRollDialog(page: import("@playwright/test").Page): Promise<number> {
+    return evalInWorld(page, async () => {
+        const actor = window.game.actors.find((a: any) => a.name === "smoke-penalty-character");
+        const skill = actor.items.find((i: any) => i.type === "skill" && i.name === "smoke-penalty-skill");
+        await skill.roll();
+        return window.game.messages.size as number;
+    });
+}
+
+test("single click submits a roll after entering a penalty (#193)", async ({page}) => {
+    await loginAndWaitReady(page);
+    await ensureSkillActor(page);
+    const before = await openRollDialog(page);
+
+    const dialog = page.locator("#nonex-ist-od6s-roll-dialog");
+    await expect(dialog).toBeVisible();
+
+    // Enter an action penalty — the input keeps focus (change has not fired yet).
+    await dialog.locator("#actionpenalty").fill("1");
+
+    // One real click on Roll. mousedown blurs the penalty input → `change`
+    // fires → (old code re-rendered here and ate the click). The click must
+    // still submit.
+    await dialog.locator(".dialog-submit").click();
+
+    await expect(dialog, "dialog closes after a single click").toBeHidden();
+    const after = await evalInWorld(page, async () => window.game.messages.size as number);
+    expect(after, "a single click produced exactly one roll message").toBe(before + 1);
+});
+
+test("penalty change updates the resulting-dice preview in place", async ({page}) => {
+    await loginAndWaitReady(page);
+    await ensureSkillActor(page);
+    await openRollDialog(page);
+
+    const dialog = page.locator("#nonex-ist-od6s-roll-dialog");
+    await expect(dialog).toBeVisible();
+
+    const preview = dialog.locator(".roll-dice-preview").first();
+    const baseline = parseInt(((await preview.textContent()) ?? "0").trim(), 10);
+
+    // Fill then blur (Tab) so the `change` handler runs and patches the preview.
+    await dialog.locator("#actionpenalty").fill("1");
+    await dialog.locator("#actionpenalty").press("Tab");
+
+    await expect(preview).toHaveText(String(Math.max(0, baseline - 1)));
+
+    // Clean up the open dialog (cancel, not submit).
+    await evalInWorld(page, async () => {
+        const dlg = [...window.foundry.applications.instances.values()].find(
+            (a: any) => a.constructor.name.includes("RollDialog"),
+        );
+        if (dlg) { try { await (dlg as any).close(); } catch { /* ignore */ } }
+    });
+});

--- a/types/foundry.d.ts
+++ b/types/foundry.d.ts
@@ -92,6 +92,11 @@ declare namespace foundry {
         function getProperty(object: object, key: string): any;
         function setProperty(object: object, key: string, value: any): boolean;
         function randomID(length?: number): string;
+        // v13+ home of the sort helper (was `foundry.utils.SortingHelpers.performIntegerSort`).
+        function performIntegerSort<T>(
+            source: T,
+            options: { target: T | undefined | null; siblings: T[]; sortKey?: string; sortBefore?: boolean }
+        ): { target: T; update: Record<string, any> }[];
     }
 
     namespace applications {
@@ -1301,15 +1306,6 @@ interface FormDataExtended {
 declare var FormDataExtended: {
     new (form: HTMLFormElement): FormDataExtended;
 };
-
-// ---- SortingHelpers ----
-
-declare class SortingHelpers {
-    static performIntegerSort<T>(
-        source: T,
-        options: { target: T | undefined | null; siblings: T[]; sortKey?: string; sortBefore?: boolean }
-    ): { target: T; update: Record<string, any> }[];
-}
 
 // ---- jQuery (for v1 Application migration period) ----
 


### PR DESCRIPTION
Closes #193

## Summary

Fixes two user-facing V14 bugs and clears the roll/chat pipeline of deprecated Foundry V14 APIs.

- **#193 — double-click roll with a penalty.** Entering a penalty then clicking **Roll** required two clicks: the penalty field's `change` (fired on blur when the button is pressed) re-rendered the dialog and destroyed the submit button mid-click. The numeric-modifier handlers now patch the resulting-dice preview in place instead of re-rendering, so one click submits.
- **"Use a Character Point" chat menu was dead on V14.** It was bound to a custom hook Foundry no longer emits and used jQuery on what is now a plain `HTMLElement`. Re-registered on `getChatMessageContextOptions` with the V14 entry shape (`label`/`visible`/`onClick`) and HTMLElement DOM.
- **Deprecation migration.** `rollMode` → `messageMode` (`Roll#toMessage`, `Combat#rollInitiative`), `CONST.DICE_ROLL_MODES` → messageMode keys, `resolveRollMode` → `resolveMessageMode`, and `SortingHelpers.performIntegerSort` → `foundry.utils.performIntegerSort`. Eliminates the deprecation warnings these logged on every roll. Historical chat messages still classify correctly (legacy values accepted on read).

## Commits

1. `fix(roll):` single-click penalty submit + messageMode/sort migration (bundled because they share `roll-dialog.ts`/`roll.html`)
2. `fix(chat):` restore the "Use a Character Point" context menu
3. `test(smoke):` E2E coverage for both fixes + harden the flaky melee-range gate test
4. `chore(test-env):` run E2E against Foundry 14.364 (matches `system.json` verified) + fix Taskfile container-runtime detection

## Testing

- `pnpm run check` green — lint 0 errors, typecheck clean, **429 unit + 327 domain** tests pass.
- Full smoke suite run against **live Foundry 14.364**: all green. New specs (`tier-3-roll-penalty`, `tier-3-chat-cp-menu`) fail on pre-fix code; the existing "no deprecation warnings" roll guard was latently red before the migration and is now green.
- The melee-range gate test flaked ~50% due to headless-Chromium canvas timing (`measurePath` transiently returns 0); hardened with a stable-measurement settle-wait + file-scoped retries → 0 hard failures across repeated runs.

## Notes

- CHANGELOG `[Unreleased]` updated with the user-facing Fixed/Changed entries.
- `.env` (local, gitignored) also bumped to 14.364; the tracked `.env.example` example and Taskfile comment are aligned.