### PR TITLE
chore(release): 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ GitLab wiki at <https://gitlab.com/vtt2/opend6-space/-/wikis/Release-Notes>.
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-07-05
+
 ### Fixed
 
 - Rolling a skill or attribute with a penalty entered no longer requires two

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opend6-space",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "type": "module",
   "description": "OpenD6 Space system for Foundry VTT v14. Uses the rules from the OpenD6 Project SRD.",
   "scripts": {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "nonex-ist-od6s",
   "title": "OpenD6 Space",
   "description": "OpenD6 Space System for FoundryVTT",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "compatibility": {
     "minimum": "14",
     "verified": "14.364",


### PR DESCRIPTION
Patch release bumping `src/system.json` + `package.json` to **3.1.1** and rolling `[Unreleased]` into a dated `[3.1.1]` section.

Ships the V14 roll/chat compatibility work merged in #194:

- **Fixed:** single-click penalty roll (#193); restored the "Use a Character Point" chat context menu on Foundry V14.
- **Changed:** migrated the roll/chat pipeline off deprecated V14 APIs (`rollMode` → `messageMode`, `CONST.DICE_ROLL_MODES`, `SortingHelpers.performIntegerSort`), eliminating per-roll deprecation warnings.

`compatibility.verified` is already `14.364` (validated by the smoke suite). After merge, `task release:patch` tags `v3.1.1` and CI builds the signed `od6s.zip`.